### PR TITLE
Depend on `bitcoin/serde` for `v2`

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["tests"]
 send = []
 receive = ["rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand-std", "chacha20poly1305", "ohttp", "bhttp", "serde"]
+v2 = ["bitcoin/rand-std", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde"]
 
 [dependencies]
 bitcoin = { version = "0.30.0", features = ["base64"] }


### PR DESCRIPTION
Some configurations were not building v2 without this addition.

Frankly, I'm not sure why they *were* building without it (edit: because v2 depends on Serialize/Deserialize impls for bitcoins structs)

got @BitcoinZavior's review in discord https://discord.com/channels/1120791584674435134/1166140004381245501/1194386924241162453