### PR TITLE
Bump v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bip21",

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,8 +1,11 @@
 # PayJoin Changelog
 
-# ???
+## 0.8.0
 
+- Test receiver compatibility with BlueWallet
 - Rename `sender`, `receiver` features `send`, `receive`
+- introduce `receive::Error` for fallable checklist items [#59](https://github.com/payjoin/rust-payjoin/pull/59)
+- Display receiver errors, RequestErrors with JSON (https://github.com/payjoin/rust-payjoin/pull/49)
 
 ## 0.7.0
 

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dan Gould <dan@chaincase.app>"]
 description = "PayJoin Library for the BIP78 Pay to Endpoint protocol."
 homepage = "https://github.com/chaincase-app/payjoin"

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! 1. Generate a pj_uri BIP21 using [`payjoin::Uri`](crate::Uri)::from_str
 //! 2. Listen for an original PSBT on the endpoint specified in the URI
-//! 3. Parse the request using [`UncheckedProposal::from_request()`](crate::receiver::UncheckedProposal::from_request())
+//! 3. Parse the request using [`UncheckedProposal::from_request()`](crate::receive::UncheckedProposal::from_request())
 //! 4. Validate the proposal using the `check` methods to guide you.
 //! 5. Assuming the proposal is valid, augment it into a payjoin with the available `try_preserving_privacy` and `contribute` methods
 //! 6. Extract the payjoin PSBT and sign it
@@ -38,7 +38,7 @@ pub trait Headers {
 /// The sender's original PSBT and optional parameters
 ///
 /// This type is used to proces the request. It is returned by
-/// [`UncheckedProposal::from_request()`](crate::receiver::UncheckedProposal::from_request()).
+/// [`UncheckedProposal::from_request()`](crate::receive::UncheckedProposal::from_request()).
 ///
 /// If you are implementing an interactive payment processor, you should get extract the original
 /// transaction with get_transaction_to_schedule_broadcast() and schedule, followed by checking
@@ -51,7 +51,7 @@ pub struct UncheckedProposal {
 
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
-/// Call [`UncheckedProposal::check_no_receiver_owned_inputs()`](crate::receiver::UncheckedProposal::check_no_receiver_owned_inputs()) to proceed.
+/// Call [`UncheckedProposal::check_no_receiver_owned_inputs()`](crate::receive::UncheckedProposal::check_no_receiver_owned_inputs()) to proceed.
 pub struct MaybeInputsOwned {
     psbt: Psbt,
     params: Params,
@@ -59,7 +59,7 @@ pub struct MaybeInputsOwned {
 
 /// Typestate to validate that the Original PSBT has no mixed input types.
 ///
-/// Call [`UncheckedProposal::check_no_mixed_input_types()`](crate::receiver::UncheckedProposal::check_no_mixed_input_types()) to proceed.
+/// Call [`UncheckedProposal::check_no_mixed_input_types()`](crate::receive::UncheckedProposal::check_no_mixed_input_types()) to proceed.
 pub struct MaybeMixedInputScripts {
     psbt: Psbt,
     params: Params,
@@ -67,7 +67,7 @@ pub struct MaybeMixedInputScripts {
 
 /// Typestate to validate that the Original PSBT has no inputs that have been seen before.
 ///
-/// Call [`UncheckedProposal::check_no_inputs_seen()`](crate::receiver::UncheckedProposal::check_no_inputs_seen()) to proceed.
+/// Call [`UncheckedProposal::check_no_inputs_seen()`](crate::receive::UncheckedProposal::check_no_inputs_seen()) to proceed.
 pub struct MaybeInputsSeen {
     psbt: Psbt,
     params: Params,

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -51,7 +51,7 @@ pub struct UncheckedProposal {
 
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
-/// Call [`UncheckedProposal::check_no_receiver_owned_inputs()`](crate::receive::UncheckedProposal::check_no_receiver_owned_inputs()) to proceed.
+/// Call [`check_no_receiver_owned_inputs()`](struct.UncheckedProposal.html#method.check_no_receiver_owned_inputs) to proceed.
 pub struct MaybeInputsOwned {
     psbt: Psbt,
     params: Params,
@@ -59,7 +59,7 @@ pub struct MaybeInputsOwned {
 
 /// Typestate to validate that the Original PSBT has no mixed input types.
 ///
-/// Call [`UncheckedProposal::check_no_mixed_input_types()`](crate::receive::UncheckedProposal::check_no_mixed_input_types()) to proceed.
+/// Call [`check_no_mixed_input_types`](struct.UncheckedProposal.html#method.check_no_mixed_input_scripts) to proceed.
 pub struct MaybeMixedInputScripts {
     psbt: Psbt,
     params: Params,
@@ -67,7 +67,7 @@ pub struct MaybeMixedInputScripts {
 
 /// Typestate to validate that the Original PSBT has no inputs that have been seen before.
 ///
-/// Call [`UncheckedProposal::check_no_inputs_seen()`](crate::receive::UncheckedProposal::check_no_inputs_seen()) to proceed.
+/// Call [`check_no_inputs_seen`](struct.MaybeInputsSeen.html#method.check_no_inputs_seen_before) to proceed.
 pub struct MaybeInputsSeen {
     psbt: Psbt,
     params: Params,
@@ -453,6 +453,8 @@ impl PayjoinProposal {
 
     /// Apply additional fee contribution now that the receiver has contributed input
     /// this is kind of a "build_proposal" step before we sign and finalize and extract
+    ///
+    /// WARNING: DO NOT ALTER INPUTS OR OUTPUTS AFTER THIS STEP
     pub fn apply_fee(
         &mut self,
         min_feerate_sat_per_vb: Option<u64>,
@@ -502,9 +504,6 @@ impl PayjoinProposal {
 
     /// Return a Payjoin Proposal PSBT that the sender will find acceptable.
     ///
-    /// When the receiver is satisfied with their contributions, they can apply either their own
-    /// [`min_feerate`], specified here, or the sender's optional min_feerate, whichever is greater.
-    ///
     /// This attempts to calculate any network fee owed by the receiver, subtract it from their output,
     /// and return a PSBT that can produce a consensus-valid transaction that the sender will accept.
     ///
@@ -520,7 +519,6 @@ impl PayjoinProposal {
         let mut original_inputs = self.original_psbt.input_pairs().peekable();
         let mut sender_input_indexes = vec![];
         for (i, input) in self.payjoin_psbt.input_pairs().enumerate() {
-            //input.psbtin.bip32_derivation = BTreeMap::new();
             if let Some(original) = original_inputs.peek() {
                 log::trace!(
                     "match previous_output: {} == {}",

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -9,7 +9,7 @@
 //!    canceled
 //! 4. Call [`PjUriExt::create_pj_request()`](crate::PjUriExt::create_pj_request()) with the PSBT and your parameters
 //! 5. Send the request and receive response
-//! 6. Feed the response to [`Context::process_response()`](crate::sender::Context::process_response())
+//! 6. Feed the response to [`Context::process_response()`](crate::send::Context::process_response())
 //! 7. Sign resulting PSBT
 //! 8. Cancel the one-minute deadline and broadcast the resulting PSBT
 //!
@@ -125,7 +125,7 @@ pub struct Request {
 /// Data required for validation of response.
 ///
 /// This type is used to process the response. It is returned from [`PjUriExt::create_pj_request()`](crate::PjUriExt::create_pj_request()) method
-/// and you only need to call [`.process_response()`](crate::sender::Context::process_response()) on it to continue BIP78 flow.
+/// and you only need to call [`.process_response()`](crate::send::Context::process_response()) on it to continue BIP78 flow.
 pub struct Context {
     original_psbt: Psbt,
     disable_output_substitution: bool,


### PR DESCRIPTION
## 0.8.0

- Test receiver compatibility with BlueWallet
- Rename `sender`, `receiver` features `send`, `receive`
- introduce `receive::Error` for fallable checklist items [#59](https://github.com/payjoin/rust-payjoin/pull/59)
- Display receiver errors, RequestErrors with JSON (https://github.com/payjoin/rust-payjoin/pull/49)

