### PR TITLE
Fix unwraps in `send` mod

### DIFF
--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -178,6 +178,12 @@ pub(crate) enum InternalCreateRequestError {
     InputType(crate::input_type::InputTypeError),
     #[cfg(feature = "v2")]
     V2(crate::v2::Error),
+    #[cfg(feature = "v2")]
+    SubdirectoryNotBase64(bitcoin::base64::DecodeError),
+    #[cfg(feature = "v2")]
+    SubdirectoryInvalidPubkey(bitcoin::secp256k1::Error),
+    #[cfg(feature = "v2")]
+    MissingOhttpConfig,
 }
 
 impl fmt::Display for CreateRequestError {
@@ -202,6 +208,12 @@ impl fmt::Display for CreateRequestError {
             InputType(e) => write!(f, "invalid input type: {}", e),
             #[cfg(feature = "v2")]
             V2(e) => write!(f, "v2 error: {}", e),
+            #[cfg(feature = "v2")]
+            SubdirectoryNotBase64(e) => write!(f, "subdirectory is not valid base64 error: {}", e),
+            #[cfg(feature = "v2")]
+            SubdirectoryInvalidPubkey(e) => write!(f, "subdirectory does not represent a valid pubkey: {}", e),
+            #[cfg(feature = "v2")]
+            MissingOhttpConfig => write!(f, "no ohttp configuration with which to make a v2 request available"),
         }
     }
 }
@@ -228,6 +240,12 @@ impl std::error::Error for CreateRequestError {
             InputType(error) => Some(error),
             #[cfg(feature = "v2")]
             V2(error) => Some(error),
+            #[cfg(feature = "v2")]
+            SubdirectoryNotBase64(error) => Some(error),
+            #[cfg(feature = "v2")]
+            SubdirectoryInvalidPubkey(error) => Some(error),
+            #[cfg(feature = "v2")]
+            MissingOhttpConfig => None,
         }
     }
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -333,8 +333,9 @@ impl<'a> RequestBuilder<'a> {
         let zeroth_input = psbt.input_pairs().next().ok_or(InternalCreateRequestError::NoInputs)?;
 
         let sequence = zeroth_input.txin.sequence;
-        let txout = zeroth_input.previous_txout().expect("We already checked this above");
-        let input_type = InputType::from_spent_input(txout, zeroth_input.psbtin).unwrap();
+        let txout = zeroth_input.previous_txout().map_err(InternalCreateRequestError::PrevTxOut)?;
+        let input_type = InputType::from_spent_input(txout, zeroth_input.psbtin)
+            .map_err(InternalCreateRequestError::InputType)?;
 
         #[cfg(feature = "v2")]
         let e = {
@@ -435,9 +436,11 @@ impl RequestContext {
         log::debug!("rs_base64: {:?}", rs_base64);
         let b64_config =
             bitcoin::base64::Config::new(bitcoin::base64::CharacterSet::UrlSafe, false);
-        let rs = bitcoin::base64::decode_config(rs_base64, b64_config).unwrap();
+        let rs = bitcoin::base64::decode_config(rs_base64, b64_config)
+            .map_err(InternalCreateRequestError::SubdirectoryNotBase64)?;
         log::debug!("rs: {:?}", rs.len());
-        let rs = bitcoin::secp256k1::PublicKey::from_slice(&rs).unwrap();
+        let rs = bitcoin::secp256k1::PublicKey::from_slice(&rs)
+            .map_err(InternalCreateRequestError::SubdirectoryInvalidPubkey)?;
 
         let url = self.endpoint.clone();
         let body = serialize_v2_body(
@@ -449,7 +452,12 @@ impl RequestContext {
         let body = crate::v2::encrypt_message_a(body, self.e, rs)
             .map_err(InternalCreateRequestError::V2)?;
         let (body, ohttp_res) = crate::v2::ohttp_encapsulate(
-            &self.ohttp_config.as_ref().unwrap().encode().unwrap(),
+            &self
+                .ohttp_config
+                .as_ref()
+                .ok_or(InternalCreateRequestError::MissingOhttpConfig)?
+                .encode()
+                .map_err(|e| InternalCreateRequestError::V2(e.into()))?,
             "POST",
             url.as_str(),
             Some(&body),
@@ -486,10 +494,12 @@ impl Serialize for RequestContext {
         let mut state = serializer.serialize_struct("RequestContext", 8)?;
         state.serialize_field("psbt", &self.psbt.to_string())?;
         state.serialize_field("endpoint", &self.endpoint.as_str())?;
-        let ohttp_string = self
-            .ohttp_config
-            .as_ref()
-            .map_or("".to_string(), |config| bitcoin::base64::encode(config.encode().unwrap()));
+        let ohttp_string = self.ohttp_config.as_ref().map_or(Ok("".to_string()), |config| {
+            config
+                .encode()
+                .map_err(|e| serde::ser::Error::custom(format!("ohttp-keys encoding error: {}", e)))
+                .map(|encoded| bitcoin::base64::encode(encoded))
+        })?;
         state.serialize_field("ohttp_config", &ohttp_string)?;
         state.serialize_field("disable_output_substitution", &self.disable_output_substitution)?;
         state.serialize_field(


### PR DESCRIPTION
Unnecessary unwraps were left in the send mod when the big v2 changes were merged. This addresses those.

~This is urgent to release 0.13.0~