### PR TITLE
No std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,6 @@ dependencies = [
  "bitcoind",
  "env_logger",
  "log",
- "rand",
  "url",
 ]
 
@@ -1637,6 +1636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "bitcoin_hashes",
+ "rand",
  "secp256k1-sys",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
+name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
@@ -143,6 +149,8 @@ checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
+ "core2",
+ "hashbrown 0.8.2",
  "secp256k1",
  "serde",
 ]
@@ -153,6 +161,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -412,6 +421,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -728,11 +746,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -888,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1216,7 +1244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1239,6 +1267,7 @@ dependencies = [
  "bip21",
  "bitcoin",
  "bitcoind",
+ "core2",
  "env_logger",
  "log",
  "url",

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -18,7 +18,7 @@ send = []
 receive = ["rand"]
 
 [dependencies]
-bitcoin = "0.29.2"
+bitcoin = { version = "0.29.2", default-features = false }
 base64 = "0.13.0"
 bip21 = "0.2.0"
 log = { version = "0.4.14"}

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -15,14 +15,13 @@ edition = "2018"
 
 [features]
 send = []
-receive = ["rand"]
+receive = ["bitcoin/rand"]
 
 [dependencies]
 bitcoin = { version = "0.29.2", default-features = false }
 base64 = "0.13.0"
 bip21 = "0.2.0"
 log = { version = "0.4.14"}
-rand = { version = "0.8.4", optional = true }
 url = "2.2.2"
 
 [dev-dependencies]

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -14,13 +14,18 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+#default = [ "std" ]
 send = []
 receive = ["bitcoin/rand"]
+
+std = [ "bitcoin/std" ]
+no-std = [ "core2/alloc", "bitcoin/no-std", "hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc" ]
 
 [dependencies]
 bitcoin = { version = "0.29.2", default-features = false }
 base64 = "0.13.0"
 bip21 = "0.2.0"
+core2 = { version = "0.3.0", default-features = false, optional = true }
 log = { version = "0.4.14"}
 url = "2.2.2"
 

--- a/payjoin/src/input_type.rs
+++ b/payjoin/src/input_type.rs
@@ -1,5 +1,5 @@
-use std::convert::{TryFrom, TryInto};
-use std::fmt;
+use core::convert::{TryFrom, TryInto};
+use core::fmt;
 
 use bitcoin::blockdata::script::{Instruction, Instructions, Script};
 use bitcoin::blockdata::transaction::TxOut;
@@ -148,7 +148,7 @@ impl fmt::Display for InputTypeError {
     }
 }
 
-impl std::error::Error for InputTypeError {}
+impl crate::StdError for InputTypeError {}
 
 #[cfg(test)]
 mod tests {

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -17,6 +17,26 @@
 //!
 //! To use this library as a receiver (server, payee), you need to enable `receive` Cargo feature.
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+// May depend on crate features and we don't want to bother with it
+#[allow(unused)]
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+#[cfg(feature = "std")]
+use std::io;
+
+#[allow(unused)]
+#[cfg(not(feature = "std"))]
+use core2::error::Error as StdError;
+#[cfg(not(feature = "std"))]
+use core2::io;
+
+// use core::{borrow, fmt};
+
 pub extern crate bitcoin;
 
 #[cfg(feature = "receive")]
@@ -36,3 +56,24 @@ mod uri;
 pub(crate) mod weight;
 
 pub use uri::{PjParseError, PjUri, PjUriExt, Uri, UriExt};
+
+#[rustfmt::skip]
+mod prelude {
+    #[cfg(all(not(feature = "std"), not(test)))]
+    pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc};
+
+    #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
+    pub use alloc::sync;
+
+    #[cfg(any(feature = "std", test))]
+    pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc, sync};
+
+    #[cfg(all(not(feature = "std"), not(test)))]
+    pub use alloc::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
+
+    #[cfg(any(feature = "std", test))]
+    pub use std::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
+
+    #[cfg(feature = "std")]
+    pub use std::io::sink;
+}

--- a/payjoin/src/psbt.rs
+++ b/payjoin/src/psbt.rs
@@ -1,12 +1,14 @@
 //! Utilities to make work with PSBTs easier
 
-use std::collections::BTreeMap;
-use std::convert::TryInto;
-use std::fmt;
+use alloc::collections::BTreeMap;
+use core::convert::TryInto;
+use core::fmt;
 
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::util::{bip32, psbt};
 use bitcoin::{TxIn, TxOut};
+
+use crate::prelude::*;
 
 #[derive(Debug)]
 pub(crate) enum InconsistentPsbt {
@@ -23,7 +25,7 @@ impl fmt::Display for InconsistentPsbt {
     }
 }
 
-impl std::error::Error for InconsistentPsbt {}
+impl crate::StdError for InconsistentPsbt {}
 
 /// Our Psbt type for validation and utilities
 pub(crate) trait PsbtExt: Sized {
@@ -199,7 +201,7 @@ impl fmt::Display for PrevTxOutError {
     }
 }
 
-impl std::error::Error for PrevTxOutError {}
+impl crate::StdError for PrevTxOutError {}
 
 #[derive(Debug)]
 pub(crate) enum PsbtInputError {
@@ -219,8 +221,8 @@ impl fmt::Display for PsbtInputError {
     }
 }
 
-impl std::error::Error for PsbtInputError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl crate::StdError for PsbtInputError {
+    fn source(&self) -> Option<&(dyn crate::StdError + 'static)> {
         match self {
             PsbtInputError::PrevTxOut(error) => Some(error),
             PsbtInputError::UnequalTxid => None,
@@ -245,6 +247,6 @@ impl fmt::Display for PsbtInputsError {
     }
 }
 
-impl std::error::Error for PsbtInputsError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
+impl crate::StdError for PsbtInputsError {
+    fn source(&self) -> Option<&(dyn crate::StdError + 'static)> { Some(&self.error) }
 }

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -1,12 +1,13 @@
-use std::error;
-use std::fmt::{self, Display};
+use core::fmt;
+
+use crate::prelude::*;
 
 #[derive(Debug)]
 pub enum Error {
     /// To be returned as HTTP 400
     BadRequest(RequestError),
     // To be returned as HTTP 500
-    Server(Box<dyn error::Error>),
+    Server(Box<dyn crate::StdError >),
 }
 
 impl fmt::Display for Error {
@@ -18,8 +19,8 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+impl crate::StdError for Error {
+    fn source(&self) -> Option<&(dyn crate::StdError  + 'static)> {
         match &self {
             Self::BadRequest(_) => None,
             Self::Server(e) => Some(e.as_ref()),
@@ -43,7 +44,7 @@ pub(crate) enum InternalRequestError {
     Decode(bitcoin::consensus::encode::Error),
     MissingHeader(&'static str),
     InvalidContentType(String),
-    InvalidContentLength(std::num::ParseIntError),
+    InvalidContentLength(core::num::ParseIntError),
     ContentLengthTooLarge(u64),
     SenderParams(super::optional_parameters::Error),
     /// The raw PSBT fails bip78-specific validation.
@@ -71,7 +72,7 @@ impl From<InternalRequestError> for RequestError {
 
 impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn write_error(f: &mut fmt::Formatter, code: &str, message: impl Display) -> fmt::Result {
+        fn write_error(f: &mut fmt::Formatter, code: &str, message: impl fmt::Display) -> fmt::Result {
             write!(f, r#"{{ "errorCode": "{}", "message": "{}" }}"#, code, message)
         }
 

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -13,7 +13,7 @@
 //!
 
 use std::cmp::{max, min};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::{Amount, OutPoint, Script, TxOut};
@@ -327,9 +327,10 @@ impl PayjoinProposal {
     // https://eprint.iacr.org/2022/589.pdf
     pub fn try_preserving_privacy(
         &self,
-        candidate_inputs: HashMap<Amount, OutPoint>,
+        candidate_inputs: impl IntoIterator<Item = (Amount, OutPoint)>,
     ) -> Result<OutPoint, SelectionError> {
-        if candidate_inputs.is_empty() {
+        let mut candidate_inputs = candidate_inputs.into_iter().peekable();
+        if candidate_inputs.peek().is_none() {
             return Err(SelectionError::from(InternalSelectionError::Empty));
         }
 

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -21,11 +21,11 @@ use bitcoin::{Amount, OutPoint, Script, TxOut};
 mod error;
 mod optional_parameters;
 
+use bitcoin::secp256k1::rand::seq::SliceRandom;
+use bitcoin::secp256k1::rand::{self, Rng};
 pub use error::{Error, RequestError, SelectionError};
 use error::{InternalRequestError, InternalSelectionError};
 use optional_parameters::Params;
-use rand::seq::SliceRandom;
-use rand::Rng;
 
 use crate::fee_rate::FeeRate;
 use crate::input_type::InputType;

--- a/payjoin/src/receive/optional_parameters.rs
+++ b/payjoin/src/receive/optional_parameters.rs
@@ -1,9 +1,10 @@
-use std::borrow::Borrow;
-use std::fmt;
+use alloc::borrow::Borrow;
+use core::fmt;
 
 use log::warn;
 
 use crate::fee_rate::FeeRate;
+use crate::prelude::*;
 
 #[derive(Debug)]
 pub(crate) struct Params {
@@ -110,6 +111,6 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+impl crate::StdError for Error {
+    fn source(&self) -> Option<&(dyn crate::StdError + 'static)> { None }
 }

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use bitcoin::{PackedLockTime, Sequence};
 
@@ -15,7 +15,7 @@ pub struct ValidationError {
 
 #[derive(Debug)]
 pub(crate) enum InternalValidationError {
-    Decode(bitcoin::consensus::encode::Error),
+    Decode(base64::DecodeError),
     InvalidInputType(InputTypeError),
     InvalidProposedInput(crate::psbt::PrevTxOutError),
     VersionsDontMatch { proposed: i32, original: i32 },
@@ -87,8 +87,8 @@ impl fmt::Display for ValidationError {
     }
 }
 
-impl std::error::Error for ValidationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl crate::StdError for ValidationError {
+    fn source(&self) -> Option<&(dyn crate::StdError + 'static)> {
         use InternalValidationError::*;
 
         match &self.internal {
@@ -168,8 +168,8 @@ impl fmt::Display for CreateRequestError {
     }
 }
 
-impl std::error::Error for CreateRequestError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl crate::StdError for CreateRequestError {
+    fn source(&self) -> Option<&(dyn crate::StdError + 'static)> {
         use InternalCreateRequestError::*;
 
         match &self.0 {

--- a/payjoin/src/uri.rs
+++ b/payjoin/src/uri.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
-use std::convert::TryFrom;
+//use bitcoincore::borrow::Cow;
+use core::fmt;
+use core::convert::TryFrom;
 
+use alloc::borrow::Cow;
 use url::Url;
 
 #[cfg(feature = "send")]
@@ -122,7 +124,7 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
         &mut self,
         key: &str,
         value: bip21::Param<'_>,
-    ) -> std::result::Result<
+    ) -> Result<
         bip21::de::ParamKind,
         <Self::Value as bip21::DeserializationError>::Error,
     > {
@@ -150,7 +152,7 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
 
     fn finalize(
         self,
-    ) -> std::result::Result<Self::Value, <Self::Value as bip21::DeserializationError>::Error> {
+    ) -> Result<Self::Value, <Self::Value as bip21::DeserializationError>::Error> {
         match (self.pj, self.pjos) {
             (None, None) => Ok(PayJoin::Unsupported),
             (None, Some(_)) => Err(PjParseError(InternalPjParseError::MissingEndpoint)),
@@ -171,8 +173,8 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
     }
 }
 
-impl std::fmt::Display for PjParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for PjParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             InternalPjParseError::BadPjOs => write!(f, "Bad pjos parameter"),
             InternalPjParseError::MultipleParams(param) => {
@@ -200,7 +202,7 @@ enum InternalPjParseError {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     use crate::Uri;
 


### PR DESCRIPTION
Conform to wasm restrictions for https://github.com/MutinyWallet/mutiny-node/issues/194

`bitcoin/rand` is a reexport of `secp256k1/rand` which [is no-std](https://github.com/rust-bitcoin/rust-secp256k1/blob/7c8270a8506e31731e540fab7ee1abde1f48314e/Cargo.toml#L42-L45)

@TonyGiorgio I think these are the changes you're looking for