### PR TITLE
fix: Encode ohttp_keys without padding

### DIFF
--- a/payjoin/src/uri.rs
+++ b/payjoin/src/uri.rs
@@ -238,9 +238,11 @@ impl<'a> bip21::SerializeParams for &'a PayjoinExtras {
             ("pjos", if self.disable_output_substitution { "1" } else { "0" }.to_string()),
         ];
         #[cfg(feature = "v2")]
-        if let Some(config) = self.ohttp_keys.clone().and_then(|c| c.encode().ok()) {
-            let encoded_config = bitcoin::base64::encode_config(config, bitcoin::base64::URL_SAFE);
-            params.push(("ohttp", encoded_config));
+        if let Some(ohttp_keys) = self.ohttp_keys.clone().and_then(|c| c.encode().ok()) {
+            let config =
+                bitcoin::base64::Config::new(bitcoin::base64::CharacterSet::UrlSafe, false);
+            let base64_ohttp_keys = bitcoin::base64::encode_config(ohttp_keys, config);
+            params.push(("ohttp", base64_ohttp_keys));
         } else {
             log::warn!("Failed to encode ohttp config, ignoring");
         }


### PR DESCRIPTION
we were encoding the ohttp_keys with unnecessary padding before.

before: `bitcoin:tb1qqsjmzl4w4gcyf78gr7c33muhrtyfk99exanajs?amount=0.00012222&pj=https://payjo.in/AjPOFs1CNb8WQEgB0lD3o34NP6IY3Ph5-sJlIU0Y9ZM7&pjos=0&ohttp=
AQAg3c9qovMZvPzLh8XHgD8q86WG7SmPQvPamCTvEoueKBsABAABAAM%3D`

after: `bitcoin:tb1qdzl8lurku099a4g47neyx57av4q3mm2eny8yzh?amount=0.00012222&pj=https://payjo.in/A4SFFhvlNkYmIVya2hFOTuZrjHVoQPKWB-mq_Gg8A24b&pjos=0&ohttp=
AQAg3c9qovMZvPzLh8XHgD8q86WG7SmPQvPamCTvEoueKBsABAABAAM `