### PR TITLE
Clean subdir api

### DIFF
--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -260,8 +260,6 @@ impl Enrolled {
         Ok(crate::v2::ohttp_encapsulate(&mut self.ohttp_keys, "GET", &fallback_target, None)?)
     }
 
-    pub fn pubkey(&self) -> [u8; 33] { self.s.public_key().serialize() }
-
     pub fn fallback_target(&self) -> String {
         let pubkey = &self.s.public_key().serialize();
         let b64_config = base64::Config::new(base64::CharacterSet::UrlSafe, false);

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -56,17 +56,9 @@ impl Enroller {
         }
     }
 
-    pub fn subdirectory(&self) -> String {
-        let pubkey = &self.s.public_key().serialize();
-        let b64_config = base64::Config::new(base64::CharacterSet::UrlSafe, false);
-        base64::encode_config(pubkey, b64_config)
-    }
-
-    pub fn payjoin_subdir(&self) -> String { format!("{}/{}", self.subdirectory(), "payjoin") }
-
     pub fn extract_req(&mut self) -> Result<(Request, ohttp::ClientResponse), Error> {
         let url = self.ohttp_relay.clone();
-        let subdirectory = self.subdirectory();
+        let subdirectory = subdir_path_from_pubkey(&self.s.public_key());
         let (body, ctx) = crate::v2::ohttp_encapsulate(
             &mut self.ohttp_keys,
             "POST",
@@ -97,7 +89,7 @@ impl Enroller {
     }
 }
 
-fn subdirectory(pubkey: &bitcoin::secp256k1::PublicKey) -> String {
+fn subdir_path_from_pubkey(pubkey: &bitcoin::secp256k1::PublicKey) -> String {
     let pubkey = pubkey.serialize();
     let b64_config = base64::Config::new(base64::CharacterSet::UrlSafe, false);
     base64::encode_config(pubkey, b64_config)
@@ -518,7 +510,7 @@ impl PayjoinProposal {
         let post_payjoin_target = format!(
             "{}{}/payjoin",
             self.context.directory.as_str(),
-            subdirectory(&self.context.s.public_key())
+            subdir_path_from_pubkey(&self.context.s.public_key())
         );
         log::debug!("Payjoin post target: {}", post_payjoin_target.as_str());
         let (body, ctx) = crate::v2::ohttp_encapsulate(

--- a/payjoin/src/v2.rs
+++ b/payjoin/src/v2.rs
@@ -8,25 +8,6 @@ use chacha20poly1305::{AeadCore, ChaCha20Poly1305, Nonce};
 
 pub const PADDED_MESSAGE_BYTES: usize = 7168; // 7KB
 
-pub fn subdir(path: &str) -> String {
-    let subdirectory: String;
-
-    if let Some(pos) = path.rfind('/') {
-        subdirectory = path[pos + 1..].to_string();
-    } else {
-        subdirectory = path.to_string();
-    }
-
-    let pubkey_id: String;
-
-    if let Some(pos) = subdirectory.find('?') {
-        pubkey_id = subdirectory[..pos].to_string();
-    } else {
-        pubkey_id = subdirectory;
-    }
-    pubkey_id
-}
-
 /// crypto context
 ///
 /// <- Receiver S


### PR DESCRIPTION
There were a couple of functions with similar names that confused me. Some weren't even used. This cleans them up

- first commit repalces unnecessary functions with a well named conversion fn
- second encapsulates a similarly named private conversion function in the right place
-  third removes a helper function with no apparent use