### PR TITLE
Support taproot PSBTs

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -800,6 +800,7 @@ impl ProvisionalProposal {
             self.payjoin_psbt.inputs[i].witness_utxo = None;
             self.payjoin_psbt.inputs[i].final_script_sig = None;
             self.payjoin_psbt.inputs[i].final_script_witness = None;
+            self.payjoin_psbt.inputs[i].tap_key_sig = None;
         }
         Ok(PayjoinProposal {
             payjoin_psbt: self.payjoin_psbt,

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -988,11 +988,18 @@ fn clear_unneeded_fields(psbt: &mut Psbt) {
     psbt.unknown_mut().clear();
     for input in psbt.inputs_mut() {
         input.bip32_derivation.clear();
+        input.tap_internal_key = None;
+        input.tap_key_origins.clear();
+        input.tap_key_sig = None;
+        input.tap_merkle_root = None;
+        input.tap_script_sigs.clear();
         input.proprietary.clear();
         input.unknown.clear();
     }
     for output in psbt.outputs_mut() {
         output.bip32_derivation.clear();
+        output.tap_internal_key = None;
+        output.tap_key_origins.clear();
         output.proprietary.clear();
         output.unknown.clear();
     }


### PR DESCRIPTION
  Sometimes taproot signers leave around taproot signing artifacts.
  Part of the spec is to remove unnecessary psbt data for counterparties,
  so this ensures removal of taproot variety unnecessary data too.

Before this change it was possible for bitcoind's walletprocesspsbt to fail when it didn't have to because superfluous psbt data was present on the original psbt. This falls in line with the sender checklist, [see "The Original PSBT MUST"](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#protocol)

