### PR TITLE
Remove duplicate `serde_json` dep

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -35,7 +35,6 @@ serde_json = "1.0.108"
 [dev-dependencies]
 bitcoind = { version = "0.31.1", features = ["0_21_2"] }
 env_logger = "0.9.0"
-serde_json = "1.0.66"
 rustls = "0.21.9"
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["postgres"] }


### PR DESCRIPTION
serde_json was defined as both a dependency and dev_dependency in `payjoin`.