### PR TITLE
Serve HTTPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +132,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b36f4c848f6bd9ff208128f08751135846cc23ae57d66ab10a22efff1c675f3c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bech32",
  "bitcoin-private",
  "bitcoin_hashes",
@@ -939,7 +945,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8d6b3f301ba426b30feca834a2a18d48d5b54e5065496b5c1b05537bee3639"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "serde",
  "serde_json",
 ]
@@ -950,7 +956,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "serde",
  "serde_json",
 ]
@@ -1245,7 +1251,7 @@ name = "payjoin-cli"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bip21",
  "bitcoincore-rpc",
  "clap",
@@ -1253,8 +1259,19 @@ dependencies = [
  "env_logger",
  "log",
  "payjoin",
+ "rcgen",
  "reqwest",
  "rouille",
+ "serde",
+]
+
+[[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.2",
  "serde",
 ]
 
@@ -1393,6 +1410,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4954fbc00dcd4d8282c987710e50ba513d351400dbdd00e803a05172a90d8976"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,7 +1462,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1485,30 +1514,29 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "serde",
 ]
 
 [[package]]
 name = "rouille"
-version = "3.6.1"
+version = "3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f86e4c51a773f953f02bbab5fd049f004bfd384341d62da2a079aff812ab176"
+checksum = "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "brotli",
  "chrono",
  "deflate",
  "filetime",
  "multipart",
- "num_cpus",
  "percent-encoding",
  "rand",
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1_smol",
  "threadpool",
  "time 0.3.17",
  "tiny_http",
@@ -1677,15 +1705,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
+name = "sha1_smol"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -1853,6 +1876,8 @@ dependencies = [
  "chunked_transfer",
  "httpdate",
  "log",
+ "openssl",
+ "zeroize",
 ]
 
 [[package]]
@@ -2347,6 +2372,21 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time 0.3.17",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zip"

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
-https = ["rcgen", "rouille/ssl"]
+local-https = ["rcgen", "rouille/ssl"]
 
 [dependencies]
 anyhow = "1.0.70"

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
+https = ["rcgen", "rouille/ssl"]
 
 [dependencies]
 anyhow = "1.0.70"
@@ -23,5 +24,6 @@ env_logger = "0.9.0"
 log = "0.4.7"
 payjoin = { path = "../payjoin", features = ["send", "receive"] }
 reqwest = { version = "0.11.4", features = ["blocking"] }
-rouille = "3.6.1"
+rcgen = { version = "0.11.1", optional = true }
+rouille = "3.6.2"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -25,8 +25,8 @@ Your configuration details will vary, but you may use this as a template.
 
  Set up 2 local regtest wallets and fund them. This example uses "boom" and "ocean"
 
-Determine the RPC port specified in your bitcoind's "bitcoin.conf"
-file. Mine was 18443. This can be set in `bitcoin.conf` like so:
+Determine the RPC port specified in your bitcoind's `bitcoin.conf`
+file. 18443 is the default. This can be set like so:
 
 ```conf
 rpcport = 18443
@@ -35,27 +35,16 @@ rpcport = 18443
 From the `payjoin-cli directory, where "boom" is the receiving wallet, 18443 is the rpc port, and you wish to request 10,000 sats run:
 
 ```console
-RUST_LOG=debug cargo run -- -r "http://localhost:18443/wallet/boom" receive 10000
+RUST_LOG=debug cargo run --features=local-https -- -r "http://localhost:18443/wallet/boom" receive 10000
 ```
+
+The default configuration listens for payjoin requests at `http://localhost:3000` and expects you to proxy https requests there.
+Payjoin requires a secure endpoint, either https and .onion are valid. In order to receive payjoin in a local testing environment one may enable the  `local-https` feature which will provision a self-signed certificate and host the `https://localhost:3000` endpoint. Emphasis on HTTP**S**.
 
 This will generate a payjoin capable bip21 URI with which to accept payjoin:
 
 ```console
-BITCOIN:BCRT1QCJ4X75DUNY4X5NAWLM3CR8MALM9YAUYWWEWKWL?amount=0.00010&pj=https://localhost:3010
-```
-
-Default configuration listens for payjoin requests at
-`http://localhost:3000` and lists server as `https://localhost:3010`.
-
-Download and install [`local-ssl-proxy`](https://github.com/cameronhunter/local-ssl-proxy)
-
-The default configuration listens for payjoin requests at `http://localhost:3000` and lists the server as
-`https://localhost:3010`. Payjoin requires a secure endpoint, either https and .onion are valid. Therefore, in order to receive
-payjoin, one must also host an https reverse proxy to marshall https requests from localhost:3010 to
-localhost:3000.To do this, run:
-
-```console
-local-ssl-proxy --source 3010 --target 3000
+BITCOIN:BCRT1QCJ4X75DUNY4X5NAWLM3CR8MALM9YAUYWWEWKWL?amount=0.00010&pj=https://localhost:3000
 ```
 
 ### Send Payjoin
@@ -66,7 +55,7 @@ Create another config.toml file in this directory and configure it as you did
 previously, except replace the receiver wallet name with the sender
 wallet name ("ocean" for me).
 
-If you are testing locally, add the following line to the
+If you are testing locally using a self-signed certificate as with the `local-https` feature, add the following line to the
 configuration file:
 
 danger_accept_invalid_certs = true
@@ -81,3 +70,5 @@ from the sender directory:
 You should see the payjoin transaction occur and be able to verify the
 Partially Signed Bitcoin Transaction (PSBT), inputs, and Unspent
 Transaction Outputs (UTXOs).
+
+Congrats, you've payjoined!

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -1,73 +1,83 @@
 # payjoin-cli
 
- ## A command-line payjoin client for bitcoind in rust
+## A command-line payjoin client for bitcoind in rust
 
 ### Install payjoin-cli
- \
- Get a list of commands and options:
- ```console
- RUST_LOG=debug cargo run -- --help
- ```
- Manually create a config.toml file within the payjoin-cli directory
- and configurate it as follows:
+
+Get a list of commands and options:
+
+```console
+RUST_LOG=debug cargo run -- --help
+```
+
+ Manually create a `config.toml` file within the payjoin-cli directory
+ and configure it like so:
+
 ```toml
  # config.toml
- bitcoind_cookie = "[bitcoind cookie file location]" # mine was: "/tmp/regtest1/bitcoind/regtest/.cookie" 
- bitcoind_rpchost = "[rpcport/wallet/wallet name]" # mine was: "http://localhost:18443/wallet/boom"
+ bitcoind_cookie = "/tmp/regtest1/bitcoind/regtest/.cookie" 
+ bitcoind_rpchost = "http://localhost:18443/wallet/boom"
  ```
+
+Your configuration details will vary, but you may use this as a template.
 
 ### Receive Payjoin
- Set up 2 local regtest wallets and fund them. In my case, I funded a
- regtest wallet "boom" with 158 coins and another wallet "ocean" with
- .8 coins.
 
- Determine the RPC port specified in your bitcoind's "bitcoin.conf"
- file. Mine was 18443. Look for:
- ```toml
- rpcport= # rpc port
- ```
- Run the following command from the payjoin-cli directory, where "boom"
- is the receiving wallet, 18443 is the rpc port, and you wish to
- request 10,000 sats:
- ```console
- RUST_LOG=debug cargo run -- -r "http://localhost:18443/wallet/boom" receive 10000
- ```
- This will generate a pay join-capable bip21 URI with which to accept
- payjoin as follows:
- ```console
- BITCOIN:BCRT1QCJ4X75DUNY4X5NAWLM3CR8MALM9YAUYWWEWKWL?amount=0.00010&pj=https://localhost:3010
- ```
+ Set up 2 local regtest wallets and fund them. This example uses "boom" and "ocean"
 
- Default configuration listens for payjoin requests at
- http://localhost:3000 and lists server as https://localhost:3010.
+Determine the RPC port specified in your bitcoind's "bitcoin.conf"
+file. Mine was 18443. This can be set in `bitcoin.conf` like so:
 
- Download and install local-ssl-proxy:\
- https://github.com/cameronhunter/local-ssl-proxy \
- The default configuration listens for payjoin requests at http://localhost:3000 and lists the server as 
- https://localhost:3010. Only https and .onion payjoin endpoints are valid. Therefore, in order to receive
-  payjoin, one must also host an https reverse proxy to marshall https requests from localhost:3010 to
-   localhost:3000.To do this, run:
+```conf
+rpcport = 18443
+```
+
+From the `payjoin-cli directory, where "boom" is the receiving wallet, 18443 is the rpc port, and you wish to request 10,000 sats run:
+
+```console
+RUST_LOG=debug cargo run -- -r "http://localhost:18443/wallet/boom" receive 10000
+```
+
+This will generate a payjoin capable bip21 URI with which to accept payjoin:
+
+```console
+BITCOIN:BCRT1QCJ4X75DUNY4X5NAWLM3CR8MALM9YAUYWWEWKWL?amount=0.00010&pj=https://localhost:3010
+```
+
+Default configuration listens for payjoin requests at
+`http://localhost:3000` and lists server as `https://localhost:3010`.
+
+Download and install [`local-ssl-proxy`](https://github.com/cameronhunter/local-ssl-proxy)
+
+The default configuration listens for payjoin requests at `http://localhost:3000` and lists the server as
+`https://localhost:3010`. Payjoin requires a secure endpoint, either https and .onion are valid. Therefore, in order to receive
+payjoin, one must also host an https reverse proxy to marshall https requests from localhost:3010 to
+localhost:3000.To do this, run:
+
 ```console
 local-ssl-proxy --source 3010 --target 3000
 ```
-###  Send Payjoin
 
- Create a "sender" directory within payjoin-cli. Open a new terminal window and navigate to this directory.
- Note: A wallet cannot payjoin with itself, need separate wallets.
- Create another config.toml file in this directory and configure it as you did
- previously, except replace the receiver wallet name with the sender
- wallet name ("ocean" for me).
+### Send Payjoin
 
- If you are testing locally, add the following line to the
- configuration file:
+Create a "sender" directory within payjoin-cli. Open a new terminal window and navigate to this directory.
+Note: A wallet cannot payjoin with itself, need separate wallets.
+Create another config.toml file in this directory and configure it as you did
+previously, except replace the receiver wallet name with the sender
+wallet name ("ocean" for me).
 
- danger_accept_invalid_certs = true
+If you are testing locally, add the following line to the
+configuration file:
 
- Using the previously generated bip21 URI, run the following command
- from the sender directory:
+danger_accept_invalid_certs = true
+
+Using the previously generated bip21 URI, run the following command
+from the sender directory:
+
 ```console
  RUST_LOG=debug cargo run -- send "[BIP21 URI]"
 ```
- You should see the payjoin transaction occur and be able to verify the
- Partially Signed Bitcoin Transaction (PSBT), inputs, and Unspent
- Transaction Outputs (UTXOs).
+
+You should see the payjoin transaction occur and be able to verify the
+Partially Signed Bitcoin Transaction (PSBT), inputs, and Unspent
+Transaction Outputs (UTXOs).

--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -143,26 +143,27 @@ impl App {
             self.config.pj_host
         );
         println!("{}", pj_uri_string);
-        #[cfg(any(feature = "https"))]
+
+        #[cfg(feature = "local-https")]
         let server = {
-            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-            let cert_ser = cert.serialize_pem().unwrap().into_bytes();
+            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+            let cert_ser = cert.serialize_pem()?;
             let skey_ser = cert.serialize_private_key_pem().into_bytes();
             rouille::Server::new_ssl(
                 self.config.pj_host.clone(),
                 move |req| self.handle_web_request(req),
-                cert_ser,
+                cert_ser.into_bytes(),
                 skey_ser,
             )
-            .unwrap()
+            .map_err(|e| anyhow!("Failed to create HTTPS server: {}", e))?
         };
 
-        #[cfg(not(any(feature = "https")))]
+        #[cfg(not(feature = "local-https"))]
         let server = {
             rouille::Server::new(self.config.pj_host.clone(), move |req| {
                 self.handle_web_request(req)
             })
-            .unwrap()
+            .map_err(|e| anyhow!("Failed to create HTTP server: {}", e))?
         };
 
         server.run();
@@ -418,7 +419,7 @@ impl AppConfig {
             // Subcommand defaults without which file serialization fails.
             .set_default("danger_accept_invalid_certs", false)?
             .set_default("pj_host", "0.0.0.0:3000")?
-            .set_default("pj_endpoint", "https://localhost:3010")?
+            .set_default("pj_endpoint", "https://localhost:3000")?
             .set_default("sub_only", false)?
             .add_source(File::new("config.toml", FileFormat::Toml));
 


### PR DESCRIPTION
close #81 

1. [x] Generate a Self-Signed Certificate for local testing
2. [x] Run Server with HTTPS and the generated certificate. `payjoin-cli` uses a rouille server which supports HTTPS
3. ~Trust the Self-Signed Certificate. We should prompt users to do with an explainer (since this step requires administrator permissions since a test sender needs to configure their client to use the receiver's cert~ Continue to use the config to trust self-signed certs for testing. Other options are overly complex for now since this is a testing environment
4. [x] Document and remove proxy mentions except for public deployments
5.  ~Save self-signed cert to file system so it only needs to be created and trusted configured once~