### PR TITLE
Expose only public receive::Error

### DIFF
--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -77,7 +77,8 @@ impl AppTrait for App {
                 &self.config.ohttp_config,
                 self.config.ohttp_relay.clone(),
             );
-            let (req, ctx) = enroller.extract_req()?;
+            let (req, ctx) =
+                enroller.extract_req().map_err(|e| anyhow!("Failed to extract request {}", e))?;
             log::debug!("Enrolling receiver");
             let http = http_agent()?;
             let ohttp_response = spawn_blocking(move || {

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -7,9 +7,6 @@ pub enum Error {
     BadRequest(RequestError),
     // To be returned as HTTP 500
     Server(Box<dyn error::Error>),
-    // V2 d/encapsulation failed
-    #[cfg(feature = "v2")]
-    V2(crate::v2::Error),
 }
 
 impl fmt::Display for Error {
@@ -17,8 +14,6 @@ impl fmt::Display for Error {
         match &self {
             Self::BadRequest(e) => e.fmt(f),
             Self::Server(e) => write!(f, "Internal Server Error: {}", e),
-            #[cfg(feature = "v2")]
-            Self::V2(e) => e.fmt(f),
         }
     }
 }
@@ -28,8 +23,6 @@ impl error::Error for Error {
         match &self {
             Self::BadRequest(_) => None,
             Self::Server(e) => Some(e.as_ref()),
-            #[cfg(feature = "v2")]
-            Self::V2(e) => Some(e),
         }
     }
 }
@@ -44,7 +37,7 @@ impl From<InternalRequestError> for Error {
 
 #[cfg(feature = "v2")]
 impl From<crate::v2::Error> for Error {
-    fn from(e: crate::v2::Error) -> Self { Error::V2(e) }
+    fn from(e: crate::v2::Error) -> Self { Error::Server(Box::new(e)) }
 }
 
 /// Error that may occur when the request from sender is malformed.

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -69,7 +69,7 @@ impl Enroller {
 
     pub fn payjoin_subdir(&self) -> String { format!("{}/{}", self.subdirectory(), "payjoin") }
 
-    pub fn extract_req(&mut self) -> Result<(Request, ohttp::ClientResponse), crate::v2::Error> {
+    pub fn extract_req(&mut self) -> Result<(Request, ohttp::ClientResponse), Error> {
         let url = self.ohttp_relay.clone();
         let subdirectory = self.subdirectory();
         let (body, ctx) = crate::v2::ohttp_encapsulate(
@@ -90,7 +90,7 @@ impl Enroller {
         // TODO decapsulate enroll response, for now it does no auth or nothing
         let mut buf = Vec::new();
         let _ = res.read_to_end(&mut buf);
-        let _success = crate::v2::ohttp_decapsulate(ctx, &buf).map_err(Error::V2)?;
+        let _success = crate::v2::ohttp_decapsulate(ctx, &buf)?;
 
         let ctx = Enrolled {
             directory: self.directory,
@@ -320,11 +320,11 @@ impl Enrolled {
         }
     }
 
-    fn fallback_req_body(&mut self) -> Result<(Vec<u8>, ohttp::ClientResponse), crate::v2::Error> {
+    fn fallback_req_body(&mut self) -> Result<(Vec<u8>, ohttp::ClientResponse), Error> {
         let fallback_target = format!("{}{}", &self.directory, self.fallback_target());
         log::trace!("Fallback request target: {}", fallback_target.as_str());
         let fallback_target = self.fallback_target();
-        crate::v2::ohttp_encapsulate(&mut self.ohttp_keys, "GET", &fallback_target, None)
+        Ok(crate::v2::ohttp_encapsulate(&mut self.ohttp_keys, "GET", &fallback_target, None)?)
     }
 
     pub fn pubkey(&self) -> [u8; 33] { self.s.public_key().serialize() }


### PR DESCRIPTION
payjoin::v2::Error is private and we're better of not returning it.

This also removes the receive::Error::V2 variant.