### PR TITLE
WIP: Upgrade bitcoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.10.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
 name = "bhttp"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,10 +247,8 @@ dependencies = [
 [[package]]
 name = "bip21"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9532c632b068e45a478f5e309126b6e2ec1dbf0bbd327b73836f33d9a43ede"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.31.1",
  "percent-encoding-rfc3986",
 ]
 
@@ -255,11 +259,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
  "base64 0.13.1",
- "bech32",
+ "bech32 0.9.1",
  "bitcoin-private",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd00f3c09b5f21fb357abe32d29946eb8bb7a0862bae62c0b5e4a692acbbe73c"
+dependencies = [
+ "base64 0.21.7",
+ "bech32 0.10.0-beta",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1 0.28.2",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
  "serde",
 ]
 
@@ -276,18 +304,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
  "serde",
 ]
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6c0ee9354e3dac217db4cb1dd31941073a87fe53c86bcf3eb2b8bc97f00a08"
+checksum = "8eb70725a621848c83b3809913d5314c0d20ca84877d99dd909504b564edab00"
 dependencies = [
- "bitcoin-private",
  "bitcoincore-rpc-json",
- "jsonrpc 0.14.1",
+ "jsonrpc",
  "log",
  "serde",
  "serde_json",
@@ -295,25 +332,24 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30ce6f40fb0a2e8d98522796219282504b7a4b14e2b4c26139a7bea6aec6586"
+checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
 dependencies = [
- "bitcoin",
- "bitcoin-private",
+ "bitcoin 0.31.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "bitcoind"
-version = "0.31.1"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395fe8137d13c6859fa68421779cd5a4db8cd7b0ef3122537e56f7a49a0598a9"
+checksum = "f50548a349632abb9a2007d431a302bf0401a786c91f809ff31765fba87e2397"
 dependencies = [
  "anyhow",
- "bitcoin_hashes",
- "core-rpc",
+ "bitcoin_hashes 0.13.0",
+ "bitcoincore-rpc",
  "flate2",
  "log",
  "minreq",
@@ -411,6 +447,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -554,6 +591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,32 +611,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core-rpc"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d77079e1b71c2778d6e1daf191adadcd4ff5ec3ccad8298a79061d865b235b"
-dependencies = [
- "bitcoin-private",
- "core-rpc-json",
- "jsonrpc 0.13.0",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "core-rpc-json"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581898ed9a83f31c64731b1d8ca2dfffcfec14edf1635afacd5234cddbde3a41"
-dependencies = [
- "bitcoin",
- "bitcoin-private",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1025,7 +1042,7 @@ checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1130,6 +1147,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "hex_lit"
@@ -1386,6 +1409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,17 +1435,6 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
-]
-
-[[package]]
-name = "jsonrpc"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8d6b3f301ba426b30feca834a2a18d48d5b54e5065496b5c1b05537bee3639"
-dependencies = [
- "base64 0.13.1",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1547,7 +1568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -1759,6 +1780,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,7 +1808,7 @@ version = "0.13.0"
 dependencies = [
  "bhttp 0.5.1",
  "bip21",
- "bitcoin",
+ "bitcoin 0.31.1",
  "bitcoind",
  "chacha20poly1305 0.10.1",
  "env_logger",
@@ -1822,7 +1854,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bhttp 0.4.0",
- "bitcoin",
+ "bitcoin 0.30.2",
  "hyper",
  "hyper-rustls 0.24.2",
  "ohttp 0.4.0",
@@ -1832,6 +1864,18 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "password-hash",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2093,7 +2137,7 @@ checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
  "pem",
  "ring 0.16.20",
- "time 0.3.31",
+ "time",
  "yasna",
 ]
 
@@ -2373,9 +2417,19 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
  "rand",
- "secp256k1-sys",
+ "secp256k1-sys 0.9.2",
  "serde",
 ]
 
@@ -2384,6 +2438,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -2927,17 +2990,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
@@ -3270,12 +3322,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -3577,7 +3623,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.31",
+ "time",
 ]
 
 [[package]]
@@ -3622,14 +3668,49 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
+ "aes 0.8.3",
  "byteorder",
  "bzip2",
+ "constant_time_eq",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror",
- "time 0.1.45",
+ "hmac 0.12.1",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ resolver = "2"
 
 [patch.crates-io.payjoin]
 path = "payjoin"
+
+[patch.crates-io.bip21]
+path = "../../bip21/master"

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -25,7 +25,7 @@ v2 = ["payjoin/v2"]
 [dependencies]
 anyhow = "1.0.70"
 bip21 = "0.3.1"
-bitcoincore-rpc = "0.17.0"
+bitcoincore-rpc = "0.18.0"
 clap = { version = "3.2.22", features = ["derive"] }
 config = "0.13.3"
 env_logger = "0.9.0"
@@ -41,5 +41,5 @@ ureq = "2.9.4"
 url = "2.3.1"
 
 [dev-dependencies]
-bitcoind = { version = "0.31.1", features = ["0_21_2"] }
+bitcoind = { version = "0.34.1", features = ["0_21_2"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -21,7 +21,7 @@ base64 = ["bitcoin/base64"]
 v2 = ["bitcoin/rand-std", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde"]
 
 [dependencies]
-bitcoin = { version = "0.30.0", features = ["base64"] }
+bitcoin = { version = "0.31.1", features = ["base64"] }
 bip21 = "0.3.1"
 chacha20poly1305 = { version = "0.10.1", optional = true }
 log = { version = "0.4.14"}
@@ -33,7 +33,7 @@ url = "2.2.2"
 serde_json = "1.0.108"
 
 [dev-dependencies]
-bitcoind = { version = "0.31.1", features = ["0_21_2"] }
+bitcoind = { version = "0.34.1", features = ["0_21_2"] }
 env_logger = "0.9.0"
 rustls = "0.22.2"
 testcontainers = "0.15.0"

--- a/payjoin/src/input_type.rs
+++ b/payjoin/src/input_type.rs
@@ -214,7 +214,7 @@ impl std::error::Error for InputTypeError {}
 mod tests {
     use bitcoin::psbt::Input as PsbtInput;
     use bitcoin::script::PushBytesBuf;
-    use bitcoin::{PublicKey, ScriptBuf};
+    use bitcoin::{Amount, PublicKey, ScriptBuf};
 
     use super::*;
 
@@ -228,13 +228,13 @@ mod tests {
 
     #[test]
     fn test_p2pk() {
-        let input_type = InputType::from_spent_input(&TxOut { script_pubkey: ScriptBuf::new_p2pk(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap()), value: 42, }, &Default::default()).unwrap();
+        let input_type = InputType::from_spent_input(&TxOut { script_pubkey: ScriptBuf::new_p2pk(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap()), value: Amount::from_sat(42), }, &Default::default()).unwrap();
         assert_eq!(input_type, InputType::P2Pk);
     }
 
     #[test]
     fn test_p2pkh() {
-        let input_type = InputType::from_spent_input(&TxOut { script_pubkey: ScriptBuf::new_p2pkh(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap().pubkey_hash()), value: 42, }, &Default::default()).unwrap();
+        let input_type = InputType::from_spent_input(&TxOut { script_pubkey: ScriptBuf::new_p2pkh(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap().pubkey_hash()), value: Amount::from_sat(42), }, &Default::default()).unwrap();
         assert_eq!(input_type, InputType::P2Pkh);
     }
 
@@ -242,7 +242,7 @@ mod tests {
     fn test_p2sh() {
         let script = ScriptBuf::new_op_return(&[42]);
         let input_type = InputType::from_spent_input(
-            &TxOut { script_pubkey: ScriptBuf::new_p2sh(&script.script_hash()), value: 42 },
+            &TxOut { script_pubkey: ScriptBuf::new_p2sh(&script.script_hash()), value: Amount::from_sat(42) },
             &PsbtInput { final_script_sig: Some(script), ..Default::default() },
         )
         .unwrap();
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_p2wpkh() {
-        let input_type = InputType::from_spent_input(&TxOut { script_pubkey: ScriptBuf::new_v0_p2wpkh(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap().wpubkey_hash().expect("WTF, the key is uncompressed")), value: 42, }, &Default::default()).unwrap();
+        let input_type = InputType::from_spent_input(&TxOut { script_pubkey: ScriptBuf::new_p2wpkh(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap().wpubkey_hash().expect("WTF, the key is uncompressed")), value: Amount::from_sat(42), }, &Default::default()).unwrap();
         assert_eq!(input_type, InputType::SegWitV0 { ty: SegWitV0Type::Pubkey, nested: false });
     }
 
@@ -259,7 +259,7 @@ mod tests {
     fn test_p2wsh() {
         let script = ScriptBuf::new_op_return(&[42]);
         let input_type = InputType::from_spent_input(
-            &TxOut { script_pubkey: ScriptBuf::new_v0_p2wsh(&script.wscript_hash()), value: 42 },
+            &TxOut { script_pubkey: ScriptBuf::new_p2wsh(&script.wscript_hash()), value: Amount::from_sat(42) },
             &PsbtInput { final_script_sig: Some(script), ..Default::default() },
         )
         .unwrap();
@@ -268,12 +268,12 @@ mod tests {
 
     #[test]
     fn test_p2sh_p2wpkh() {
-        let segwit_script = ScriptBuf::new_v0_p2wpkh(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap().wpubkey_hash().expect("WTF, the key is uncompressed"));
+        let segwit_script = ScriptBuf::new_p2wpkh(&PublicKey::from_slice(b"\x02\x50\x86\x3A\xD6\x4A\x87\xAE\x8A\x2F\xE8\x3C\x1A\xF1\xA8\x40\x3C\xB5\x3F\x53\xE4\x86\xD8\x51\x1D\xAD\x8A\x04\x88\x7E\x5B\x23\x52").unwrap().wpubkey_hash().expect("WTF, the key is uncompressed"));
         let segwit_script_hash = segwit_script.script_hash();
         let script_sig = wrap_p2sh_script(&segwit_script);
 
         let input_type = InputType::from_spent_input(
-            &TxOut { script_pubkey: ScriptBuf::new_p2sh(&segwit_script_hash), value: 42 },
+            &TxOut { script_pubkey: ScriptBuf::new_p2sh(&segwit_script_hash), value: Amount::from_sat(42) },
             &PsbtInput { final_script_sig: Some(script_sig), ..Default::default() },
         )
         .unwrap();
@@ -283,12 +283,12 @@ mod tests {
     #[test]
     fn test_p2sh_p2wsh() {
         let script = ScriptBuf::new_op_return(&[42]);
-        let segwit_script = ScriptBuf::new_v0_p2wsh(&script.wscript_hash());
+        let segwit_script = ScriptBuf::new_p2wsh(&script.wscript_hash());
         let segwit_script_hash = segwit_script.script_hash();
         let script_sig = wrap_p2sh_script(&segwit_script);
 
         let input_type = InputType::from_spent_input(
-            &TxOut { script_pubkey: ScriptBuf::new_p2sh(&segwit_script_hash), value: 42 },
+            &TxOut { script_pubkey: ScriptBuf::new_p2sh(&segwit_script_hash), value: Amount::from_sat(42) },
             &PsbtInput { final_script_sig: Some(script_sig), ..Default::default() },
         )
         .unwrap();

--- a/payjoin/src/psbt.rs
+++ b/payjoin/src/psbt.rs
@@ -30,7 +30,7 @@ pub(crate) trait PsbtExt: Sized {
     fn outputs_mut(&mut self) -> &mut [psbt::Output];
     fn xpub_mut(
         &mut self,
-    ) -> &mut BTreeMap<bip32::ExtendedPubKey, (bip32::Fingerprint, bip32::DerivationPath)>;
+    ) -> &mut BTreeMap<bip32::Xpub, (bip32::Fingerprint, bip32::DerivationPath)>;
     fn proprietary_mut(&mut self) -> &mut BTreeMap<psbt::raw::ProprietaryKey, Vec<u8>>;
     fn unknown_mut(&mut self) -> &mut BTreeMap<psbt::raw::Key, Vec<u8>>;
     fn input_pairs(&self) -> Box<dyn Iterator<Item = InputPair<'_>> + '_>;
@@ -48,7 +48,7 @@ impl PsbtExt for Psbt {
 
     fn xpub_mut(
         &mut self,
-    ) -> &mut BTreeMap<bip32::ExtendedPubKey, (bip32::Fingerprint, bip32::DerivationPath)> {
+    ) -> &mut BTreeMap<bip32::Xpub, (bip32::Fingerprint, bip32::DerivationPath)> {
         &mut self.xpub
     }
 
@@ -96,11 +96,11 @@ impl PsbtExt for Psbt {
         let mut total_inputs = bitcoin::Amount::ZERO;
 
         for output in &self.unsigned_tx.output {
-            total_outputs += bitcoin::Amount::from_sat(output.value);
+            total_outputs += output.value;
         }
 
         for input in self.input_pairs() {
-            total_inputs += bitcoin::Amount::from_sat(input.previous_txout().unwrap().value);
+            total_inputs += input.previous_txout().unwrap().value;
         }
         log::debug!("  total_inputs:  {}", total_inputs);
         log::debug!("- total_outputs: {}", total_outputs);


### PR DESCRIPTION
Here's a rough look at whats needed to upgrade to the latest `rust-bitcoin v0.31.1`.

Note, all the base64 stuff needs checking, I don't know what ohttp is, I just swung my axe around wildly.

I used a local version of `bip21`, it has the bitcoin upgrade already on master.

Fix: #124