### PR TITLE
Signal keyconfig problem

### DIFF
--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -132,11 +132,9 @@ impl App {
             );
             let (req, ctx) = enroller.extract_req()?;
             log::debug!("Enrolling receiver");
+            let http = http_agent()?;
             let ohttp_response = spawn_blocking(move || {
-                let http = http_agent()?;
-                http.post(req.url.as_ref())
-                    .send_bytes(&req.body)
-                    .with_context(|| "HTTP request failed")
+                http.post(req.url.as_ref()).send_bytes(&req.body).map_err(map_ureq_err)
             })
             .await??;
 
@@ -172,7 +170,7 @@ impl App {
             .extract_v2_req()
             .map_err(|e| anyhow!("v2 req extraction failed {}", e))?;
         let http = http_agent()?;
-        let res = http.post(req.url.as_str()).send_bytes(&req.body)?;
+        let res = http.post(req.url.as_str()).send_bytes(&req.body).map_err(map_ureq_err)?;
         let mut buf = Vec::new();
         let _ = res.into_reader().read_to_end(&mut buf)?;
         let res = payjoin_proposal.deserialize_res(buf, ohttp_ctx);
@@ -204,7 +202,7 @@ impl App {
                 http.post(req.url.as_ref())
                     .set("Content-Type", "text/plain")
                     .send_bytes(&req.body)
-                    .with_context(|| "HTTP request failed")
+                    .map_err(map_ureq_err)
             })
             .await??;
 
@@ -229,8 +227,10 @@ impl App {
                 enrolled.extract_req().map_err(|_| anyhow!("Failed to extract request"))?;
             log::debug!("GET fallback_psbt");
             let http = http_agent()?;
-            let ohttp_response =
-                spawn_blocking(move || http.post(req.url.as_str()).send_bytes(&req.body)).await??;
+            let ohttp_response = spawn_blocking(move || {
+                http.post(req.url.as_str()).send_bytes(&req.body).map_err(map_ureq_err)
+            })
+            .await??;
 
             let proposal = enrolled
                 .process_res(ohttp_response.into_reader(), context)
@@ -905,3 +905,15 @@ fn http_agent() -> Result<ureq::Agent> {
 
 #[cfg(not(feature = "danger-local-https"))]
 fn http_agent() -> Result<ureq::Agent> { Ok(ureq::Agent::new()) }
+
+fn map_ureq_err(e: ureq::Error) -> anyhow::Error {
+    let e_string = e.to_string();
+    match e.into_response() {
+        Some(res) => anyhow!(
+            "HTTP request failed: {} {}",
+            res.status(),
+            res.into_string().unwrap_or_default()
+        ),
+        None => anyhow!("No HTTP response: {}", e_string),
+    }
+}

--- a/payjoin-relay/src/main.rs
+++ b/payjoin-relay/src/main.rs
@@ -213,13 +213,13 @@ impl HandlerError {
     fn to_response(&self) -> Response<Body> {
         let status = match self {
             HandlerError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
-            HandlerError::BadRequest(e) => {
-                error!("Bad request: {}", e);
-                StatusCode::BAD_REQUEST
-            }
             HandlerError::InternalServerError(e) => {
                 error!("Internal server error: {}", e);
                 StatusCode::INTERNAL_SERVER_ERROR
+            }
+            HandlerError::BadRequest(e) => {
+                error!("Bad request: {}", e);
+                StatusCode::BAD_REQUEST
             }
         };
 

--- a/payjoin-relay/src/main.rs
+++ b/payjoin-relay/src/main.rs
@@ -211,20 +211,19 @@ enum HandlerError {
 
 impl HandlerError {
     fn to_response(&self) -> Response<Body> {
-        let status = match self {
-            HandlerError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+        let mut res = Response::default();
+        match self {
+            HandlerError::PayloadTooLarge => *res.status_mut() = StatusCode::PAYLOAD_TOO_LARGE,
             HandlerError::InternalServerError(e) => {
                 error!("Internal server error: {}", e);
-                StatusCode::INTERNAL_SERVER_ERROR
+                *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR
             }
             HandlerError::BadRequest(e) => {
                 error!("Bad request: {}", e);
-                StatusCode::BAD_REQUEST
+                *res.status_mut() = StatusCode::BAD_REQUEST
             }
         };
 
-        let mut res = Response::new(Body::empty());
-        *res.status_mut() = status;
         res
     }
 }

--- a/payjoin-relay/src/main.rs
+++ b/payjoin-relay/src/main.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use bitcoin::{self, base64};
+use hyper::header::HeaderValue;
 use hyper::server::conn::AddrIncoming;
 use hyper::server::Builder;
 use hyper::service::{make_service_fn, service_fn};
@@ -151,8 +152,9 @@ async fn handle_ohttp(
     let ohttp_body =
         hyper::body::to_bytes(body).await.map_err(|e| HandlerError::BadRequest(e.into()))?;
     let mut ohttp_locked = ohttp.lock().await;
-    let (bhttp_req, res_ctx) =
-        ohttp_locked.decapsulate(&ohttp_body).map_err(|e| HandlerError::BadRequest(e.into()))?;
+    let (bhttp_req, res_ctx) = ohttp_locked
+        .decapsulate(&ohttp_body)
+        .map_err(|e| HandlerError::OhttpKeyRejection(e.into()))?;
     drop(ohttp_locked);
     let mut cursor = std::io::Cursor::new(bhttp_req);
     let req =
@@ -206,6 +208,7 @@ async fn handle_v2(pool: DbPool, req: Request<Body>) -> Result<Response<Body>, H
 enum HandlerError {
     PayloadTooLarge,
     InternalServerError(anyhow::Error),
+    OhttpKeyRejection(anyhow::Error),
     BadRequest(anyhow::Error),
 }
 
@@ -217,6 +220,15 @@ impl HandlerError {
             HandlerError::InternalServerError(e) => {
                 error!("Internal server error: {}", e);
                 *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR
+            }
+            HandlerError::OhttpKeyRejection(e) => {
+                const OHTTP_KEY_REJECTION_RES_JSON: &str = r#"{"type":"https://iana.org/assignments/http-problem-types#ohttp-key", "title": "key identifier unknown"}"#;
+
+                error!("Bad request: Key configuration rejected: {}", e);
+                *res.status_mut() = StatusCode::BAD_REQUEST;
+                res.headers_mut()
+                    .insert("Content-Type", HeaderValue::from_static("application/problem+json"));
+                *res.body_mut() = Body::from(OHTTP_KEY_REJECTION_RES_JSON);
             }
             HandlerError::BadRequest(e) => {
                 error!("Bad request: {}", e);

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -198,6 +198,7 @@ mod integration {
         use super::*;
 
         const PJ_RELAY_URL: &str = "https://localhost:8088";
+        const BAD_OHTTP_CONFIG: &str = "AQAg3WpRjS0aqAxQUoLvpas2VYjT2oIg6-3XSiB-QiYI1BAABAABAAM";
         const OH_RELAY_URL: &str = "https://localhost:8088";
         const LOCAL_CERT_FILE: &str = "localhost.der";
 
@@ -223,6 +224,19 @@ mod integration {
 
             // **********************
             // Inside the Receiver:
+            // Try enroll with bad relay ohttp-config
+            let mut bad_enroller =
+                Enroller::from_relay_config(&PJ_RELAY_URL, &BAD_OHTTP_CONFIG, &OH_RELAY_URL);
+            let (req, _ctx) = bad_enroller.extract_req()?;
+            let res =
+                spawn_blocking(move || http_agent().post(req.url.as_str()).send_bytes(&req.body))
+                    .await?;
+            assert!(res.is_err());
+            assert!(
+                res.unwrap_err().into_response().unwrap().content_type()
+                    == "application/problem+json"
+            );
+
             // Enroll with relay
             let mut enroller =
                 Enroller::from_relay_config(&PJ_RELAY_URL, &ohttp_config, &OH_RELAY_URL);


### PR DESCRIPTION
Fix #152 

Signal OHTTP Key Configuration problem

Respond with `application/problem+json` when OHTTP decapsulation fails
according to draft-ietf-ohai-ohttp section 5.3. See:
https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#section-5.3

Ensure the error response is clearly understood in payjoin-cli