### PR TITLE
Incl headers

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -56,7 +56,7 @@ impl AppTrait for App {
         println!("Sending fallback request to {}", &req.url);
         let response = http
             .post(req.url.as_str())
-            .set("Content-Type", "text/plain")
+            .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
             .send_string(&body.clone())
             .with_context(|| "HTTP request failed")?;
         let fallback_tx = Psbt::from_str(&body)

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -86,7 +86,7 @@ impl AppTrait for App {
             let http = http_agent()?;
             let ohttp_response = spawn_blocking(move || {
                 http.post(req.url.as_ref())
-                    .set("Content-Type", "message/ohttp-req")
+                    .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
                     .send_bytes(&req.body)
                     .map_err(map_ureq_err)
             })
@@ -125,7 +125,7 @@ impl AppTrait for App {
         let http = http_agent()?;
         let res = http
             .post(req.url.as_str())
-            .set("Content-Type", "message/ohttp-req")
+            .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
             .send_bytes(&req.body)
             .map_err(map_ureq_err)?;
         let mut buf = Vec::new();
@@ -165,7 +165,7 @@ impl App {
             let http = http_agent()?;
             let response = spawn_blocking(move || {
                 http.post(req.url.as_ref())
-                    .set("Content-Type", "message/ohttp-req")
+                    .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
                     .send_bytes(&req.body)
                     .map_err(map_ureq_err)
             })
@@ -194,7 +194,7 @@ impl App {
             let http = http_agent()?;
             let ohttp_response = spawn_blocking(move || {
                 http.post(req.url.as_str())
-                    .set("Content-Type", "message/ohttp-req")
+                    .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
                     .send_bytes(&req.body)
                     .map_err(map_ureq_err)
             })

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -36,6 +36,11 @@ pub use v2::OhttpKeys;
 pub(crate) mod input_type;
 #[cfg(any(feature = "send", feature = "receive"))]
 pub(crate) mod psbt;
+#[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
+mod request;
+#[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
+pub use request::Request;
+
 mod uri;
 #[cfg(any(feature = "send", feature = "receive"))]
 pub(crate) mod weight;

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -39,7 +39,7 @@ pub(crate) mod psbt;
 #[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
 mod request;
 #[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
-pub use request::Request;
+pub use request::*;
 
 mod uri;
 #[cfg(any(feature = "send", feature = "receive"))]

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -9,22 +9,7 @@ use url::Url;
 use super::{Error, InternalRequestError, RequestError, SelectionError};
 use crate::psbt::PsbtExt;
 use crate::receive::optional_parameters::Params;
-use crate::OhttpKeys;
-
-/// Represents data that needs to be transmitted to the payjoin directory.
-///
-/// You need to send this request over HTTP(S) to the directory.
-#[non_exhaustive]
-#[derive(Debug)]
-pub struct Request {
-    /// URL to send the request to.
-    ///
-    /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: url::Url,
-
-    /// Bytes to be sent to the receiver.
-    pub body: Vec<u8>,
-}
+use crate::{OhttpKeys, Request};
 
 #[derive(Debug, Clone)]
 pub struct V2Context {

--- a/payjoin/src/request.rs
+++ b/payjoin/src/request.rs
@@ -1,0 +1,18 @@
+use url::Url;
+
+/// Represents data that needs to be transmitted to the receiver or payjoin directory.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Request {
+    /// URL to send the request to.
+    ///
+    /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
+    pub url: Url,
+
+    /// Bytes to be sent to the receiver.
+    ///
+    /// This is properly encoded PSBT, already in base64. You only need to make sure `Content-Type`
+    /// is appropriate (`text/plain` for v1 requests and 'message/ohttp-req' for v2)
+    /// and `Content-Length` is `body.len()` (most libraries do the latter automatically).
+    pub body: Vec<u8>,
+}

--- a/payjoin/src/request.rs
+++ b/payjoin/src/request.rs
@@ -1,5 +1,10 @@
 use url::Url;
 
+pub const V1_REQ_CONTENT_TYPE: &str = "text/plain";
+
+#[cfg(feature = "v2")]
+pub const V2_REQ_CONTENT_TYPE: &str = "message/ohttp-req";
+
 /// Represents data that needs to be transmitted to the receiver or payjoin directory.
 #[non_exhaustive]
 #[derive(Debug, Clone)]

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -43,6 +43,7 @@ use url::Url;
 
 use crate::input_type::InputType;
 use crate::psbt::PsbtExt;
+use crate::request::Request;
 use crate::uri::UriExt;
 use crate::weight::{varint_size, ComputeWeight};
 use crate::{PjUri, Uri};
@@ -529,24 +530,6 @@ impl<'de> Deserialize<'de> for RequestContext {
 
         deserializer.deserialize_struct("RequestContext", FIELDS, RequestContextVisitor)
     }
-}
-/// Represents data that needs to be transmitted to the receiver.
-///
-/// You need to send this request over HTTP(S) to the receiver.
-#[non_exhaustive]
-#[derive(Debug, Clone)]
-pub struct Request {
-    /// URL to send the request to.
-    ///
-    /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Url,
-
-    /// Bytes to be sent to the receiver.
-    ///
-    /// This is properly encoded PSBT, already in base64. You only need to make sure `Content-Type`
-    /// is `text/plain` and `Content-Length` is `body.len()` (most libraries do the latter
-    /// automatically).
-    pub body: Vec<u8>,
 }
 
 /// Data required for validation of response.

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -13,8 +13,8 @@ mod integration {
     use log::{debug, log_enabled, Level};
     use once_cell::sync::{Lazy, OnceCell};
     use payjoin::bitcoin::base64;
-    use payjoin::send::{Request, RequestBuilder};
-    use payjoin::{PjUriBuilder, Uri};
+    use payjoin::send::RequestBuilder;
+    use payjoin::{PjUriBuilder, Request, Uri};
     use tracing_subscriber::{EnvFilter, FmtSubscriber};
     use url::Url;
 

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -76,7 +76,7 @@ mod integration {
         impl HeaderMock {
             fn from_vec(body: &[u8]) -> HeaderMock {
                 let mut h = HashMap::new();
-                h.insert("content-type".to_string(), "text/plain".to_string());
+                h.insert("content-type".to_string(), payjoin::V1_REQ_CONTENT_TYPE.to_string());
                 h.insert("content-length".to_string(), body.len().to_string());
                 HeaderMock(h)
             }
@@ -307,7 +307,7 @@ mod integration {
                     spawn_blocking(move || {
                         agent_clone
                             .post(url.as_str())
-                            .set("Content-Type", "text/plain")
+                            .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
                             .send_bytes(&body)
                     })
                     .await??
@@ -416,7 +416,7 @@ mod integration {
                     spawn_blocking(move || {
                         agent_clone
                             .post(url.as_str())
-                            .set("Content-Type", "text/plain")
+                            .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
                             .send_bytes(&body)
                     })
                     .await?
@@ -478,7 +478,7 @@ mod integration {
                     spawn_blocking(move || {
                         agent_clone
                             .post(url.as_str())
-                            .set("Content-Type", "text/plain")
+                            .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
                             .send_bytes(&body)
                             .expect("Failed to send request")
                     })


### PR DESCRIPTION
Draft attempt to fix #224 

~However, I'm not convinced this is ideal over a complete `pub headers: HashMap<String, Sring>` field yet.~

We can combine the request type, but I think we can stick with the current struct and just instruct to add the `const` headers ass appropriate in the reference implementations and `Request` documentation.