### PR TITLE
Build `PjUri` with `PjUriBuilder`

### DIFF
--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -83,7 +83,7 @@ mod e2e {
                 .await
                 .expect("Failed to write to stdout");
 
-            if line.starts_with("BITCOIN") {
+            if line.to_ascii_uppercase().starts_with("BITCOIN") {
                 bip21 = line;
                 break;
             }

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -42,4 +42,5 @@ pub(crate) mod weight;
 
 #[cfg(feature = "base64")]
 pub use bitcoin::base64;
-pub use uri::{PjParseError, PjUri, Uri};
+pub use uri::{PjParseError, PjUri, PjUriBuilder, Uri};
+pub use url::Url;

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -43,7 +43,7 @@ use crate::input_type::InputType;
 use crate::psbt::PsbtExt;
 use crate::uri::UriExt;
 use crate::weight::{varint_size, ComputeWeight};
-use crate::PjUri;
+use crate::{PjUri, Uri};
 
 // See usize casts
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
@@ -71,7 +71,7 @@ impl<'a> RequestBuilder<'a> {
     /// to keep them separated.
     pub fn from_psbt_and_uri(
         psbt: Psbt,
-        uri: crate::Uri<'a, NetworkChecked>,
+        uri: Uri<'a, NetworkChecked>,
     ) -> Result<Self, CreateRequestError> {
         let uri = uri
             .check_pj_supported()

--- a/payjoin/src/uri.rs
+++ b/payjoin/src/uri.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 
 use bitcoin::address::{Error, NetworkChecked, NetworkUnchecked};
-use bitcoin::Network;
+use bitcoin::{Address, Amount, Network};
 use url::Url;
 
 #[derive(Clone)]
@@ -93,6 +93,93 @@ impl<'a> UriExt<'a> for Uri<'a, NetworkChecked> {
                 Err(uri)
             }
         }
+    }
+}
+
+/// Build a valid `PjUri`.
+///
+/// Payjoin receiver can use this builder to create a payjoin
+/// uri to send to the sender.
+pub struct PjUriBuilder {
+    /// Address you want to receive funds to.
+    address: Address,
+    /// Amount you want to receive.
+    ///
+    /// If `None` the amount will be left unspecified.
+    amount: Option<Amount>,
+    /// Message
+    message: Option<String>,
+    /// Label
+    label: Option<String>,
+    /// Payjoin endpoint url listening for payjoin requests.
+    pj: Url,
+    /// Whether or not payjoin output substitution is allowed
+    pjos: bool,
+    #[cfg(feature = "v2")]
+    /// Config for ohttp.
+    ///
+    /// Required only for v2 payjoin.
+    ohttp: Option<ohttp::KeyConfig>,
+}
+
+impl PjUriBuilder {
+    /// Create a new `PjUriBuilder` with required parameters.
+    pub fn new(
+        address: Address,
+        pj: Url,
+        #[cfg(feature = "v2")] ohttp_config: Option<ohttp::KeyConfig>,
+    ) -> Self {
+        Self {
+            address,
+            amount: None,
+            message: None,
+            label: None,
+            pj,
+            pjos: false,
+            #[cfg(feature = "v2")]
+            ohttp: ohttp_config,
+        }
+    }
+    /// Set the amount you want to receive.
+    pub fn amount(mut self, amount: Amount) -> Self {
+        self.amount = Some(amount);
+        self
+    }
+
+    /// Set the message.
+    pub fn message(mut self, message: String) -> Self {
+        self.message = Some(message);
+        self
+    }
+
+    /// Set the label.
+    pub fn label(mut self, label: String) -> Self {
+        self.label = Some(label);
+        self
+    }
+
+    /// Set whether or not payjoin output substitution is allowed.
+    pub fn pjos(mut self, pjos: bool) -> Self {
+        self.pjos = pjos;
+        self
+    }
+
+    /// Build payjoin URI.
+    ///
+    /// Constructs a `bip21::Uri` with PayjoinParams from the
+    /// parameters set in the builder.
+    pub fn build<'a>(self) -> PjUri<'a> {
+        let extras = PayjoinExtras {
+            endpoint: self.pj,
+            disable_output_substitution: self.pjos,
+            #[cfg(feature = "v2")]
+            ohttp_config: self.ohttp,
+        };
+        let mut pj_uri = bip21::Uri::with_extras(self.address, extras);
+        pj_uri.amount = self.amount;
+        pj_uri.label = self.label.map(Into::into);
+        pj_uri.message = self.message.map(Into::into);
+        pj_uri
     }
 }
 
@@ -270,7 +357,7 @@ enum InternalPjParseError {
 mod tests {
     use std::convert::TryFrom;
 
-    use crate::Uri;
+    use super::*;
 
     #[test]
     fn test_short() {
@@ -332,5 +419,44 @@ mod tests {
             .unwrap()
             .extras
             .pj_is_supported());
+    }
+
+    #[test]
+    fn test_builder() {
+        use std::str::FromStr;
+
+        use url::Url;
+        use PjUriBuilder;
+        let https = "https://example.com/";
+        let onion = "http://vjdpwgybvubne5hda6v4c5iaeeevhge6jvo3w2cl6eocbwwvwxp7b7qd.onion/";
+        let base58 = "12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX";
+        let bech32_upper = "TB1Q6D3A2W975YNY0ASUVD9A67NER4NKS58FF0Q8G4";
+        let bech32_lower = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+
+        for address in vec![base58, bech32_upper, bech32_lower] {
+            for pj in vec![https, onion] {
+                let address = bitcoin::Address::from_str(address).unwrap().assume_checked();
+                let amount = bitcoin::Amount::ONE_BTC;
+                let builder = PjUriBuilder::new(
+                    address.clone(),
+                    Url::parse(pj).unwrap(),
+                    #[cfg(feature = "v2")]
+                    None,
+                )
+                .amount(amount)
+                .message("message".to_string())
+                .label("label".to_string())
+                .pjos(true);
+                let uri = builder.build();
+                assert_eq!(uri.address, address);
+                assert_eq!(uri.amount.unwrap(), bitcoin::Amount::ONE_BTC);
+                let label: Cow<'_, str> = uri.label.clone().unwrap().try_into().unwrap();
+                let message: Cow<'_, str> = uri.message.clone().unwrap().try_into().unwrap();
+                assert_eq!(label, "label");
+                assert_eq!(message, "message");
+                assert_eq!(uri.extras.disable_output_substitution, true);
+                assert_eq!(uri.extras.endpoint.to_string(), pj.to_string());
+            }
+        }
     }
 }


### PR DESCRIPTION
resolves #62 

@jbesraa I was having some difficulty reviewing #148 because we began to make changes outside of the scope of the issue and ultimately we hadn't yet arrived at the builder pattern. I hated to see that issue blocked for so long so I reworked it into a shape I would want to review.

I took that PR as a starting point and stripped it down to be a minimal change to just complete the issue it sets out to resolve. Should we want to restructure the `Uri`/`PjUri` pair, or change the structure of PjUri entirely rather than use a bip21 alias let's consider the merits of those changes in a targeted issues.

Please let me know what you think of the changes these four commits make.

