### PR TITLE
Respect `disableoutputsubstitution` in payjoin-cli

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -298,11 +298,14 @@ impl App {
                 .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
         }
 
-        let receiver_substitute_address = bitcoind
-            .get_new_address(None, None)
-            .map_err(|e| Error::Server(e.into()))?
-            .assume_checked();
-        provisional_payjoin.substitute_output_address(receiver_substitute_address);
+        if !provisional_payjoin.is_output_substitution_disabled() {
+            // Substitute the receiver output address.
+            let receiver_substitute_address = bitcoind
+                .get_new_address(None, None)
+                .map_err(|e| Error::Server(e.into()))?
+                .assume_checked();
+            provisional_payjoin.substitute_output_address(receiver_substitute_address);
+        }
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -280,11 +280,14 @@ impl App {
                 .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
         }
 
-        let receiver_substitute_address = bitcoind
-            .get_new_address(None, None)
-            .map_err(|e| Error::Server(e.into()))?
-            .assume_checked();
-        provisional_payjoin.substitute_output_address(receiver_substitute_address);
+        if !provisional_payjoin.is_output_substitution_disabled() {
+            // Substitute the receiver output address.
+            let receiver_substitute_address = bitcoind
+                .get_new_address(None, None)
+                .map_err(|e| Error::Server(e.into()))?
+                .assume_checked();
+            provisional_payjoin.substitute_output_address(receiver_substitute_address);
+        }
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -473,6 +473,10 @@ impl ProvisionalProposal {
         );
     }
 
+    pub fn is_output_substitution_disabled(&self) -> bool {
+        self.params.disable_output_substitution
+    }
+
     /// Just replace an output address with
     pub fn substitute_output_address(&mut self, substitute_address: bitcoin::Address) {
         self.payjoin_psbt.unsigned_tx.output[self.owned_vouts[0]].script_pubkey =

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -443,6 +443,10 @@ impl ProvisionalProposal {
         self.inner.contribute_non_witness_input(tx, outpoint)
     }
 
+    pub fn is_output_substitution_disabled(&self) -> bool {
+        self.inner.is_output_substitution_disabled()
+    }
+
     /// Just replace an output address with
     pub fn substitute_output_address(&mut self, substitute_address: bitcoin::Address) {
         self.inner.substitute_output_address(substitute_address)


### PR DESCRIPTION
Fix for https://github.com/payjoin/rust-payjoin/issues/238