### PR TITLE
Fix `<CRATE>` specific release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -31,25 +31,25 @@ branch **development** version is *MAJOR.MINOR.0*.
 Change the `master` branch to the next MINOR+1 version:
 
 - [ ] Switch to the `master` branch.
-- [ ] Create a new PR branch called `bump-dev-MAJOR-MINOR+1`, eg. `bump-dev-0-22`.
-- [ ] Bump the `bump-dev-MAJOR-MINOR+1` branch to the next development MINOR+1 version.
+- [ ] Create a new PR branch called `bump-<CRATE>-MAJOR-MINOR+1`, eg. `bump-<CRATE>-0-22`.
+- [ ] Bump the `bump-<CRATE>-MAJOR-MINOR+1` branch to the next development MINOR+1 version.
   - Change the `Cargo.toml` version value to `MAJOR.MINOR+1.0`.
   - Update the `CHANGELOG.md` file.
-  - The commit message should be "Bump version to MAJOR.MINOR+1.0".
-- [ ] Create PR and merge the `bump-dev-MAJOR-MINOR+1` branch to `master`.
-  - Title PR "Bump version to MAJOR.MINOR+1.0".
+  - The commit message should be "Bump <CRATE> version to MAJOR.MINOR+1.0".
+- [ ] Create PR and merge the `bump-<CRATE>-MAJOR-MINOR+1` branch to `master`.
+  - Title PR "Bump <CRATE> version to MAJOR.MINOR+1.0".
 
 Create a new release branch and release candidate tag:
 
 - [ ] Double check that your local `master` is up-to-date with the upstream repo.
-- [ ] Create a new branch called `release/MAJOR.MINOR+1` from `master`.
-- [ ] Bump the `release/MAJOR.MINOR+1` branch to `MAJOR.MINOR+1.0-rc.1` version.
+- [ ] Create a new branch called `release/<CRATE>-MAJOR.MINOR+1` from `master`.
+- [ ] Bump the `release/<CRATE>-MAJOR.MINOR+1` branch to `MAJOR.MINOR+1.0-rc.1` version.
   - Change the `Cargo.toml` version value to `MAJOR.MINOR+1.0-rc.1`.
   - The commit message should be "Bump <CRATE> version to MAJOR.MINOR+1.0-rc.1".
 - [ ] Add a tag to the `HEAD` commit in the `release/<CRATE>-MAJOR.MINOR+1` branch.
   - The tag name should be `<CRATE>-MAJOR.MINOR+1.0-rc.1`
   - Use message "Release <CRATE>-MAJOR.MINOR+1.0 rc.1".
-  - Make sure the tag is signed, for extra safety use the explicit `--sign` flag.
+  - Make sure the tag is signed, for extra safety use the explicit `--sign` flag, e.g. `git tag -a payjoin-0.10.0-rc.1 -m "Release payjoin-0.10.0-rc.1" --sign`.
 - [ ] Push the `release/<CRATE>-MAJOR.MINOR` branch and new tag to the `payjoin/rust-payjoin` repo.
   - Use `git push --tags` option to push the new `<CRATE>-MAJOR.MINOR+1.0-rc.1` tag.
 
@@ -63,7 +63,7 @@ If any issues need to be fixed before the *MAJOR.MINOR+1.0* version is released:
   - The commit message should be "Bump version to MAJOR.MINOR+1.0-rc.x+1".
 - [ ] Add a tag to the `HEAD` commit in the `release/<CRATE>-MAJOR.MINOR+1` branch.
   - The tag name should be `<CRATE>-MAJOR.MINOR+1.0-rc.x+1`, where x is the current release candidate number.
-  - Use tag message "Release MAJOR.MINOR+1.0 rc.x+1".
+  - Use tag message "Release <CRATE> MAJOR.MINOR+1.0 rc.x+1".
   - Make sure the tag is signed, for extra safety use the explicit `--sign` flag.
 - [ ] Push the new tag to the `payjoin/rust-payjoin` repo.
   - Use `git push --tags` option to push the new `<CRATE>-MAJOR.MINOR+1.0-rc.x+1` tag.


### PR DESCRIPTION
Some of the issue template comments were missing the specifics we need since we release both `payjoin` and `payjoin-cli` crates from this repository.