### PR TITLE
Remove annoying duplicate code in tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "env_logger",
  "log",
  "ohttp 0.5.1",
+ "once_cell",
  "rand",
  "rustls 0.22.2",
  "serde",

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = "1.0.108"
 [dev-dependencies]
 bitcoind = { version = "0.31.1", features = ["0_21_2"] }
 env_logger = "0.9.0"
+once_cell = "1"
 rustls = "0.22.2"
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["postgres"] }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -428,7 +428,6 @@ mod integration {
             println!("Initializing relay server");
             env::set_var("PJ_RELAY_PORT", "8088");
             env::set_var("PJ_RELAY_TIMEOUT_SECS", "2");
-            //env::set_var("PGPASSWORD", "welcome");
             let postgres = docker.run(Postgres::default());
             env::set_var("PJ_DB_HOST", format!("127.0.0.1:{}", postgres.get_host_port_ipv4(5432)));
             println!("Postgres running on {}", postgres.get_host_port_ipv4(5432));

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -260,7 +260,6 @@ mod integration {
                     http_agent()
                         .post(url.as_str())
                         .set("Content-Type", "text/plain")
-                        .set("Async", "true")
                         .send_bytes(&body)
                 })
                 .await??


### PR DESCRIPTION
Remove annoying duplicate code in tests. It was making it hard to change them and make me not want to write tests which is a big red flag.

Pretty ugly since it builds on #195 