### PR TITLE
bump payjoin 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "bip21",
  "bitcoin",

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Payjoin Changelog
 
-## 0.8.1
+## 0.9.0
+
+Bumping `bitcoin` and other crates was a breaking api change. This is a 0.8.1 semver re-release.
+
+- Bump `bitcoin-0.30.0`
+- Bump `bip21-0.3.1`
+- Swap `base64-0.13.0` for `bitcoin`'s `base64` feature export
+
+## 0.8.1 (yanked)
 
 - Bump `bitcoin-0.30.0`
 - Bump `bip21-0.3.1`

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Dan Gould <dan@chaincase.app>"]
 description = "Payjoin Library for the BIP78 Pay to Endpoint protocol."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
0.8.1 broke the api because it bumped bitcoin-0.30.0. That's a breaking change, so I yanked it and am re-releasing 0.9.0