### PR TITLE
payjoin-cli: Include err context on bitcoind fail

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -29,6 +29,9 @@ impl AppTrait for App {
     fn new(config: AppConfig) -> Result<Self> {
         let seen_inputs = Arc::new(Mutex::new(SeenInputs::new()?));
         let app = Self { config, seen_inputs };
+        app.bitcoind()?
+            .get_blockchain_info()
+            .context("Failed to connect to bitcoind. Check config RPC connection.")?;
         Ok(app)
     }
 

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -30,6 +30,9 @@ impl AppTrait for App {
         let receive_store = Arc::new(AsyncMutex::new(ReceiveStore::new()?));
         let send_store = Arc::new(AsyncMutex::new(SendStore::new()?));
         let app = Self { config, receive_store, send_store, seen_inputs };
+        app.bitcoind()?
+            .get_blockchain_info()
+            .context("Failed to connect to bitcoind. Check config RPC connection.")?;
         Ok(app)
     }
 


### PR DESCRIPTION
Simply wrapping an error and passing it up does not provide context to a cli caller. Supplying enough context helps them diagnose the issue.

However, we need to think hard about whether or not we actually want to panic and crash the software. Are these conditions actually unrecoverable?

Additionally, the new expect strings break encapsulation since they reference  `bitcoind_rpchost`. If that's something that could be missing or error, I would prefer the problem area is what produces the error. I.e, if config validation fails, that should produce this error, not a call to get_new_address many lines and functions deeper into the program.