### PR TITLE
Handle ResponseError version-unsupported variant supported field 

### DIFF
--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -123,11 +123,18 @@ impl fmt::Display for RequestError {
                 &format!("Content length too large: {}.", length),
             ),
             InternalRequestError::SenderParams(e) => match e {
-                super::optional_parameters::Error::UnknownVersion => write_error(
-                    f,
-                    "version-unsupported",
-                    "This version of payjoin is not supported.",
-                ),
+                super::optional_parameters::Error::UnknownVersion => {
+                    write!(
+                        f,
+                        r#"{{
+                            "errorCode": "version-unsupported",
+                            "supported": "{}",
+                            "message": "This version of payjoin is not supported."
+                        }}"#,
+                        serde_json::to_string(&super::optional_parameters::SUPPORTED_VERSIONS)
+                            .map_err(|_| fmt::Error)?
+                    )
+                }
                 _ => write_error(f, "sender-params-error", e),
             },
             InternalRequestError::InconsistentPsbt(e) =>

--- a/payjoin/src/receive/optional_parameters.rs
+++ b/payjoin/src/receive/optional_parameters.rs
@@ -4,6 +4,11 @@ use std::fmt;
 use bitcoin::FeeRate;
 use log::warn;
 
+#[cfg(feature = "v2")]
+pub(crate) const SUPPORTED_VERSIONS: [&str; 2] = ["1", "2"];
+#[cfg(not(feature = "v2"))]
+pub(crate) const SUPPORTED_VERSIONS: [&str; 1] = ["1"];
+
 #[derive(Debug, Clone)]
 pub(crate) struct Params {
     // version
@@ -42,7 +47,7 @@ impl Params {
         for (k, v) in pairs {
             match (k.borrow(), v.borrow()) {
                 ("v", v) =>
-                    if v != "1" {
+                    if !SUPPORTED_VERSIONS.contains(&v) {
                         return Err(Error::UnknownVersion);
                     },
                 ("additionalfeeoutputindex", index) =>

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -378,7 +378,7 @@ impl Display for WellKnownError {
         match self {
             Self::Unavailable(_) => write!(f, "The payjoin endpoint is not available for now."),
             Self::NotEnoughMoney(_) => write!(f, "The receiver added some inputs but could not bump the fee of the payjoin proposal."),
-            Self::VersionUnsupported(_, _) => write!(f, "This version of payjoin is not supported."),
+            Self::VersionUnsupported(_, v) => write!(f, "This version of payjoin is not supported. Use version {:?}.", v),
             Self::OriginalPsbtRejected(_) => write!(f, "The receiver rejected the original PSBT."),
         }
     }
@@ -392,14 +392,16 @@ mod tests {
 
     #[test]
     fn test_parse_json() {
-        let known_str_error =
-            r#"{"errorCode":"version-unsupported", "message":"custom message here"}"#;
+        let known_str_error = r#"{"errorCode":"version-unsupported", "message":"custom message here", "supported": [1, 2]}"#;
         let error = ResponseError::from_str(known_str_error);
         match error {
             ResponseError::WellKnown(e) => {
                 assert_eq!(e.error_code(), "version-unsupported");
                 assert_eq!(e.message(), "custom message here");
-                assert_eq!(e.to_string(), "This version of payjoin is not supported.");
+                assert_eq!(
+                    e.to_string(),
+                    "This version of payjoin is not supported. Use version [1, 2]."
+                );
             }
             _ => panic!("Expected WellKnown error"),
         };

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -1124,16 +1124,18 @@ fn serialize_url(
 
 #[cfg(test)]
 mod test {
-    const ORIGINAL_PSBT: &str = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+    use std::str::FromStr;
 
+    use bitcoin::psbt::Psbt;
+    use bitcoin::FeeRate;
+
+    use crate::psbt::PsbtExt;
+    use crate::send::error::{ResponseError, WellKnownError};
+
+    const ORIGINAL_PSBT: &str = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
     const PAYJOIN_PROPOSAL: &str = "cHNidP8BAJwCAAAAAo8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////jye60aAl3JgZdaIERvjkeh72VYZuTGH/ps2I4l0IO4MBAAAAAP7///8CJpW4BQAAAAAXqRQd6EnwadJ0FQ46/q6NcutaawlEMIcACT0AAAAAABepFHdAltvPSGdDwi9DR+m0af6+i2d6h9MAAAAAAQEgqBvXBQAAAAAXqRTeTh6QYcpZE1sDWtXm1HmQRUNU0IcBBBYAFMeKRXJTVYKNVlgHTdUmDV/LaYUwIgYDFZrAGqDVh1TEtNi300ntHt/PCzYrT2tVEGcjooWPhRYYSFzWUDEAAIABAACAAAAAgAEAAAAAAAAAAAEBIICEHgAAAAAAF6kUyPLL+cphRyyI5GTUazV0hF2R2NWHAQcXFgAUX4BmVeWSTJIEwtUb5TlPS/ntohABCGsCRzBEAiBnu3tA3yWlT0WBClsXXS9j69Bt+waCs9JcjWtNjtv7VgIge2VYAaBeLPDB6HGFlpqOENXMldsJezF9Gs5amvDQRDQBIQJl1jz1tBt8hNx2owTm+4Du4isx0pmdKNMNIjjaMHFfrQABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUIgICygvBWB5prpfx61y1HDAwo37kYP3YRJBvAjtunBAur3wYSFzWUDEAAIABAACAAAAAgAEAAAABAAAAAAA=";
 
     fn create_v1_context() -> super::ContextV1 {
-        use std::str::FromStr;
-
-        use bitcoin::psbt::Psbt;
-        use bitcoin::FeeRate;
-
         use crate::input_type::{InputType, SegWitV0Type};
         let original_psbt = Psbt::from_str(ORIGINAL_PSBT).unwrap();
         eprintln!("original: {:#?}", original_psbt);
@@ -1153,12 +1155,6 @@ mod test {
 
     #[test]
     fn official_vectors() {
-        use std::str::FromStr;
-
-        use bitcoin::psbt::Psbt;
-
-        use crate::psbt::PsbtExt;
-
         let original_psbt = Psbt::from_str(ORIGINAL_PSBT).unwrap();
         eprintln!("original: {:#?}", original_psbt);
         let ctx = create_v1_context();
@@ -1200,9 +1196,7 @@ mod test {
     }
 
     #[test]
-    fn handle_known_errors() {
-        use crate::send::error::{ResponseError, WellKnownError};
-
+    fn handle_json_errors() {
         let ctx = create_v1_context();
         let known_json_error = serde_json::json!({
             "errorCode": "version-unsupported",

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -45,52 +45,14 @@ mod integration {
             // **********************
             // Inside the Receiver:
             // this data would transit from one party to another over the network in production
-            let valid_response = handle_pj_request(req, headers, receiver);
+            let response = handle_pj_request(req, headers, receiver);
             // this response would be returned as http response to the sender
 
             // **********************
             // Inside the Sender:
-            //
-            // Validate sender can handle known errors correctly
-            let known_error = r#"{"errorCode":"version-unsupported", "message":"Debug Message"}"#;
-            let response_error =
-                ctx.clone().process_response(&mut known_error.as_bytes()).unwrap_err();
-            assert_eq!(
-                format!("{:#}", response_error),
-                "This version of payjoin is not supported."
-            );
-            assert_eq!(
-                format!("{:?}", response_error),
-                "Well known error: { \"errorCode\": \"version-unsupported\",\n                \"message\": \"Debug Message\" }"
-            );
-            match response_error {
-                payjoin::send::ResponseError::WellKnown(e) => {
-                    assert_eq!(e.clone().error_code(), "version-unsupported");
-                    assert_eq!(e.message(), "Debug Message");
-                }
-                _ => panic!("Unexpected error type"),
-            };
-            let response_error = ctx.clone().process_response(&mut known_error.as_bytes());
-            assert_eq!(
-                response_error.unwrap_err().to_string(),
-                "This version of payjoin is not supported.".to_string()
-            );
-            let unrecognized_error = r#"{"errorCode":"not-recognized", "message":"o"}"#;
-            let response_error = ctx.clone().process_response(&mut unrecognized_error.as_bytes());
-            assert_eq!(
-                response_error.unwrap_err().to_string(),
-                "The receiver sent an unrecognized error."
-            );
-            // we only accept json with errorCode
-            let validation_error = r#"{"error_code":"not-recognized", "message":"o"}"#;
-            let error = ctx.clone().process_response(&mut validation_error.as_bytes()).unwrap_err();
-            assert_eq!(
-                error.to_string(),
-                "The receiver sent an invalid response: couldn't decode as PSBT or JSON"
-            );
+
             // Sender checks, signs, finalizes, extracts, and broadcasts
-            let checked_payjoin_proposal_psbt =
-                ctx.process_response(&mut valid_response.as_bytes())?;
+            let checked_payjoin_proposal_psbt = ctx.process_response(&mut response.as_bytes())?;
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
             Ok(())


### PR DESCRIPTION
This parses supported versions into the WellKnownError struct and prints supported versions in the `Display` meaning templates. It deviates slightly from spec for more semantic clarity, and only parses `u64` versions so a malicious receiver can't put arbitrary messages in the printed `"supported"` json field.