### PR TITLE
payjoin-cli: Organize config errors

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -1,9 +1,8 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use anyhow::Result;
 use clap::ArgMatches;
-use config::{Config, File, FileFormat};
+use config::{Config, ConfigError, File, FileFormat};
 use serde::Deserialize;
 use url::Url;
 
@@ -25,7 +24,7 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    pub(crate) fn new(matches: &ArgMatches) -> Result<Self> {
+    pub(crate) fn new(matches: &ArgMatches) -> Result<Self, ConfigError> {
         let builder = Config::builder()
             .set_default("bitcoind_rpchost", "http://localhost:18443")?
             .set_override_option(

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -55,12 +55,10 @@ impl AppConfig {
 
         #[cfg(feature = "v2")]
         let builder = builder
-            .set_default("ohttp_keys", None::<String>)?
             .set_override_option(
                 "ohttp_keys",
                 matches.get_one::<String>("ohttp_keys").map(|s| s.as_str()),
             )?
-            .set_default("ohttp_relay", "")?
             .set_override_option(
                 "ohttp_relay",
                 matches.get_one::<Url>("ohttp_relay").map(|s| s.as_str()),

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let matches = cli();
-    let config = AppConfig::new(&matches)?;
+    let config = AppConfig::new(&matches).with_context(|| "Failed to parse config")?;
     let app = App::new(config)?;
 
     match matches.subcommand() {


### PR DESCRIPTION
fix #242 

The original error was caused by a bad default `""` `ohttp_relay` value. That has been addressesed as well as the context that's provided when an error does happen.

Supplying config error context makes it so the issue outlined in #242 would now throw:

```
Error: Failed to parse config

Caused by:
    missing field `ohttp_relay`
```