### PR TITLE
Implement clone for ffi

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -18,14 +18,14 @@ exclude = ["tests"]
 send = []
 receive = ["rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand-std", "chacha20poly1305", "ohttp", "bhttp", "serde"]
+v2 = ["bitcoin/rand-std", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde"]
 
 [dependencies]
 bitcoin = { version = "0.30.0", features = ["base64"] }
 bip21 = "0.3.1"
 chacha20poly1305 = { version = "0.10.1", optional = true }
 log = { version = "0.4.14"}
-ohttp = { version = "0.4.0", optional = true }
+ohttp = { version = "0.5.1", optional = true }
 bhttp = { version = "0.4.0", optional = true }
 rand = { version = "0.8.4", optional = true }
 serde = { version = "1.0.186", default-features = false, optional = true }

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -292,7 +292,7 @@ pub trait Headers {
 
 /// The sender's original PSBT and optional parameters
 ///
-/// This type is used to proces the request. It is returned by
+/// This type is used to process the request. It is returned by
 /// [`UncheckedProposal::from_request()`](crate::receive::UncheckedProposal::from_request()).
 ///
 /// If you are implementing an interactive payment processor, you should get extract the original
@@ -584,9 +584,9 @@ impl ProvisionalProposal {
     /// Return the input chosen that has been applied to the Proposal.
     ///
     /// Proper coin selection allows payjoin to resemble ordinary transactions.
-    /// To ensure the resemblence, a number of heuristics must be avoided.
+    /// To ensure the resemblance, a number of heuristics must be avoided.
     ///
-    /// UIH "Unecessary input heuristic" is one class of them to avoid. We define
+    /// UIH "Unnecessary input heuristic" is one class of them to avoid. We define
     /// UIH1 and UIH2 according to the BlockSci practice
     /// BlockSci UIH1 and UIH2:
     // if min(out) < min(in) then UIH1 else UIH2

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -405,6 +405,7 @@ impl UncheckedProposal {
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
 /// Call [`check_no_receiver_owned_inputs()`](struct.UncheckedProposal.html#method.check_no_receiver_owned_inputs) to proceed.
+#[derive(Clone)]
 pub struct MaybeInputsOwned {
     psbt: Psbt,
     params: Params,
@@ -448,6 +449,7 @@ impl MaybeInputsOwned {
 /// Typestate to validate that the Original PSBT has no mixed input types.
 ///
 /// Call [`check_no_mixed_input_types`](struct.UncheckedProposal.html#method.check_no_mixed_input_scripts) to proceed.
+#[derive(Clone)]
 pub struct MaybeMixedInputScripts {
     psbt: Psbt,
     params: Params,
@@ -500,6 +502,7 @@ impl MaybeMixedInputScripts {
 /// Typestate to validate that the Original PSBT has no inputs that have been seen before.
 ///
 /// Call [`check_no_inputs_seen`](struct.MaybeInputsSeen.html#method.check_no_inputs_seen_before) to proceed.
+#[derive(Clone)]
 pub struct MaybeInputsSeen {
     psbt: Psbt,
     params: Params,
@@ -533,6 +536,7 @@ impl MaybeInputsSeen {
 ///
 /// Only accept PSBTs that send us money.
 /// Identify those outputs with `identify_receiver_outputs()` to proceed
+#[derive(Clone)]
 pub struct OutputsUnknown {
     psbt: Psbt,
     params: Params,
@@ -571,7 +575,7 @@ impl OutputsUnknown {
 }
 
 /// A mutable checked proposal that the receiver may contribute inputs to to make a payjoin.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProvisionalProposal {
     original_psbt: Psbt,
     payjoin_psbt: Psbt,
@@ -822,6 +826,7 @@ impl ProvisionalProposal {
 }
 
 /// A mutable checked proposal that the receiver may contribute inputs to to make a payjoin.
+#[derive(Clone)]
 pub struct PayjoinProposal {
     payjoin_psbt: Psbt,
     params: Params,

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -318,7 +318,7 @@ impl Enrolled {
 
 /// The sender's original PSBT and optional parameters
 ///
-/// This type is used to proces the request. It is returned by
+/// This type is used to process the request. It is returned by
 /// [`UncheckedProposal::from_request()`](super::::UncheckedProposal::from_request()).
 ///
 /// If you are implementing an interactive payment processor, you should get extract the original
@@ -479,9 +479,9 @@ impl ProvisionalProposal {
     /// Return the input chosen that has been applied to the Proposal.
     ///
     /// Proper coin selection allows payjoin to resemble ordinary transactions.
-    /// To ensure the resemblence, a number of heuristics must be avoided.
+    /// To ensure the resemblance, a number of heuristics must be avoided.
     ///
-    /// UIH "Unecessary input heuristic" is one class of them to avoid. We define
+    /// UIH "Unnecessary input heuristic" is one class of them to avoid. We define
     /// UIH1 and UIH2 according to the BlockSci practice
     /// BlockSci UIH1 and UIH2:
     // if min(out) < min(in) then UIH1 else UIH2

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -24,7 +24,7 @@ pub struct Request {
     pub body: Vec<u8>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct V2Context {
     relay_url: url::Url,
     ohttp_config: Vec<u8>,
@@ -33,7 +33,7 @@ pub struct V2Context {
     e: Option<bitcoin::secp256k1::PublicKey>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Enroller {
     relay_url: url::Url,
     ohttp_config: Vec<u8>,
@@ -325,6 +325,7 @@ impl Enrolled {
 /// transaction with extract_tx_to_schedule_broadcast() and schedule, followed by checking
 /// that the transaction can be broadcast with check_broadcast_suitability. Otherwise it is safe to
 /// call assume_interactive_receive to proceed with validation.
+#[derive(Clone)]
 pub struct UncheckedProposal {
     inner: super::UncheckedProposal,
     context: V2Context,
@@ -387,6 +388,7 @@ impl UncheckedProposal {
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
 /// Call [`check_no_receiver_owned_inputs()`](struct.UncheckedProposal.html#method.check_no_receiver_owned_inputs) to proceed.
+#[derive(Clone)]
 pub struct MaybeInputsOwned {
     inner: super::MaybeInputsOwned,
     context: V2Context,
@@ -409,6 +411,7 @@ impl MaybeInputsOwned {
 /// Typestate to validate that the Original PSBT has no mixed input types.
 ///
 /// Call [`check_no_mixed_input_types`](struct.UncheckedProposal.html#method.check_no_mixed_input_scripts) to proceed.
+#[derive(Clone)]
 pub struct MaybeMixedInputScripts {
     inner: super::MaybeMixedInputScripts,
     context: V2Context,
@@ -429,6 +432,7 @@ impl MaybeMixedInputScripts {
 /// Typestate to validate that the Original PSBT has no inputs that have been seen before.
 ///
 /// Call [`check_no_inputs_seen`](struct.MaybeInputsSeen.html#method.check_no_inputs_seen_before) to proceed.
+#[derive(Clone)]
 pub struct MaybeInputsSeen {
     inner: super::MaybeInputsSeen,
     context: V2Context,
@@ -451,6 +455,7 @@ impl MaybeInputsSeen {
 ///
 /// Only accept PSBTs that send us money.
 /// Identify those outputs with `identify_receiver_outputs()` to proceed
+#[derive(Clone)]
 pub struct OutputsUnknown {
     inner: super::OutputsUnknown,
     context: V2Context,
@@ -468,7 +473,7 @@ impl OutputsUnknown {
 }
 
 /// A mutable checked proposal that the receiver may contribute inputs to to make a payjoin.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProvisionalProposal {
     pub inner: super::ProvisionalProposal,
     context: V2Context,
@@ -517,6 +522,7 @@ impl ProvisionalProposal {
 }
 
 /// A mutable checked proposal that the receiver may contribute inputs to to make a payjoin.
+#[derive(Clone)]
 pub struct PayjoinProposal {
     inner: super::PayjoinProposal,
     context: V2Context,

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -362,6 +362,7 @@ impl<'a> RequestBuilder<'a> {
     }
 }
 
+#[derive(Clone)]
 pub struct RequestContext {
     psbt: Psbt,
     endpoint: Url,

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -164,6 +164,7 @@ mod error;
 
 type InternalResult<T> = Result<T, InternalValidationError>;
 
+#[derive(Clone)]
 pub struct RequestBuilder<'a> {
     psbt: Psbt,
     uri: PjUri<'a>,

--- a/payjoin/src/uri.rs
+++ b/payjoin/src/uri.rs
@@ -5,6 +5,7 @@ use bitcoin::address::{Error, NetworkChecked, NetworkUnchecked};
 use bitcoin::Network;
 use url::Url;
 
+#[derive(Clone)]
 pub enum Payjoin {
     Supported(PayjoinParams),
     V2Only(PayjoinParams),
@@ -21,6 +22,7 @@ impl Payjoin {
     }
 }
 
+#[derive(Clone)]
 pub struct PayjoinParams {
     pub(crate) _endpoint: Url,
     pub(crate) disable_output_substitution: bool,


### PR DESCRIPTION
Resolves https://github.com/payjoin/rust-payjoin/issues/164

#[derive(Clone)] attribute for the following structs implemented:

Configuration
PrjUriRequest
Context
MaybeInputsOwned
MaybeMixedInputScripts
MaybeInputsSeen
OutputsUnknown
ProvisionalProposal
PayjoinProposal


Adding Clone to the structs will make the FFI code simpler, ref: https://github.com/LtbLightning/payjoin-ffi. Right now, most structs have just one function. When you call this function, it takes over the memory because it uses self and not &self. This works fine in Rust, but it's a problem for FFI where we need to use &self.

Without Clone, we can't call payjoin functions directly. We've been using mutexes and extra helper functions to get around this. If we implement Clone, we can copy structs when we need to, making the FFI code cleaner and easier to work with. This change will help avoid those extra workarounds thereby making the code easier to maintain and enhance.