### PR TITLE
Ready payjoin v0.11.0 and payjoin-cli v0.0.1-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bip21",
  "bitcoin",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin-cli"
-version = "0.0.1"
+version = "0.0.1-alpha"
 dependencies = [
  "anyhow",
  "bip21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["payjoin", "payjoin-cli"]
 resolver = "2"
+
+[patch.crates-io.payjoin]
+path = "payjoin"

--- a/payjoin-cli/CHANGELOG.md
+++ b/payjoin-cli/CHANGELOG.md
@@ -1,5 +1,5 @@
 # payjoin-cli Changelog
 
-## 0.0.1
+## 0.0.1-alpha
 
 - Release initial payjoin-cli to send and receive payjoin from bitcoind

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "payjoin-cli"
-version = "0.0.1"
+version = "0.0.1-alpha"
 authors = ["Dan Gould <d@ngould.dev>", "Martin Habovstiak <martin.habovstiak@gmail.com>"]
 repository = "https://github.com/payjoin/rust-payjoin"
 readme = "README.md"
 edition = "2021"
 resolver = "2"
+exclude = ["tests"]
 
 [[bin]]
 name = "payjoin-cli"
@@ -26,7 +27,7 @@ env_logger = "0.9.0"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.24", optional = true }
 log = "0.4.7"
-payjoin = { path = "../payjoin", features = ["send", "receive", "base64"] }
+payjoin = { version = "0.11.0", features = ["send", "receive", "base64"] }
 ureq = "2.8.0"
 rcgen = { version = "0.11.1", optional = true }
 rustls = { version = "0.21.9", optional = true }

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Payjoin Changelog
 
+## 0.11.0
+
+- Introduce `send` `RequestBuilder` flow
+
 ## 0.10.0
 
 - Export `base64` with feature by @jbesraa in #102

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Dan Gould <dan@chaincase.app>"]
 description = "Payjoin Library for the BIP78 Pay to Endpoint protocol."
 repository = "https://github.com/payjoin/rust-payjoin"
@@ -10,6 +10,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies", "network-program
 license = "MITNFA"
 resolver = "2"
 edition = "2021"
+exclude = ["tests"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- update versions
- Exclude tests
- amend changelogs
- patch payjoin with local version for dev