### PR TITLE
Configure payjoin-client from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +69,17 @@ name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "atty"
@@ -324,6 +346,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,7 +465,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -441,7 +482,7 @@ checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -469,6 +510,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "either"
@@ -684,6 +731,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -894,6 +944,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonrpc"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +986,12 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -968,6 +1035,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1025,6 +1098,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1094,7 +1177,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1127,10 +1210,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
@@ -1155,11 +1254,13 @@ dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
  "clap",
+ "config",
  "env_logger",
  "log",
  "payjoin",
  "reqwest",
  "rouille",
+ "serde",
 ]
 
 [[package]]
@@ -1173,6 +1274,50 @@ name = "percent-encoding-rfc3986"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
+
+[[package]]
+name = "pest"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1206,9 +1351,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1240,9 +1385,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1365,6 +1510,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "rouille"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1543,16 @@ dependencies = [
  "time 0.3.17",
  "tiny_http",
  "url",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1523,22 +1689,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1589,6 +1755,17 @@ name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "slab"
@@ -1648,7 +1825,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_derive",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1664,7 +1841,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1 0.6.1",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1684,6 +1861,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1741,7 +1929,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1817,7 +2005,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "standback",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1889,6 +2077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +2131,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicase"
@@ -2062,7 +2265,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2096,7 +2299,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2318,6 +2521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/payjoin-client/Cargo.toml
+++ b/payjoin-client/Cargo.toml
@@ -19,3 +19,5 @@ base64 = "0.13.0"
 clap = "4.1.4"
 log = "0.4.7"
 env_logger = "0.9.0"
+config = "0.13.3"
+serde = { version = "1.0.160", features = ["derive"] }

--- a/payjoin-client/src/app_config.rs
+++ b/payjoin-client/src/app_config.rs
@@ -1,0 +1,58 @@
+use anyhow::{Context, Result};
+use clap::ArgMatches;
+use config::{Config, File, FileFormat};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AppConfig {
+    pub bitcoind_rpchost: String,
+    pub bitcoind_cookie: Option<String>,
+    pub bitcoind_rpcuser: String,
+    pub bitcoind_rpcpass: String,
+
+    // send-only
+    pub danger_accept_invalid_certs: bool,
+
+    // receive-only
+    pub pj_host: String,
+    pub pj_endpoint: String,
+    pub sub_only: bool,
+}
+
+impl AppConfig {
+    pub(crate) fn new(matches: &ArgMatches) -> Result<Self> {
+        let builder = Config::builder()
+            .set_default("bitcoind_rpchost", "http://localhost:18443")?
+            .set_default("bitcoind_cookie", None::<String>)?
+            .set_default("bitcoind_rpcuser", "bitcoin")?
+            .set_default("bitcoind_rpcpass", "")?
+            .set_default("danger_accept_invalid_certs", false)?
+            .set_default("pj_host", "0.0.0.0:3000")?
+            .set_default("pj_endpoint", "https://localhost:3010")?
+            .set_default("sub_only", false)?
+            .add_source(File::new("config.toml", FileFormat::Toml))
+            .set_override_option(
+                "bitcoind_rpchost",
+                matches.get_one::<String>("rpchost").map(|s| s.as_str()),
+            )?
+            .set_override_option(
+                "bitcoind_cookie",
+                matches.get_one::<String>("cookie_file").map(|s| s.as_str()),
+            )?;
+        let builder = match matches.subcommand() {
+            Some(("send", matches)) => builder.set_override_option(
+                "danger_accept_invalid_certs",
+                matches.get_one::<bool>("DANGER_ACCEPT_INVALID_CERTS").map(|s| *s),
+            )?,
+            Some(("receive", matches)) => builder
+                .set_override_option(
+                    "pj_endpoint",
+                    matches.get_one::<String>("endpoint").map(|s| s.as_str()),
+                )?
+                .set_override_option("sub_only", matches.get_one::<bool>("sub_only").map(|s| *s))?,
+            _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
+        };
+        let app_conf = builder.build()?;
+        app_conf.try_deserialize().context("Failed to deserialize config")
+    }
+}

--- a/payjoin-client/src/main.rs
+++ b/payjoin-client/src/main.rs
@@ -12,29 +12,31 @@ use payjoin::receiver::PayjoinProposal;
 use payjoin::{PjUriExt, UriExt};
 use rouille::{Request, Response};
 
+struct App {
+    config: AppConfig,
+    bitcoind: bitcoincore_rpc::Client,
+}
+
 fn main() -> Result<()> {
     env_logger::init();
 
     let matches = cli();
     let config = parse_config(&matches)?;
 
-    let bitcoind = bitcoincore_rpc::Client::new(&config.bitcoind_rpchost, config.bitcoind_auth)
-        .context("Failed to connect to bitcoind")?;
+    let bitcoind =
+        bitcoincore_rpc::Client::new(&config.bitcoind_rpchost, config.bitcoind_auth.clone())
+            .context("Failed to connect to bitcoind")?;
+    let app = App { config, bitcoind };
+
     match matches.subcommand() {
         Some(("send", sub_matches)) => {
             let bip21 = sub_matches.get_one::<String>("BIP21").context("Missing BIP21 argument")?;
-            send_payjoin(bitcoind, bip21, config.danger_accept_invalid_certs)?;
+            app.send_payjoin(bip21)?;
         }
         Some(("receive", sub_matches)) => {
             let amount =
                 sub_matches.get_one::<String>("AMOUNT").context("Missing AMOUNT argument")?;
-            receive_payjoin(
-                bitcoind,
-                amount,
-                &config.pj_host,
-                &config.pj_endpoint,
-                config.sub_only,
-            )?;
+            app.receive_payjoin(amount)?;
         }
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
@@ -42,212 +44,206 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn send_payjoin(
-    bitcoind: bitcoincore_rpc::Client,
-    bip21: &str,
-    danger_accept_invalid_certs: bool,
-) -> Result<()> {
-    let link = payjoin::Uri::try_from(bip21)
-        .map_err(|e| anyhow!("Failed to create URI from BIP21: {}", e))?;
+impl App {
+    fn send_payjoin(&self, bip21: &str) -> Result<()> {
+        let link = payjoin::Uri::try_from(bip21)
+            .map_err(|e| anyhow!("Failed to create URI from BIP21: {}", e))?;
 
-    let link = link
-        .check_pj_supported()
-        .map_err(|e| anyhow!("The provided URI doesn't support payjoin (BIP78): {}", e))?;
+        let link = link
+            .check_pj_supported()
+            .map_err(|e| anyhow!("The provided URI doesn't support payjoin (BIP78): {}", e))?;
 
-    let amount = link
-        .amount
-        .ok_or(anyhow!("please specify the amount in the Uri"))
-        .map(|amt| Amount::from_sat(amt.to_sat()))?;
-    let mut outputs = HashMap::with_capacity(1);
-    outputs.insert(link.address.to_string(), amount);
+        let amount = link
+            .amount
+            .ok_or(anyhow!("please specify the amount in the Uri"))
+            .map(|amt| Amount::from_sat(amt.to_sat()))?;
+        let mut outputs = HashMap::with_capacity(1);
+        outputs.insert(link.address.to_string(), amount);
 
-    let options = bitcoincore_rpc::json::WalletCreateFundedPsbtOptions {
-        lock_unspent: Some(true),
-        fee_rate: Some(Amount::from_sat(2000)),
-        ..Default::default()
-    };
-    let psbt = bitcoind
-        .wallet_create_funded_psbt(
-            &[], // inputs
-            &outputs,
-            None, // locktime
-            Some(options),
+        let options = bitcoincore_rpc::json::WalletCreateFundedPsbtOptions {
+            lock_unspent: Some(true),
+            fee_rate: Some(Amount::from_sat(2000)),
+            ..Default::default()
+        };
+        let psbt = self
+            .bitcoind
+            .wallet_create_funded_psbt(
+                &[], // inputs
+                &outputs,
+                None, // locktime
+                Some(options),
+                None,
+            )
+            .context("Failed to create PSBT")?
+            .psbt;
+        let psbt = self
+            .bitcoind
+            .wallet_process_psbt(&psbt, None, None, None)
+            .with_context(|| "Failed to process PSBT")?
+            .psbt;
+        let psbt = load_psbt_from_base64(psbt.as_bytes())
+            .with_context(|| "Failed to load PSBT from base64")?;
+        log::debug!("Original psbt: {:#?}", psbt);
+        let pj_params = payjoin::sender::Configuration::with_fee_contribution(
+            payjoin::bitcoin::Amount::from_sat(10000),
             None,
-        )
-        .context("Failed to create PSBT")?
-        .psbt;
-    let psbt = bitcoind
-        .wallet_process_psbt(&psbt, None, None, None)
-        .with_context(|| "Failed to process PSBT")?
-        .psbt;
-    let psbt = load_psbt_from_base64(psbt.as_bytes())
-        .with_context(|| "Failed to load PSBT from base64")?;
-    log::debug!("Original psbt: {:#?}", psbt);
-    let pj_params = payjoin::sender::Configuration::with_fee_contribution(
-        payjoin::bitcoin::Amount::from_sat(10000),
-        None,
-    );
-    let (req, ctx) = link
-        .create_pj_request(psbt, pj_params)
-        .with_context(|| "Failed to create payjoin request")?;
-    let client = reqwest::blocking::Client::builder()
-        .danger_accept_invalid_certs(danger_accept_invalid_certs)
-        .build()
-        .with_context(|| "Failed to build reqwest http client")?;
-    let response = client
-        .post(req.url)
-        .body(req.body)
-        .header("Content-Type", "text/plain")
-        .send()
-        .with_context(|| "HTTP request failed")?;
-    // TODO display well-known errors and log::debug the rest
-    let psbt = ctx.process_response(response).with_context(|| "Failed to process response")?;
-    log::debug!("Proposed psbt: {:#?}", psbt);
-    let psbt = bitcoind
-        .wallet_process_psbt(&serialize_psbt(&psbt), None, None, None)
-        .with_context(|| "Failed to process PSBT")?
-        .psbt;
-    let tx = bitcoind
-        .finalize_psbt(&psbt, Some(true))
-        .with_context(|| "Failed to finalize PSBT")?
-        .hex
-        .ok_or_else(|| anyhow!("Incomplete PSBT"))?;
-    let txid =
-        bitcoind.send_raw_transaction(&tx).with_context(|| "Failed to send raw transaction")?;
-    log::info!("Transaction sent: {}", txid);
-    Ok(())
-}
-
-fn receive_payjoin(
-    bitcoind: bitcoincore_rpc::Client,
-    amount_arg: &str,
-    pj_host: &str,
-    endpoint_arg: &str,
-    sub_only: bool,
-) -> Result<()> {
-    use payjoin::Uri;
-
-    let pj_receiver_address = bitcoind.get_new_address(None, None)?;
-    let amount = Amount::from_sat(amount_arg.parse()?);
-    let pj_uri_string = format!(
-        "{}?amount={}&pj={}",
-        pj_receiver_address.to_qr_uri(),
-        amount.to_btc(),
-        endpoint_arg
-    );
-    let pj_uri = Uri::from_str(&pj_uri_string)
-        .map_err(|e| anyhow!("Constructed a bad URI string from args: {}", e))?;
-    let _pj_uri = pj_uri
-        .check_pj_supported()
-        .map_err(|e| anyhow!("Constructed URI does not support payjoin: {}", e))?;
-
-    println!("Awaiting payjoin at BIP 21 Payjoin Uri:");
-    println!("{}", pj_uri_string);
-
-    rouille::start_server(pj_host, move |req| handle_web_request(&req, &bitcoind, sub_only));
-}
-
-fn handle_web_request(
-    req: &Request,
-    bitcoind: &bitcoincore_rpc::Client,
-    sub_only: bool,
-) -> Response {
-    handle_payjoin_request(req, bitcoind, sub_only)
-        .map_err(|e| match e {
-            ReceiveError::RequestError(e) => {
-                log::error!("Error handling request: {}", e);
-                Response::text(e.to_string()).with_status_code(400)
-            }
-            e => {
-                log::error!("Error handling request: {}", e);
-                Response::text(e.to_string()).with_status_code(500)
-            }
-        })
-        .unwrap_or_else(|err_resp| err_resp)
-}
-
-fn handle_payjoin_request(
-    req: &Request,
-    bitcoind: &bitcoincore_rpc::Client,
-    sub_only: bool,
-) -> Result<Response, ReceiveError> {
-    use bitcoin::hashes::hex::ToHex;
-
-    let headers = Headers(req.headers());
-    let proposal = payjoin::receiver::UncheckedProposal::from_request(
-        req.data().context("Failed to read request body")?,
-        req.raw_query_string(),
-        headers,
-    )?;
-
-    // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-    let _to_broadcast_in_failure_case = proposal.get_transaction_to_schedule_broadcast();
-
-    // The network is used for checks later
-    let network = match bitcoind.get_blockchain_info()?.chain.as_str() {
-        "main" => bitcoin::Network::Bitcoin,
-        "test" => bitcoin::Network::Testnet,
-        "regtest" => bitcoin::Network::Regtest,
-        _ => return Err(ReceiveError::Other(anyhow!("Unknown network"))),
-    };
-
-    // Receive Check 1: Can Broadcast
-    let proposal = proposal.check_can_broadcast(|tx| {
-        bitcoind
-            .test_mempool_accept(&[bitcoin::consensus::encode::serialize(&tx).to_hex()])
-            .unwrap()
-            .first()
-            .unwrap()
-            .allowed
-    })?;
-    log::trace!("check1");
-
-    // Receive Check 2: receiver can't sign for proposal inputs
-    let proposal = proposal.check_inputs_not_owned(|input| {
-        let address = bitcoin::Address::from_script(&input, network).unwrap();
-        bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
-    })?;
-    log::trace!("check2");
-    // Receive Check 3: receiver can't sign for proposal inputs
-    let proposal = proposal.check_no_mixed_input_scripts()?;
-    log::trace!("check3");
-
-    // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
-    let mut payjoin = proposal
-        .check_no_inputs_seen_before(|_| false)
-        .unwrap()
-        .identify_receiver_outputs(|output_script| {
-            let address = bitcoin::Address::from_script(&output_script, network).unwrap();
-            bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
-        })?;
-    log::trace!("check4");
-
-    if !sub_only {
-        // Select receiver payjoin inputs.
-        _ = try_contributing_inputs(&mut payjoin, bitcoind)
-            .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
+        );
+        let (req, ctx) = link
+            .create_pj_request(psbt, pj_params)
+            .with_context(|| "Failed to create payjoin request")?;
+        let client = reqwest::blocking::Client::builder()
+            .danger_accept_invalid_certs(self.config.danger_accept_invalid_certs)
+            .build()
+            .with_context(|| "Failed to build reqwest http client")?;
+        let response = client
+            .post(req.url)
+            .body(req.body)
+            .header("Content-Type", "text/plain")
+            .send()
+            .with_context(|| "HTTP request failed")?;
+        // TODO display well-known errors and log::debug the rest
+        let psbt = ctx.process_response(response).with_context(|| "Failed to process response")?;
+        log::debug!("Proposed psbt: {:#?}", psbt);
+        let psbt = self
+            .bitcoind
+            .wallet_process_psbt(&serialize_psbt(&psbt), None, None, None)
+            .with_context(|| "Failed to process PSBT")?
+            .psbt;
+        let tx = self
+            .bitcoind
+            .finalize_psbt(&psbt, Some(true))
+            .with_context(|| "Failed to finalize PSBT")?
+            .hex
+            .ok_or_else(|| anyhow!("Incomplete PSBT"))?;
+        let txid = self
+            .bitcoind
+            .send_raw_transaction(&tx)
+            .with_context(|| "Failed to send raw transaction")?;
+        log::info!("Transaction sent: {}", txid);
+        Ok(())
     }
 
-    let receiver_substitute_address = bitcoind.get_new_address(None, None)?;
-    payjoin.substitute_output_address(receiver_substitute_address);
+    fn receive_payjoin(self, amount_arg: &str) -> Result<()> {
+        use payjoin::Uri;
 
-    let payjoin_proposal_psbt = payjoin.apply_fee(Some(1))?;
+        let pj_receiver_address = self.bitcoind.get_new_address(None, None)?;
+        let amount = Amount::from_sat(amount_arg.parse()?);
+        let pj_uri_string = format!(
+            "{}?amount={}&pj={}",
+            pj_receiver_address.to_qr_uri(),
+            amount.to_btc(),
+            self.config.pj_endpoint
+        );
+        let pj_uri = Uri::from_str(&pj_uri_string)
+            .map_err(|e| anyhow!("Constructed a bad URI string from args: {}", e))?;
+        let _pj_uri = pj_uri
+            .check_pj_supported()
+            .map_err(|e| anyhow!("Constructed URI does not support payjoin: {}", e))?;
 
-    log::debug!("Extracted PSBT: {:#?}", payjoin_proposal_psbt);
-    // Sign payjoin psbt
-    let payjoin_base64_string =
-        base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
-    // `wallet_process_psbt` adds available utxo data and finalizes
-    let payjoin_proposal_psbt =
-        bitcoind.wallet_process_psbt(&payjoin_base64_string, None, None, Some(false))?.psbt;
-    let payjoin_proposal_psbt =
-        load_psbt_from_base64(payjoin_proposal_psbt.as_bytes()).context("Failed to parse PSBT")?;
-    let payjoin_proposal_psbt = payjoin.prepare_psbt(payjoin_proposal_psbt)?;
-    log::debug!("Receiver's PayJoin proposal PSBT Rsponse: {:#?}", payjoin_proposal_psbt);
+        println!("Awaiting payjoin at BIP 21 Payjoin Uri:");
+        println!("{}", pj_uri_string);
 
-    let payload = base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
-    log::info!("successful response");
-    Ok(Response::text(payload))
+        rouille::start_server(self.config.pj_host.clone(), move |req| {
+            self.handle_web_request(&req)
+        });
+    }
+
+    fn handle_web_request(&self, req: &Request) -> Response {
+        self.handle_payjoin_request(req)
+            .map_err(|e| match e {
+                ReceiveError::RequestError(e) => {
+                    log::error!("Error handling request: {}", e);
+                    Response::text(e.to_string()).with_status_code(400)
+                }
+                e => {
+                    log::error!("Error handling request: {}", e);
+                    Response::text(e.to_string()).with_status_code(500)
+                }
+            })
+            .unwrap_or_else(|err_resp| err_resp)
+    }
+
+    fn handle_payjoin_request(&self, req: &Request) -> Result<Response, ReceiveError> {
+        use bitcoin::hashes::hex::ToHex;
+
+        let headers = Headers(req.headers());
+        let proposal = payjoin::receiver::UncheckedProposal::from_request(
+            req.data().context("Failed to read request body")?,
+            req.raw_query_string(),
+            headers,
+        )?;
+
+        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
+        let _to_broadcast_in_failure_case = proposal.get_transaction_to_schedule_broadcast();
+
+        // The network is used for checks later
+        let network = match self.bitcoind.get_blockchain_info()?.chain.as_str() {
+            "main" => bitcoin::Network::Bitcoin,
+            "test" => bitcoin::Network::Testnet,
+            "regtest" => bitcoin::Network::Regtest,
+            _ => return Err(ReceiveError::Other(anyhow!("Unknown network"))),
+        };
+
+        // Receive Check 1: Can Broadcast
+        let proposal = proposal.check_can_broadcast(|tx| {
+            self.bitcoind
+                .test_mempool_accept(&[bitcoin::consensus::encode::serialize(&tx).to_hex()])
+                .unwrap()
+                .first()
+                .unwrap()
+                .allowed
+        })?;
+        log::trace!("check1");
+
+        // Receive Check 2: receiver can't sign for proposal inputs
+        let proposal = proposal.check_inputs_not_owned(|input| {
+            let address = bitcoin::Address::from_script(&input, network).unwrap();
+            self.bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
+        })?;
+        log::trace!("check2");
+        // Receive Check 3: receiver can't sign for proposal inputs
+        let proposal = proposal.check_no_mixed_input_scripts()?;
+        log::trace!("check3");
+
+        // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
+        let mut payjoin = proposal
+            .check_no_inputs_seen_before(|_| false)
+            .unwrap()
+            .identify_receiver_outputs(|output_script| {
+                let address = bitcoin::Address::from_script(&output_script, network).unwrap();
+                self.bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
+            })?;
+        log::trace!("check4");
+
+        if !self.config.sub_only {
+            // Select receiver payjoin inputs.
+            _ = try_contributing_inputs(&mut payjoin, &self.bitcoind)
+                .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
+        }
+
+        let receiver_substitute_address = self.bitcoind.get_new_address(None, None)?;
+        payjoin.substitute_output_address(receiver_substitute_address);
+
+        let payjoin_proposal_psbt = payjoin.apply_fee(Some(1))?;
+
+        log::debug!("Extracted PSBT: {:#?}", payjoin_proposal_psbt);
+        // Sign payjoin psbt
+        let payjoin_base64_string =
+            base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
+        // `wallet_process_psbt` adds available utxo data and finalizes
+        let payjoin_proposal_psbt = self
+            .bitcoind
+            .wallet_process_psbt(&payjoin_base64_string, None, None, Some(false))?
+            .psbt;
+        let payjoin_proposal_psbt = load_psbt_from_base64(payjoin_proposal_psbt.as_bytes())
+            .context("Failed to parse PSBT")?;
+        let payjoin_proposal_psbt = payjoin.prepare_psbt(payjoin_proposal_psbt)?;
+        log::debug!("Receiver's PayJoin proposal PSBT Rsponse: {:#?}", payjoin_proposal_psbt);
+
+        let payload = base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
+        log::info!("successful response");
+        Ok(Response::text(payload))
+    }
 }
 
 fn try_contributing_inputs(


### PR DESCRIPTION
close #54 

This separates payjoin client app logic into its own struct. Bitcoind RPC gets connected to from the app struct, initialized from config.

`send_payjoin` and `receive_payjoin` are now better suited for binding since the app is initialized with a configuration of Strings and  the methods run in the context of the `App` impl.

link #44