### PR TITLE
Rename config.toml & CLI argument field pj_host to `port`

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -83,7 +84,7 @@ impl AppTrait for App {
         let pj_uri_string = self.construct_payjoin_uri(amount_arg, None)?;
         println!(
             "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
-            self.config.pj_host
+            self.config.port
         );
         println!("{}", pj_uri_string);
 
@@ -113,6 +114,7 @@ impl App {
     }
 
     async fn start_http_server(self) -> Result<()> {
+        let addr = SocketAddr::from(([0, 0, 0, 0], self.config.port));
         #[cfg(feature = "danger-local-https")]
         let server = {
             use std::io::Write;
@@ -129,7 +131,7 @@ impl App {
             let key =
                 PrivateKeyDer::from(PrivatePkcs8KeyDer::from(cert.serialize_private_key_der()));
             let certs = vec![CertificateDer::from(cert.serialize_der()?)];
-            let incoming = AddrIncoming::bind(&self.config.pj_host)?;
+            let incoming = AddrIncoming::bind(&addr)?;
             let acceptor = hyper_rustls::TlsAcceptor::builder()
                 .with_single_cert(certs, key)
                 .map_err(|e| anyhow::anyhow!("TLS error: {}", e))?
@@ -139,7 +141,7 @@ impl App {
         };
 
         #[cfg(not(feature = "danger-local-https"))]
-        let server = Server::bind(&self.config.pj_host);
+        let server = Server::bind(&addr);
         let app = self.clone();
         let make_svc = make_service_fn(|_| {
             let app = app.clone();

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -108,10 +108,7 @@ impl AppTrait for App {
         log::debug!("Enrolled receiver");
         let pj_uri_string =
             self.construct_payjoin_uri(amount_arg, &enrolled.fallback_target(), ohttp_keys)?;
-        println!(
-            "Listening at port {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
-            self.config.port
-        );
+        println!("Configured to accept payjoin at BIP 21 Payjoin Uri:");
         println!("{}", pj_uri_string);
 
         log::debug!("Awaiting proposal");

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -109,8 +109,8 @@ impl AppTrait for App {
         let pj_uri_string =
             self.construct_payjoin_uri(amount_arg, &enrolled.fallback_target(), ohttp_keys)?;
         println!(
-            "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
-            self.config.pj_host
+            "Listening at port {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
+            self.config.port
         );
         println!("{}", pj_uri_string);
 

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -108,7 +108,7 @@ fn cli() -> ArgMatches {
                 .arg_required_else_help(true)
                 .arg(
                     Arg::new("port")
-                        .long("host-port")
+                        .long("port")
                         .short('p')
                         .num_args(1)
                         .help("The local port to listen on"),

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -48,8 +48,8 @@ mod e2e {
         let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
         let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
         let cookie_file = &bitcoind.params.cookie_file;
-        let pj_host = find_free_port();
-        let pj_endpoint = format!("https://localhost:{}", pj_host);
+        let port = find_free_port();
+        let pj_endpoint = format!("https://localhost:{}", port);
 
         let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
 
@@ -60,8 +60,8 @@ mod e2e {
             .arg(&cookie_file)
             .arg("receive")
             .arg(RECEIVE_SATS)
-            .arg("--host-port")
-            .arg(&pj_host.to_string())
+            .arg("--port")
+            .arg(&port.to_string())
             .arg("--endpoint")
             .arg(&pj_endpoint)
             .stdout(Stdio::piped())


### PR DESCRIPTION
This addresses a concern @thebrandonlucas brought up in testing about how payjoin-cli config is not straightforward to understand.

1. the first commit renames pj_host to `port`, and properly feature flags it, since it's only for the v1 receiver to bind to
2. Remove a listening message where nothing is listening since listening port is not a concern in v2, it's client only.