### PR TITLE
Parse AppConfig types when they're passed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -38,7 +38,7 @@ rustls = { version = "0.22.2", optional = true }
 serde = { version = "1.0.160", features = ["derive"] }
 tokio = { version = "1.12.0", features = ["full"] }
 ureq = "2.9.4"
-url = "2.3.1"
+url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
 bitcoind = { version = "0.31.1", features = ["0_21_2"] }

--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -60,11 +60,11 @@ impl App {
     pub fn bitcoind(&self) -> Result<bitcoincore_rpc::Client> {
         match &self.config.bitcoind_cookie {
             Some(cookie) => bitcoincore_rpc::Client::new(
-                &self.config.bitcoind_rpchost,
+                self.config.bitcoind_rpchost.as_str(),
                 bitcoincore_rpc::Auth::CookieFile(cookie.into()),
             ),
             None => bitcoincore_rpc::Client::new(
-                &self.config.bitcoind_rpchost,
+                self.config.bitcoind_rpchost.as_str(),
                 bitcoincore_rpc::Auth::UserPass(
                     self.config.bitcoind_rpcuser.clone(),
                     self.config.bitcoind_rpcpass.clone(),
@@ -128,9 +128,9 @@ impl App {
 
         let mut enrolled = if !is_retry {
             let mut enroller = Enroller::from_relay_config(
-                &self.config.pj_endpoint,
+                self.config.pj_endpoint.clone(),
                 &self.config.ohttp_config,
-                &self.config.ohttp_proxy,
+                self.config.ohttp_proxy.clone(),
             );
             let (req, ctx) = enroller.extract_req()?;
             log::debug!("Enrolling receiver");
@@ -197,7 +197,7 @@ impl App {
     #[cfg(feature = "v2")]
     async fn long_poll_post(&self, req_ctx: &mut payjoin::send::RequestContext) -> Result<Psbt> {
         loop {
-            let (req, ctx) = req_ctx.extract_v2(&self.config.ohttp_proxy)?;
+            let (req, ctx) = req_ctx.extract_v2(self.config.ohttp_proxy.clone())?;
             println!("Sending fallback request to {}", &req.url);
             let http = http_agent()?;
             let response = spawn_blocking(move || {

--- a/payjoin-cli/src/app.rs
+++ b/payjoin-cli/src/app.rs
@@ -9,8 +9,6 @@ use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::bitcoin::Amount;
 use bitcoincore_rpc::jsonrpc::serde_json;
 use bitcoincore_rpc::RpcApi;
-use clap::ArgMatches;
-use config::{Config, File, FileFormat};
 #[cfg(not(feature = "v2"))]
 use hyper::service::{make_service_fn, service_fn};
 #[cfg(not(feature = "v2"))]
@@ -29,6 +27,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex as AsyncMutex;
 #[cfg(feature = "v2")]
 use tokio::task::spawn_blocking;
+
+use crate::AppConfig;
 
 #[cfg(feature = "danger-local-https")]
 const LOCAL_CERT_FILE: &str = "localhost.der";
@@ -771,85 +771,6 @@ impl OutPointSet {
     fn new() -> Self { Self(HashSet::new()) }
 
     fn insert(&mut self, input: bitcoin::OutPoint) -> bool { self.0.insert(input) }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct AppConfig {
-    pub bitcoind_rpchost: String,
-    pub bitcoind_cookie: Option<String>,
-    pub bitcoind_rpcuser: String,
-    pub bitcoind_rpcpass: String,
-    #[cfg(feature = "v2")]
-    pub ohttp_config: String,
-    #[cfg(feature = "v2")]
-    pub ohttp_proxy: String,
-
-    // receive-only
-    pub pj_host: String,
-    pub pj_endpoint: String,
-    pub sub_only: bool,
-}
-
-impl AppConfig {
-    pub(crate) fn new(matches: &ArgMatches) -> Result<Self> {
-        let builder = Config::builder()
-            .set_default("bitcoind_rpchost", "http://localhost:18443")?
-            .set_override_option(
-                "bitcoind_rpchost",
-                matches.get_one::<String>("rpchost").map(|s| s.as_str()),
-            )?
-            .set_default("bitcoind_cookie", None::<String>)?
-            .set_override_option(
-                "bitcoind_cookie",
-                matches.get_one::<String>("cookie_file").map(|s| s.as_str()),
-            )?
-            .set_default("bitcoind_rpcuser", "bitcoin")?
-            .set_override_option(
-                "bitcoind_rpcuser",
-                matches.get_one::<String>("rpcuser").map(|s| s.as_str()),
-            )?
-            .set_default("bitcoind_rpcpass", "")?
-            .set_override_option(
-                "bitcoind_rpcpass",
-                matches.get_one::<String>("rpcpass").map(|s| s.as_str()),
-            )?
-            // Subcommand defaults without which file serialization fails.
-            .set_default("pj_host", "0.0.0.0:3000")?
-            .set_default("pj_endpoint", "https://localhost:3000")?
-            .set_default("sub_only", false)?
-            .add_source(File::new("config.toml", FileFormat::Toml).required(false));
-
-        #[cfg(feature = "v2")]
-        let builder = builder
-            .set_default("ohttp_config", "")?
-            .set_override_option(
-                "ohttp_config",
-                matches.get_one::<String>("ohttp_config").map(|s| s.as_str()),
-            )?
-            .set_default("ohttp_proxy", "")?
-            .set_override_option(
-                "ohttp_proxy",
-                matches.get_one::<String>("ohttp_proxy").map(|s| s.as_str()),
-            )?;
-
-        let builder = match matches.subcommand() {
-            Some(("send", _)) => builder,
-            Some(("receive", matches)) => builder
-                .set_override_option(
-                    "pj_host",
-                    matches.get_one::<String>("port").map(|port| format!("0.0.0.0:{}", port)),
-                )?
-                .set_override_option(
-                    "pj_endpoint",
-                    matches.get_one::<String>("endpoint").map(|s| s.as_str()),
-                )?
-                .set_override_option("sub_only", matches.get_one::<bool>("sub_only").copied())?,
-            _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
-        };
-        let app_conf = builder.build()?;
-        log::debug!("App config: {:?}", app_conf);
-        app_conf.try_deserialize().context("Failed to deserialize config")
-    }
 }
 
 fn try_contributing_inputs(

--- a/payjoin-cli/src/appconf.rs
+++ b/payjoin-cli/src/appconf.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::ArgMatches;
@@ -9,7 +10,7 @@ use url::Url;
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct AppConfig {
     pub bitcoind_rpchost: Url,
-    pub bitcoind_cookie: Option<String>,
+    pub bitcoind_cookie: Option<PathBuf>,
     pub bitcoind_rpcuser: String,
     pub bitcoind_rpcpass: String,
     #[cfg(feature = "v2")]

--- a/payjoin-cli/src/appconf.rs
+++ b/payjoin-cli/src/appconf.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use anyhow::Result;
 use clap::ArgMatches;
 use config::{Config, File, FileFormat};
@@ -16,7 +18,7 @@ pub(crate) struct AppConfig {
     pub ohttp_proxy: Url,
 
     // receive-only
-    pub pj_host: String,
+    pub pj_host: SocketAddr,
     pub pj_endpoint: Url,
     pub sub_only: bool,
 }

--- a/payjoin-cli/src/appconf.rs
+++ b/payjoin-cli/src/appconf.rs
@@ -1,0 +1,83 @@
+use anyhow::{Context, Result};
+use clap::ArgMatches;
+use config::{Config, File, FileFormat};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AppConfig {
+    pub bitcoind_rpchost: String,
+    pub bitcoind_cookie: Option<String>,
+    pub bitcoind_rpcuser: String,
+    pub bitcoind_rpcpass: String,
+    #[cfg(feature = "v2")]
+    pub ohttp_config: String,
+    #[cfg(feature = "v2")]
+    pub ohttp_proxy: String,
+
+    // receive-only
+    pub pj_host: String,
+    pub pj_endpoint: String,
+    pub sub_only: bool,
+}
+
+impl AppConfig {
+    pub(crate) fn new(matches: &ArgMatches) -> Result<Self> {
+        let builder = Config::builder()
+            .set_default("bitcoind_rpchost", "http://localhost:18443")?
+            .set_override_option(
+                "bitcoind_rpchost",
+                matches.get_one::<String>("rpchost").map(|s| s.as_str()),
+            )?
+            .set_default("bitcoind_cookie", None::<String>)?
+            .set_override_option(
+                "bitcoind_cookie",
+                matches.get_one::<String>("cookie_file").map(|s| s.as_str()),
+            )?
+            .set_default("bitcoind_rpcuser", "bitcoin")?
+            .set_override_option(
+                "bitcoind_rpcuser",
+                matches.get_one::<String>("rpcuser").map(|s| s.as_str()),
+            )?
+            .set_default("bitcoind_rpcpass", "")?
+            .set_override_option(
+                "bitcoind_rpcpass",
+                matches.get_one::<String>("rpcpass").map(|s| s.as_str()),
+            )?
+            // Subcommand defaults without which file serialization fails.
+            .set_default("pj_host", "0.0.0.0:3000")?
+            .set_default("pj_endpoint", "https://localhost:3000")?
+            .set_default("sub_only", false)?
+            .add_source(File::new("config.toml", FileFormat::Toml).required(false));
+
+        #[cfg(feature = "v2")]
+        let builder = builder
+            .set_default("ohttp_config", "")?
+            .set_override_option(
+                "ohttp_config",
+                matches.get_one::<String>("ohttp_config").map(|s| s.as_str()),
+            )?
+            .set_default("ohttp_proxy", "")?
+            .set_override_option(
+                "ohttp_proxy",
+                matches.get_one::<String>("ohttp_proxy").map(|s| s.as_str()),
+            )?;
+
+        let builder = match matches.subcommand() {
+            Some(("send", _)) => builder,
+            Some(("receive", matches)) => builder
+                .set_override_option(
+                    "pj_host",
+                    matches.get_one::<String>("port").map(|port| format!("0.0.0.0:{}", port)),
+                )?
+                .set_override_option(
+                    "pj_endpoint",
+                    matches.get_one::<String>("endpoint").map(|s| s.as_str()),
+                )?
+                .set_override_option("sub_only", matches.get_one::<bool>("sub_only").copied())?,
+            _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
+        };
+        let app_conf = builder.build()?;
+        log::debug!("App config: {:?}", app_conf);
+        app_conf.try_deserialize().context("Failed to deserialize config")
+    }
+}

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -5,6 +5,7 @@ mod app;
 use app::App;
 mod appconf;
 use appconf::AppConfig;
+use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -49,7 +50,8 @@ fn cli() -> ArgMatches {
             .long("rpchost")
             .short('r')
             .num_args(1)
-            .help("The port of the bitcoin node"))
+            .help("The port of the bitcoin node")
+            .value_parser(value_parser!(Url)))
         .arg(Arg::new("cookie_file")
             .long("cookie-file")
             .short('c')
@@ -69,7 +71,8 @@ fn cli() -> ArgMatches {
             .help("The ohttp config file"))
         .arg(Arg::new("ohttp_proxy")
             .long("ohttp-proxy")
-            .help("The ohttp proxy url"))
+            .help("The ohttp proxy url")
+            .value_parser(value_parser!(Url)))
         .arg(Arg::new("retry")
             .long("retry")
             .short('e')
@@ -101,7 +104,8 @@ fn cli() -> ArgMatches {
                     .long("endpoint")
                     .short('e')
                     .num_args(1)
-                    .help("The `pj=` endpoint to receive the payjoin request"))
+                    .help("The `pj=` endpoint to receive the payjoin request")
+                    .value_parser(value_parser!(Url)))
                 .arg(Arg::new("sub_only")
                     .long("sub-only")
                     .short('s')

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result};
 use clap::{arg, value_parser, Arg, ArgMatches, Command};
 
 mod app;
-use app::{App, AppConfig};
+use app::App;
+mod appconf;
+use appconf::AppConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -45,8 +45,8 @@ mod e2e {
             "sender doesn't own bitcoin"
         );
 
-        let receiver_rpchost = format!("{}/wallet/receiver", bitcoind.params.rpc_socket);
-        let sender_rpchost = format!("{}/wallet/sender", bitcoind.params.rpc_socket);
+        let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
+        let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
         let cookie_file = &bitcoind.params.cookie_file;
         let pj_host = find_free_port();
         let pj_endpoint = format!("https://localhost:{}", pj_host);

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -321,7 +321,7 @@ impl RequestContext {
     #[cfg(feature = "v2")]
     pub fn extract_v2(
         &mut self,
-        ohttp_proxy_url: &str,
+        ohttp_proxy: Url,
     ) -> Result<(Request, ContextV2), CreateRequestError> {
         let rs_base64 = crate::v2::subdir(self.endpoint.as_str()).to_string();
         log::debug!("rs_base64: {:?}", rs_base64);
@@ -349,10 +349,9 @@ impl RequestContext {
             Some(&body),
         )
         .map_err(InternalCreateRequestError::V2)?;
-        log::debug!("ohttp_proxy_url: {:?}", ohttp_proxy_url);
-        let url = Url::parse(ohttp_proxy_url).map_err(InternalCreateRequestError::Url)?;
+        log::debug!("ohttp_proxy_url: {:?}", ohttp_proxy);
         Ok((
-            Request { url, body },
+            Request { url: ohttp_proxy, body },
             // this method may be called more than once to re-construct the ohttp, therefore we must clone (or TODO memoize)
             ContextV2 {
                 context_v1: ContextV1 {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -240,8 +240,11 @@ mod integration {
             // **********************
             // Inside the Receiver:
             // Try enroll with bad relay ohttp-keys
-            let mut bad_enroller =
-                Enroller::from_relay_config(&PJ_RELAY_URL, &BAD_OHTTP_KEYS, &OH_RELAY_URL);
+            let mut bad_enroller = Enroller::from_relay_config(
+                Url::parse(PJ_RELAY_URL)?,
+                &BAD_OHTTP_KEYS,
+                Url::parse(OH_RELAY_URL)?,
+            );
             let (req, _ctx) = bad_enroller.extract_req()?;
             let res =
                 spawn_blocking(move || http_agent().post(req.url.as_str()).send_bytes(&req.body))
@@ -253,8 +256,11 @@ mod integration {
             );
 
             // Enroll with relay
-            let mut enroller =
-                Enroller::from_relay_config(&PJ_RELAY_URL, &ohttp_config, &OH_RELAY_URL);
+            let mut enroller = Enroller::from_relay_config(
+                Url::parse(PJ_RELAY_URL)?,
+                &ohttp_config,
+                Url::parse(OH_RELAY_URL)?,
+            );
             let (req, ctx) = enroller.extract_req()?;
             let res =
                 spawn_blocking(move || http_agent().post(req.url.as_str()).send_bytes(&req.body))
@@ -285,7 +291,7 @@ mod integration {
             debug!("Original psbt: {:#?}", psbt);
             let (send_req, send_ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
-                .extract_v2(OH_RELAY_URL)?;
+                .extract_v2(Url::parse(OH_RELAY_URL)?)?;
             log::info!("send fallback v2");
             log::debug!("Request: {:#?}", &send_req.body);
             let response = {
@@ -378,8 +384,11 @@ mod integration {
             // **********************
             // Inside the Receiver:
             // Enroll with relay
-            let mut enroller =
-                Enroller::from_relay_config(&PJ_RELAY_URL, &ohttp_config, &OH_RELAY_URL);
+            let mut enroller = Enroller::from_relay_config(
+                Url::parse(PJ_RELAY_URL)?,
+                &ohttp_config,
+                Url::parse(OH_RELAY_URL)?,
+            );
             let (req, ctx) = enroller.extract_req()?;
             let res =
                 spawn_blocking(move || http_agent().post(req.url.as_str()).send_bytes(&req.body))


### PR DESCRIPTION
We were handling config / argument types later on and it made it complex to know if a particular config was bad early on. This makes sure they're the right type from the get-go. It also helps strongly type some `payjoin` function signatures rather than accept strings.

The AppConfig has also been moved to its own file.