### PR TITLE
Fix #154 `process_response` return `ResponseError`

### DIFF
--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -208,12 +208,13 @@ impl App {
             .await??;
 
             println!("Sent fallback transaction");
-            let psbt = ctx.process_response(&mut response.into_reader())?;
-            if let Some(psbt) = psbt {
-                return Ok(psbt);
-            } else {
-                log::info!("No response yet for POST payjoin request, retrying some seconds");
-                std::thread::sleep(std::time::Duration::from_secs(5));
+            match ctx.process_response(&mut response.into_reader()) {
+                Ok(Some(psbt)) => return Ok(psbt),
+                Ok(None) => std::thread::sleep(std::time::Duration::from_secs(5)),
+                Err(re) => {
+                    println!("{}", re);
+                    log::debug!("{:?}", re);
+                }
             }
         }
     }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -687,7 +687,7 @@ impl ContextV2 {
     pub fn process_response(
         self,
         response: &mut impl std::io::Read,
-    ) -> Result<Option<Psbt>, ValidationError> {
+    ) -> Result<Option<Psbt>, ResponseError> {
         let mut res_buf = Vec::new();
         response.read_to_end(&mut res_buf).map_err(InternalValidationError::Io)?;
         let mut res_buf = crate::v2::ohttp_decapsulate(self.ohttp_res, &res_buf)


### PR DESCRIPTION
This returns an option so that empty OK responses from the directory can poll again for a response.

The main v1 integration test handling these errors already seems sufficient to me. Ideally these v1/v2 code paths merge once we get achieve the Payjoin V2 Beta milestone.