### PR TITLE
Include ohttp ctx in session ctx

### DIFF
--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -197,7 +197,7 @@ impl App {
     #[cfg(feature = "v2")]
     async fn long_poll_post(&self, req_ctx: &payjoin::send::RequestContext) -> Result<Psbt> {
         loop {
-            let (req, ctx, ohttp) = req_ctx.extract_v2(&self.config.ohttp_proxy)?;
+            let (req, ctx) = req_ctx.extract_v2(&self.config.ohttp_proxy)?;
             println!("Sending fallback request to {}", &req.url);
             let http = http_agent()?;
             let response = spawn_blocking(move || {
@@ -209,7 +209,7 @@ impl App {
             .await??;
 
             println!("Sent fallback transaction");
-            let psbt = ctx.process_response(&mut response.into_reader(), ohttp)?;
+            let psbt = ctx.process_response(&mut response.into_reader())?;
             if let Some(psbt) = psbt {
                 return Ok(psbt);
             } else {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -247,7 +247,7 @@ mod integration {
             // Create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
             let psbt = build_original_psbt(&sender, &pj_uri)?;
             debug!("Original psbt: {:#?}", psbt);
-            let (send_req, send_ctx, ohttp) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
+            let (send_req, send_ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
                 .extract_v2(OH_RELAY_URL)?;
             log::info!("send fallback v2");
@@ -298,7 +298,7 @@ mod integration {
             })
             .await??;
             let checked_payjoin_proposal_psbt =
-                send_ctx.process_response(&mut response.into_reader(), ohttp)?.unwrap();
+                send_ctx.process_response(&mut response.into_reader())?.unwrap();
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
             log::info!("sent");


### PR DESCRIPTION
This was moved in order to persist ContextV2, but RequestContext is persisted instead.

Reverts c5929542f4008315c9149116376f80b1db60128d