### PR TITLE
Replace `Configuration` with ergonomic `RequestBuilder`

### DIFF
--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -83,13 +83,9 @@ impl App {
         let psbt = Psbt::from_str(&psbt).with_context(|| "Failed to load PSBT from base64")?;
         log::debug!("Original psbt: {:#?}", psbt);
 
-        let payout_scripts = std::iter::once(uri.address.script_pubkey());
-
         let (req, ctx) = payjoin::send::RequestBuilder::from_psbt_and_uri(psbt, uri)
             .with_context(|| "Failed to build payjoin request")?
-            .with_recommended_params(payout_scripts, fee_rate)
-            .with_context(|| "Configuration error")?
-            .build()
+            .build_recommended(fee_rate)
             .with_context(|| "Failed to build payjoin request")?;
 
         let client = reqwest::blocking::Client::builder()

--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -9,9 +9,9 @@ use bitcoincore_rpc::jsonrpc::serde_json;
 use bitcoincore_rpc::RpcApi;
 use clap::ArgMatches;
 use config::{Config, File, FileFormat};
+use payjoin::bitcoin;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::receive::{Error, ProvisionalProposal};
-use payjoin::{bitcoin, PjUriExt, UriExt};
 use rouille::{Request, Response};
 use serde::{Deserialize, Serialize};
 
@@ -42,21 +42,15 @@ impl App {
     }
 
     pub fn send_payjoin(&self, bip21: &str) -> Result<()> {
-        use payjoin::send::Configuration;
+        let uri = payjoin::Uri::try_from(bip21)
+            .map_err(|e| anyhow!("Failed to create URI from BIP21: {}", e))?
+            .assume_checked();
 
-        let link = payjoin::Uri::try_from(bip21)
-            .map_err(|e| anyhow!("Failed to create URI from BIP21: {}", e))?;
-
-        let link = link
-            .assume_checked()
-            .check_pj_supported()
-            .map_err(|e| anyhow!("The provided URI doesn't support payjoin (BIP78): {}", e))?;
-
-        let amount = link.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;
+        let amount = uri.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;
 
         // wallet_create_funded_psbt requires a HashMap<address: String, Amount>
         let mut outputs = HashMap::with_capacity(1);
-        outputs.insert(link.address.to_string(), amount);
+        outputs.insert(uri.address.to_string(), amount);
 
         // TODO: make payjoin-cli send feerate configurable
         // 2.1 sat/vB == 525 sat/kwu for testing purposes.
@@ -89,14 +83,15 @@ impl App {
         let psbt = Psbt::from_str(&psbt).with_context(|| "Failed to load PSBT from base64")?;
         log::debug!("Original psbt: {:#?}", psbt);
 
-        let payout_scripts = std::iter::once(link.address.script_pubkey());
-        // recommendation or bust for this simple reference implementation
-        let pj_params = Configuration::recommended(&psbt, payout_scripts, fee_rate)
-            .unwrap_or_else(|_| Configuration::non_incentivizing());
+        let payout_scripts = std::iter::once(uri.address.script_pubkey());
 
-        let (req, ctx) = link
-            .create_pj_request(psbt, pj_params)
-            .with_context(|| "Failed to create payjoin request")?;
+        let (req, ctx) = payjoin::send::RequestBuilder::from_psbt_and_uri(psbt, uri)
+            .with_context(|| "Failed to build payjoin request")?
+            .with_recommended_params(payout_scripts, fee_rate)
+            .with_context(|| "Configuration error")?
+            .build()
+            .with_context(|| "Failed to build payjoin request")?;
+
         let client = reqwest::blocking::Client::builder()
             .danger_accept_invalid_certs(self.config.danger_accept_invalid_certs)
             .build()
@@ -141,12 +136,10 @@ impl App {
             amount.to_btc(),
             self.config.pj_endpoint
         );
-        let pj_uri = Uri::from_str(&pj_uri_string)
-            .map_err(|e| anyhow!("Constructed a bad URI string from args: {}", e))?;
-        let _pj_uri = pj_uri
-            .assume_checked()
-            .check_pj_supported()
-            .map_err(|e| anyhow!("Constructed URI does not support payjoin: {}", e))?;
+        // check that the URI is corrctly formatted
+        let _pj_uri = Uri::from_str(&pj_uri_string)
+            .map_err(|e| anyhow!("Constructed a bad URI string from args: {}", e))?
+            .assume_checked();
 
         println!(
             "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
@@ -231,10 +224,8 @@ impl App {
         };
         let uri = payjoin::Uri::try_from(uri_string.clone())
             .map_err(|_| Error::Server(anyhow!("Could not parse payjoin URI string.").into()))?;
-        let _ = uri
-            .assume_checked() // we just got it from bitcoind above
-            .check_pj_supported()
-            .map_err(|_| Error::Server(anyhow!("Created bip21 with invalid &pj=.").into()))?;
+        let _ = uri.assume_checked(); // we just got it from bitcoind above
+
         Ok(Response::text(uri_string))
     }
 

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -37,4 +37,4 @@ pub(crate) mod weight;
 
 #[cfg(feature = "base64")]
 pub use bitcoin::base64;
-pub use uri::{PjParseError, PjUri, PjUriExt, Uri, UriExt};
+pub use uri::{PjParseError, PjUri, Uri};

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -141,6 +141,30 @@ impl From<InternalConfigurationError> for ConfigurationError {
     fn from(value: InternalConfigurationError) -> Self { ConfigurationError(value) }
 }
 
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use InternalConfigurationError::*;
+
+        match &self.0 {
+            PrevTxOut(e) => write!(f, "invalid previous transaction output: {}", e),
+            InputType(e) => write!(f, "invalid input type: {}", e),
+            NoInputs => write!(f, "no inputs"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigurationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use InternalConfigurationError::*;
+
+        match &self.0 {
+            PrevTxOut(error) => Some(error),
+            InputType(error) => Some(error),
+            NoInputs => None,
+        }
+    }
+}
+
 /// Error returned when request could not be created.
 ///
 /// This error can currently only happen due to programmer mistake.
@@ -163,6 +187,7 @@ pub(crate) enum InternalCreateRequestError {
     ChangeIndexOutOfBounds,
     ChangeIndexPointsAtPayee,
     Url(url::ParseError),
+    UriDoesNotSupportPayjoin,
 }
 
 impl fmt::Display for CreateRequestError {
@@ -182,6 +207,7 @@ impl fmt::Display for CreateRequestError {
             ChangeIndexOutOfBounds => write!(f, "fee output index is points out of bounds"),
             ChangeIndexPointsAtPayee => write!(f, "fee output index is points at output belonging to the payee"),
             Url(e) => write!(f, "cannot parse endpoint url: {:#?}", e),
+            UriDoesNotSupportPayjoin => write!(f, "the URI does not support payjoin"),
         }
     }
 }
@@ -203,6 +229,7 @@ impl std::error::Error for CreateRequestError {
             ChangeIndexOutOfBounds => None,
             ChangeIndexPointsAtPayee => None,
             Url(error) => Some(error),
+            UriDoesNotSupportPayjoin => None,
         }
     }
 }

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -127,44 +127,6 @@ impl std::error::Error for ValidationError {
     }
 }
 
-#[derive(Debug)]
-pub struct ConfigurationError(InternalConfigurationError);
-
-#[derive(Debug)]
-pub(crate) enum InternalConfigurationError {
-    PrevTxOut(crate::psbt::PrevTxOutError),
-    InputType(crate::input_type::InputTypeError),
-    NoInputs,
-}
-
-impl From<InternalConfigurationError> for ConfigurationError {
-    fn from(value: InternalConfigurationError) -> Self { ConfigurationError(value) }
-}
-
-impl fmt::Display for ConfigurationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use InternalConfigurationError::*;
-
-        match &self.0 {
-            PrevTxOut(e) => write!(f, "invalid previous transaction output: {}", e),
-            InputType(e) => write!(f, "invalid input type: {}", e),
-            NoInputs => write!(f, "no inputs"),
-        }
-    }
-}
-
-impl std::error::Error for ConfigurationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use InternalConfigurationError::*;
-
-        match &self.0 {
-            PrevTxOut(error) => Some(error),
-            InputType(error) => Some(error),
-            NoInputs => None,
-        }
-    }
-}
-
 /// Error returned when request could not be created.
 ///
 /// This error can currently only happen due to programmer mistake.
@@ -188,6 +150,8 @@ pub(crate) enum InternalCreateRequestError {
     ChangeIndexPointsAtPayee,
     Url(url::ParseError),
     UriDoesNotSupportPayjoin,
+    PrevTxOut(crate::psbt::PrevTxOutError),
+    InputType(crate::input_type::InputTypeError),
 }
 
 impl fmt::Display for CreateRequestError {
@@ -208,6 +172,8 @@ impl fmt::Display for CreateRequestError {
             ChangeIndexPointsAtPayee => write!(f, "fee output index is points at output belonging to the payee"),
             Url(e) => write!(f, "cannot parse endpoint url: {:#?}", e),
             UriDoesNotSupportPayjoin => write!(f, "the URI does not support payjoin"),
+            PrevTxOut(e) => write!(f, "invalid previous transaction output: {}", e),
+            InputType(e) => write!(f, "invalid input type: {}", e),
         }
     }
 }
@@ -230,6 +196,8 @@ impl std::error::Error for CreateRequestError {
             ChangeIndexPointsAtPayee => None,
             Url(error) => Some(error),
             UriDoesNotSupportPayjoin => None,
+            PrevTxOut(error) => Some(error),
+            InputType(error) => Some(error),
         }
     }
 }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -79,7 +79,7 @@ mod integration {
         debug!("Original psbt: {:#?}", psbt);
         let (req, ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)
             .unwrap()
-            .with_fee_contribution(payjoin::bitcoin::Amount::from_sat(10000), None)
+            .build_with_fee_contribution(payjoin::bitcoin::Amount::from_sat(10000), None)
             .build()
             .unwrap();
         let headers = HeaderMock::from_vec(&req.body);

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -11,8 +11,8 @@ mod integration {
     use log::{debug, log_enabled, Level};
     use payjoin::bitcoin::base64;
     use payjoin::receive::Headers;
-    use payjoin::send::Request;
-    use payjoin::{bitcoin, Error, PjUriExt, Uri, UriExt};
+    use payjoin::send::{Request, RequestBuilder};
+    use payjoin::{bitcoin, Error, Uri};
 
     #[test]
     fn integration_test() {
@@ -53,9 +53,8 @@ mod integration {
             pj_receiver_address.to_qr_uri(),
             amount.to_btc()
         );
-        let pj_uri = Uri::from_str(&pj_uri_string).unwrap().assume_checked();
-        let pj_uri = pj_uri.check_pj_supported().expect("Bad Uri");
-
+        let pj_uri = Uri::from_str(&pj_uri_string).unwrap();
+        let pj_uri = pj_uri.assume_checked();
         // Sender create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
         let mut outputs = HashMap::with_capacity(1);
         outputs.insert(pj_uri.address.to_string(), pj_uri.amount.unwrap());
@@ -78,11 +77,11 @@ mod integration {
         let psbt = sender.wallet_process_psbt(&psbt, None, None, None).unwrap().psbt;
         let psbt = Psbt::from_str(&psbt).unwrap();
         debug!("Original psbt: {:#?}", psbt);
-        let pj_params = payjoin::send::Configuration::with_fee_contribution(
-            payjoin::bitcoin::Amount::from_sat(10000),
-            None,
-        );
-        let (req, ctx) = pj_uri.create_pj_request(psbt, pj_params).unwrap();
+        let (req, ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)
+            .unwrap()
+            .with_fee_contribution(payjoin::bitcoin::Amount::from_sat(10000), None)
+            .build()
+            .unwrap();
         let headers = HeaderMock::from_vec(&req.body);
 
         // **********************

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -79,8 +79,12 @@ mod integration {
         debug!("Original psbt: {:#?}", psbt);
         let (req, ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)
             .unwrap()
-            .build_with_fee_contribution(payjoin::bitcoin::Amount::from_sat(10000), None)
-            .build()
+            .build_with_additional_fee(
+                payjoin::bitcoin::Amount::from_sat(10000),
+                None,
+                bitcoin::FeeRate::ZERO,
+                false,
+            )
             .unwrap();
         let headers = HeaderMock::from_vec(&req.body);
 


### PR DESCRIPTION
- Replace manual Configuration struct with validated `RequestBuilder` pattern
- Remove Request construction from `Uri` and static request builder functions
- Remove unsupported batched send configuration & document how to implement it

Close #19

This change helps #101 by allowing `Context` to become a version agnostic trait.

More deletes than additions!

- [x] Don't forget to update the docs