### PR TITLE
Track seen inputs in payjoin-client

### DIFF
--- a/payjoin-client/src/main.rs
+++ b/payjoin-client/src/main.rs
@@ -205,14 +205,13 @@ impl App {
         log::trace!("check3");
 
         // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
-        let mut payjoin = proposal
-            .check_no_inputs_seen_before(|_| false)
-            .unwrap()
-            .identify_receiver_outputs(|output_script| {
-                let address = bitcoin::Address::from_script(&output_script, network).unwrap();
-                self.bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
-            })?;
+        let payjoin = proposal.check_no_inputs_seen_before(|_| false)?;
         log::trace!("check4");
+
+        let mut payjoin = payjoin.identify_receiver_outputs(|output_script| {
+            let address = bitcoin::Address::from_script(&output_script, network).unwrap();
+            self.bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
+        })?;
 
         if !self.config.sub_only {
             // Select receiver payjoin inputs.

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -29,8 +29,11 @@ pub(crate) enum InternalRequestError {
     MixedInputScripts(crate::input_type::InputType, crate::input_type::InputType),
     /// Unrecognized input type
     InputType(crate::input_type::InputTypeError),
-    /// Original psbt input has been seen before. This is a bigger problem for "interactive" receivers
-    InputSeen(bitcoin::OutPoint),
+    /// Original PSBT input has been seen before. Only automatic receivers, aka "interactive" in the spec
+    /// look out for these to prevent probing attacks.
+    ///
+    /// Save Script insetad of OutPoint because both would hurt privacy and the former can be re-used.
+    InputSeen(bitcoin::Script),
 }
 
 impl From<InternalRequestError> for RequestError {


### PR DESCRIPTION
The spec says the receiver should track inputs (which I first interpreted to mean TXOs) that have been seen before and rejecting proposals that contain them. I've re-interpreted that to mean input scripts. Even though script re-use would not hurt a receiver from a probing perspective, it would hurt our privacy benefits since a third party onlooker could use that script re-use to surveil the re-used address cluster despite our payjoin: It reduces the ambiguity that both inputs came from our cluster and only leaves the possibility that either both inputs came from them or we both contributed 1.

This uses the working bitcoind wallet to import addresses as watch-only, without a re-scan under a new label `input_seen_before`. The check can call bitcoind's `get_address_info` and if that address has been labeled then it must have been seen before.

It's important to return a well-known error from this check. We don't want curious senders to be able to figure out which inputs/scripts we may have seen before.

I note that this check_no_inputs_seen_before method could still check for an Input `Script` derived from `OutPoint` instead of being changed to check the `Script` directly, but I can't imagine a database scenario where that would be easier at this time.