### PR TITLE
Replace `ureq` with `reqwest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1421,12 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1674,6 +1686,7 @@ dependencies = [
  "payjoin-directory",
  "rand",
  "rcgen",
+ "reqwest",
  "rustls 0.22.3",
  "serde",
  "serde_json",
@@ -1682,7 +1695,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "ureq",
  "url",
 ]
 
@@ -1706,10 +1718,10 @@ dependencies = [
  "payjoin",
  "payjoin-defaults",
  "rcgen",
+ "reqwest",
  "rustls 0.22.3",
  "serde",
  "tokio",
- "ureq",
  "url",
 ]
 
@@ -1726,13 +1738,13 @@ dependencies = [
  "payjoin",
  "payjoin-directory",
  "rcgen",
+ "reqwest",
  "rustls 0.22.3",
  "testcontainers",
  "testcontainers-modules",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "ureq",
  "url",
 ]
 
@@ -2082,6 +2094,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.3",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.1",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,6 +2409,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2581,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tar"
@@ -2916,24 +2988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
-dependencies = [
- "base64 0.21.7",
- "flate2",
- "log",
- "once_cell",
- "rustls 0.22.3",
- "rustls-native-certs 0.7.0",
- "rustls-pki-types",
- "rustls-webpki 0.102.2",
- "url",
- "webpki-roots 0.26.1",
-]
-
-[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3061,18 @@ dependencies = [
  "quote",
  "syn 2.0.58",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3237,6 +3303,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -18,8 +18,8 @@ path = "src/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-native-certs = ["ureq/native-certs"]
-danger-local-https = ["rcgen", "rustls", "hyper-rustls", "payjoin-defaults/danger-local-https"]
+native-certs = ["reqwest/rustls-tls-native-roots"]
+danger-local-https = ["rcgen", "reqwest/rustls-tls", "rustls", "hyper-rustls", "payjoin-defaults/danger-local-https"]
 v2 = ["payjoin/v2", "payjoin-defaults/v2"]
 
 [dependencies]
@@ -36,10 +36,10 @@ log = "0.4.7"
 payjoin = { version = "0.15.0", features = ["send", "receive", "base64"] }
 payjoin-defaults = { path = "../payjoin-defaults" }
 rcgen = { version = "0.11.1", optional = true }
+reqwest = { version = "0.12", default-features = false }
 rustls = { version = "0.22.2", optional = true }
 serde = { version = "1.0.160", features = ["derive"] }
 tokio = { version = "1.12.0", features = ["full"] }
-ureq = "2.9.4"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -55,9 +55,11 @@ impl AppTrait for App {
         let body = String::from_utf8(req.body.clone()).unwrap();
         println!("Sending fallback request to {}", &req.url);
         let response = http
-            .post(req.url.as_str())
-            .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
-            .send_string(&body.clone())
+            .post(req.url)
+            .header("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
+            .body(body.clone())
+            .send()
+            .await
             .with_context(|| "HTTP request failed")?;
         let fallback_tx = Psbt::from_str(&body)
             .map_err(|e| anyhow!("Failed to load PSBT from base64: {}", e))?
@@ -67,10 +69,12 @@ impl AppTrait for App {
             "Sent fallback transaction hex: {:#}",
             payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
         );
-        let psbt = ctx.process_response(&mut response.into_reader()).map_err(|e| {
-            log::debug!("Error processing response: {:?}", e);
-            anyhow!("Failed to process response {}", e)
-        })?;
+        let psbt = ctx.process_response(&mut response.bytes().await?.to_vec().as_slice()).map_err(
+            |e| {
+                log::debug!("Error processing response: {:?}", e);
+                anyhow!("Failed to process response {}", e)
+            },
+        )?;
 
         self.process_pj_response(psbt)?;
         Ok(())

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -9,7 +9,6 @@ use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::Amount;
 use payjoin::{base64, bitcoin, Error, PjUriBuilder};
 use tokio::sync::Mutex as AsyncMutex;
-use tokio::task::spawn_blocking;
 
 use super::config::AppConfig;
 use super::{App as AppTrait, SeenInputs};
@@ -83,16 +82,16 @@ impl AppTrait for App {
                 enroller.extract_req().map_err(|e| anyhow!("Failed to extract request {}", e))?;
             log::debug!("Enrolling receiver");
             let http = http_agent()?;
-            let ohttp_response = spawn_blocking(move || {
-                http.post(req.url.as_ref())
-                    .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
-                    .send_bytes(&req.body)
-                    .map_err(map_ureq_err)
-            })
-            .await??;
+            let ohttp_response = http
+                .post(req.url)
+                .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+                .body(req.body)
+                .send()
+                .await
+                .map_err(map_reqwest_err)?;
 
             let enrolled = enroller
-                .process_res(ohttp_response.into_reader(), ctx)
+                .process_res(ohttp_response.bytes().await?.to_vec().as_slice(), ctx)
                 .map_err(|_| anyhow!("Enrollment failed"))?;
             self.receive_store.lock().await.write(enrolled.clone())?;
             enrolled
@@ -123,14 +122,14 @@ impl AppTrait for App {
             .map_err(|e| anyhow!("v2 req extraction failed {}", e))?;
         let http = http_agent()?;
         let res = http
-            .post(req.url.as_str())
-            .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
-            .send_bytes(&req.body)
-            .map_err(map_ureq_err)?;
-        let mut buf = Vec::new();
-        let _ = res.into_reader().read_to_end(&mut buf)?;
+            .post(req.url)
+            .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+            .body(req.body)
+            .send()
+            .await
+            .map_err(map_reqwest_err)?;
         let res = payjoin_proposal
-            .deserialize_res(buf, ohttp_ctx)
+            .deserialize_res(res.bytes().await?.to_vec(), ohttp_ctx)
             .map_err(|e| anyhow!("Failed to deserialize response {}", e))?;
         log::debug!("Received response {:?}", res);
         self.receive_store.lock().await.clear()?;
@@ -162,16 +161,16 @@ impl App {
             let (req, ctx) = req_ctx.extract_v2(self.config.ohttp_relay.clone())?;
             println!("Sending fallback request to {}", &req.url);
             let http = http_agent()?;
-            let response = spawn_blocking(move || {
-                http.post(req.url.as_ref())
-                    .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
-                    .send_bytes(&req.body)
-                    .map_err(map_ureq_err)
-            })
-            .await??;
+            let response = http
+                .post(req.url)
+                .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+                .body(req.body)
+                .send()
+                .await
+                .map_err(map_reqwest_err)?;
 
             println!("Sent fallback transaction");
-            match ctx.process_response(&mut response.into_reader()) {
+            match ctx.process_response(&mut response.bytes().await?.to_vec().as_slice()) {
                 Ok(Some(psbt)) => return Ok(psbt),
                 Ok(None) => std::thread::sleep(std::time::Duration::from_secs(5)),
                 Err(re) => {
@@ -191,16 +190,16 @@ impl App {
                 enrolled.extract_req().map_err(|_| anyhow!("Failed to extract request"))?;
             log::debug!("GET fallback_psbt");
             let http = http_agent()?;
-            let ohttp_response = spawn_blocking(move || {
-                http.post(req.url.as_str())
-                    .set("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
-                    .send_bytes(&req.body)
-                    .map_err(map_ureq_err)
-            })
-            .await??;
+            let ohttp_response = http
+                .post(req.url)
+                .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+                .body(req.body)
+                .send()
+                .await
+                .map_err(map_reqwest_err)?;
 
             let proposal = enrolled
-                .process_res(ohttp_response.into_reader(), context)
+                .process_res(ohttp_response.bytes().await?.to_vec().as_slice(), context)
                 .map_err(|_| anyhow!("GET fallback failed"))?;
             log::debug!("got response");
             match proposal {
@@ -320,28 +319,20 @@ async fn unwrap_ohttp_keys_or_else_fetch(config: &AppConfig) -> Result<payjoin::
             "localhost".to_string(),
         ])?
         .serialize_der()?;
-        Ok(tokio::task::spawn_blocking(move || {
-            payjoin_defaults::fetch_ohttp_keys(
-                ohttp_relay,
-                payjoin_directory,
-                #[cfg(feature = "danger-local-https")]
-                cert_der,
-            )
-        })
-        .await
-        .map_err(|e| anyhow!("Failed to fetch ohttp keys: {}", e))??)
+        Ok(payjoin_defaults::fetch_ohttp_keys(
+            ohttp_relay,
+            payjoin_directory,
+            #[cfg(feature = "danger-local-https")]
+            cert_der,
+        )
+        .await?)
     }
 }
 
-fn map_ureq_err(e: ureq::Error) -> anyhow::Error {
-    let e_string = e.to_string();
-    match e.into_response() {
-        Some(res) => anyhow!(
-            "HTTP request failed: {} {}",
-            res.status(),
-            res.into_string().unwrap_or_default()
-        ),
-        None => anyhow!("No HTTP response: {}", e_string),
+fn map_reqwest_err(e: reqwest::Error) -> anyhow::Error {
+    match e.status() {
+        Some(status_code) => anyhow!("HTTP request failed: {} {}", status_code, e),
+        None => anyhow!("No HTTP response: {}", e),
     }
 }
 

--- a/payjoin-defaults/Cargo.toml
+++ b/payjoin-defaults/Cargo.toml
@@ -11,13 +11,13 @@ resolver = "2"
 version = "0.0.1"
 
 [features]
-danger-local-https = ["rustls"]
+danger-local-https = ["reqwest/rustls-tls", "rustls"]
 v2 = ["payjoin/v2"]
 
 [dependencies]
 payjoin = { version = "0.15.0", features = ["send", "receive"] }
 rustls = { version = "0.22.2", optional = true }
-ureq = "2.9.4"
+reqwest = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 bitcoin = { version = "0.30.0", features = ["base64"] }

--- a/payjoin-defaults/src/lib.rs
+++ b/payjoin-defaults/src/lib.rs
@@ -1,4 +1,5 @@
-use payjoin::Url;
+#[cfg(feature = "v2")]
+use payjoin::{OhttpKeys, Url};
 
 /// Fetch the ohttp keys from the specified payjoin directory via proxy.
 ///
@@ -12,22 +13,27 @@ use payjoin::Url;
 /// * `cert_der` (optional): The DER-encoded certificate to use for local HTTPS connections.  This
 /// parameter is only available when the "danger-local-https" feature is enabled.
 #[cfg(feature = "v2")]
-pub fn fetch_ohttp_keys(
+pub async fn fetch_ohttp_keys(
     ohttp_relay: Url,
     payjoin_directory: Url,
     #[cfg(feature = "danger-local-https")] cert_der: Vec<u8>,
-) -> Result<payjoin::OhttpKeys, Error> {
+) -> Result<OhttpKeys, Error> {
+    use reqwest::{Client, Proxy};
+
     let ohttp_keys_url = payjoin_directory.join("/ohttp-keys")?;
-    let proxy = PayjoinProxy::new(
-        &ohttp_relay,
-        #[cfg(feature = "danger-local-https")]
-        cert_der,
-    )?;
-    let res = proxy.get(ohttp_keys_url.as_str()).call()?;
-    let mut body = Vec::new();
-    let _ = res.into_reader().read_to_end(&mut body)?;
-    payjoin::OhttpKeys::decode(&body)
-        .map_err(|e| Error(InternalError::InvalidOhttpKeys(e.to_string())))
+    let proxy = Proxy::all(ohttp_relay.as_str())?;
+    #[cfg(not(feature = "danger-local-https"))]
+    let client = Client::builder().proxy(proxy).build()?;
+    #[cfg(feature = "danger-local-https")]
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .use_rustls_tls()
+        .add_root_certificate(reqwest::tls::Certificate::from_der(&cert_der)?)
+        .proxy(proxy)
+        .build()?;
+    let res = client.get(ohttp_keys_url).send().await?;
+    let body = res.bytes().await?.to_vec();
+    OhttpKeys::decode(&body).map_err(|e| Error(InternalError::InvalidOhttpKeys(e.to_string())))
 }
 
 #[derive(Debug)]
@@ -36,7 +42,7 @@ pub struct Error(InternalError);
 #[derive(Debug)]
 enum InternalError {
     ParseUrl(payjoin::ParseError),
-    Ureq(ureq::Error),
+    Reqwest(reqwest::Error),
     Io(std::io::Error),
     #[cfg(feature = "danger-local-https")]
     Rustls(rustls::Error),
@@ -52,8 +58,8 @@ macro_rules! impl_from_error {
     };
 }
 
+impl_from_error!(reqwest::Error, Reqwest);
 impl_from_error!(payjoin::ParseError, ParseUrl);
-impl_from_error!(ureq::Error, Ureq);
 impl_from_error!(std::io::Error, Io);
 #[cfg(feature = "danger-local-https")]
 impl_from_error!(rustls::Error, Rustls);
@@ -63,8 +69,8 @@ impl std::fmt::Display for Error {
         use InternalError::*;
 
         match &self.0 {
+            Reqwest(e) => e.fmt(f),
             ParseUrl(e) => e.fmt(f),
-            Ureq(e) => e.fmt(f),
             Io(e) => e.fmt(f),
             #[cfg(feature = "v2")]
             InvalidOhttpKeys(e) => {
@@ -81,8 +87,8 @@ impl std::error::Error for Error {
         use InternalError::*;
 
         match &self.0 {
+            Reqwest(e) => Some(e),
             ParseUrl(e) => Some(e),
-            Ureq(e) => Some(e),
             Io(e) => Some(e),
             #[cfg(feature = "v2")]
             InvalidOhttpKeys(_) => None,
@@ -94,56 +100,4 @@ impl std::error::Error for Error {
 
 impl From<InternalError> for Error {
     fn from(value: InternalError) -> Self { Self(value) }
-}
-
-struct PayjoinProxy {
-    client: ureq::Agent,
-}
-
-impl PayjoinProxy {
-    fn new(
-        proxy: &Url,
-        #[cfg(feature = "danger-local-https")] cert_der: Vec<u8>,
-    ) -> Result<Self, Error> {
-        let proxy = ureq::Proxy::new(Self::normalize_proxy_url(proxy)?)?;
-        #[cfg(feature = "danger-local-https")]
-        let client = Self::http_agent_builder(cert_der)?.proxy(proxy).build();
-        #[cfg(not(feature = "danger-local-https"))]
-        let client = ureq::AgentBuilder::new().proxy(proxy).build();
-
-        Ok(Self { client })
-    }
-
-    fn get(&self, url: &str) -> ureq::Request { self.client.get(url) }
-
-    // Normalize the Url to include the port for ureq. ureq has a bug
-    // which makes Proxy::new(...) use port 8080 for all input with scheme
-    // http regardless of the port included in the Url. This prevents that.
-    // https://github.com/algesten/ureq/pull/717
-    fn normalize_proxy_url(proxy: &Url) -> Result<String, Error> {
-        let host = match proxy.host_str() {
-            Some(host) => host,
-            None => return Err(Error(InternalError::ParseUrl(payjoin::ParseError::EmptyHost))),
-        };
-        match proxy.scheme() {
-            "http" | "https" => Ok(format!("{}:{}", host, proxy.port().unwrap_or(80))),
-            _ => Ok(proxy.as_str().to_string()),
-        }
-    }
-
-    #[cfg(feature = "danger-local-https")]
-    fn http_agent_builder(cert_der: Vec<u8>) -> Result<ureq::AgentBuilder, Error> {
-        use std::sync::Arc;
-
-        use rustls::client::ClientConfig;
-        use rustls::pki_types::CertificateDer;
-        use rustls::RootCertStore;
-        use ureq::AgentBuilder;
-
-        let mut root_cert_store = RootCertStore::empty();
-        root_cert_store.add(CertificateDer::from(cert_der.as_slice()))?;
-        let client_config =
-            ClientConfig::builder().with_root_certificates(root_cert_store).with_no_client_auth();
-        Ok(AgentBuilder::new().tls_config(Arc::new(client_config)))
-    }
 }

--- a/payjoin-defaults/tests/integration.rs
+++ b/payjoin-defaults/tests/integration.rs
@@ -12,16 +12,16 @@ mod v2 {
     use bitcoin::{base64, Amount, FeeRate, OutPoint};
     use bitcoind::bitcoincore_rpc::core_rpc_json::{AddressType, WalletProcessPsbtResult};
     use bitcoind::bitcoincore_rpc::{self, RpcApi};
+    use http::StatusCode;
     use log::{log_enabled, Level};
     use once_cell::sync::{Lazy, OnceCell};
     use payjoin::receive::v2::{Enrolled, Enroller, PayjoinProposal, UncheckedProposal};
     use payjoin::send::RequestBuilder;
     use payjoin::{OhttpKeys, PjUriBuilder, Request, Uri};
+    use reqwest::{Client, ClientBuilder, Error, Response};
     use testcontainers_modules::redis::Redis;
     use testcontainers_modules::testcontainers::clients::Cli;
-    use tokio::task::spawn_blocking;
     use tracing_subscriber::{EnvFilter, FmtSubscriber};
-    use ureq::{Agent, AgentBuilder, Error, Response};
     use url::Url;
 
     static TESTS_TIMEOUT: Lazy<Duration> = Lazy::new(|| Duration::from_secs(20));
@@ -46,13 +46,13 @@ mod v2 {
         let port = find_free_port();
         let directory = Url::parse(&format!("https://localhost:{}", port)).unwrap();
         tokio::select!(
-          _ = init_directory(port, (cert.clone(), key)) => assert!(false, "Directory server is long running"),
-          res = enroll_with_bad_keys(directory, bad_ohttp_keys, cert) => {
-            assert_eq!(
-              res.unwrap_err().into_response().unwrap().content_type(),
-              "application/problem+json"
-            );
-          }
+            _ = init_directory(port, (cert.clone(), key)) => assert!(false, "Directory server is long running"),
+            res = enroll_with_bad_keys(directory, bad_ohttp_keys, cert) => {
+                assert_eq!(
+                    res.unwrap().headers().get("content-type").unwrap(),
+                    "application/problem+json"
+                );
+            }
         );
 
         async fn enroll_with_bad_keys(
@@ -66,9 +66,7 @@ mod v2 {
             let mut bad_enroller =
                 Enroller::from_directory_config(directory, bad_ohttp_keys, mock_ohttp_relay);
             let (req, _ctx) = bad_enroller.extract_req().expect("Failed to extract request");
-            spawn_blocking(move || agent.post(req.url.as_str()).send_bytes(&req.body))
-                .await
-                .expect("Failed to send request")
+            agent.post(req.url).body(req.body).send().await
         }
     }
 
@@ -97,8 +95,12 @@ mod v2 {
             let agent = Arc::new(http_agent(cert_der.clone())?);
             wait_for_service_ready(ohttp_relay.clone(), agent.clone()).await.unwrap();
             wait_for_service_ready(directory.clone(), agent.clone()).await.unwrap();
-            let ohttp_keys =
-                fetch_ohttp_keys(ohttp_relay, directory.clone(), cert_der.clone()).await?;
+            let ohttp_keys = payjoin_defaults::fetch_ohttp_keys(
+                ohttp_relay,
+                directory.clone(),
+                cert_der.clone(),
+            )
+            .await?;
 
             // **********************
             // Inside the Receiver:
@@ -114,24 +116,21 @@ mod v2 {
             let pj_uri = Uri::from_str(&pj_uri_string).unwrap().assume_checked();
             let psbt = build_original_psbt(&sender, &pj_uri)?;
             // debug!("Original psbt: {:#?}", psbt);
-            let (send_req, send_ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
-                .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
-                .extract_v2(directory.to_owned())?; // Mock since we're not
-                                                    // log::info!("send fallback v2");
-                                                    // log::debug!("Request: {:#?}", &send_req.body);
-            let response = {
-                let Request { url, body, .. } = send_req.clone();
-                let agent_clone = agent.clone();
-                spawn_blocking(move || {
-                    agent_clone
-                        .post(url.as_str())
-                        .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
-                        .send_bytes(&body)
-                })
-                .await??
-            };
+            let (Request { url, body, .. }, send_ctx) =
+                RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
+                    .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
+                    .extract_v2(directory.to_owned())?; // Mock since we're not
+                                                        // log::info!("send fallback v2");
+                                                        // log::debug!("Request: {:#?}", &send_req.body);
+            let response = agent
+                .post(url.clone())
+                .header("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
+                .body(body.clone())
+                .send()
+                .await
+                .unwrap();
             log::info!("Response: {:#?}", &response);
-            assert!(is_success(response.status()));
+            assert!(response.status().is_success());
             // no response body yet since we are async and pushed fallback_psbt to the buffer
 
             // **********************
@@ -139,21 +138,14 @@ mod v2 {
 
             // GET fallback psbt
             let (req, ctx) = enrolled.extract_req()?;
-            let agent_clone = agent.clone();
-            let response =
-                spawn_blocking(move || agent_clone.post(req.url.as_str()).send_bytes(&req.body))
-                    .await??;
-
+            let response = agent.post(req.url).body(req.body).send().await?;
             // POST payjoin
-            let proposal = enrolled.process_res(response.into_reader(), ctx)?.unwrap();
+            let proposal =
+                enrolled.process_res(response.bytes().await?.to_vec().as_slice(), ctx)?.unwrap();
             let mut payjoin_proposal = handle_directory_proposal(receiver, proposal);
             let (req, ctx) = payjoin_proposal.extract_v2_req()?;
-            let agent_clone = agent.clone();
-            let response =
-                spawn_blocking(move || agent_clone.post(req.url.as_str()).send_bytes(&req.body))
-                    .await??;
-            let mut res = Vec::new();
-            response.into_reader().read_to_end(&mut res)?;
+            let response = agent.post(req.url).body(req.body).send().await?;
+            let res = response.bytes().await?.to_vec();
             let _response = payjoin_proposal.deserialize_res(res, ctx)?;
             // response should be 204 http
 
@@ -162,13 +154,10 @@ mod v2 {
             // Sender checks, signs, finalizes, extracts, and broadcasts
 
             // Replay post fallback to get the response
-            let agent_clone = agent.clone();
-            let response = spawn_blocking(move || {
-                agent_clone.post(send_req.url.as_str()).send_bytes(&send_req.body)
-            })
-            .await??;
-            let checked_payjoin_proposal_psbt =
-                send_ctx.process_response(&mut response.into_reader())?.unwrap();
+            let response = agent.post(url).body(body).send().await?;
+            let checked_payjoin_proposal_psbt = send_ctx
+                .process_response(&mut response.bytes().await?.to_vec().as_slice())?
+                .unwrap();
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
             log::info!("sent");
@@ -199,11 +188,15 @@ mod v2 {
             cert_der: Vec<u8>,
         ) -> Result<(), BoxError> {
             let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver()?;
-            let agent: Arc<Agent> = Arc::new(http_agent(cert_der.clone())?);
-            wait_for_service_ready(ohttp_relay.clone(), agent.clone()).await.unwrap();
-            wait_for_service_ready(directory.clone(), agent.clone()).await.unwrap();
-            let ohttp_keys =
-                fetch_ohttp_keys(ohttp_relay, directory.clone(), cert_der.clone()).await?;
+            let agent: Arc<Client> = Arc::new(http_agent(cert_der.clone())?);
+            wait_for_service_ready(ohttp_relay.clone(), agent.clone()).await?;
+            wait_for_service_ready(directory.clone(), agent.clone()).await?;
+            let ohttp_keys = payjoin_defaults::fetch_ohttp_keys(
+                ohttp_relay,
+                directory.clone(),
+                cert_der.clone(),
+            )
+            .await?;
 
             let mut enrolled =
                 enroll_with_directory(directory, ohttp_keys.clone(), cert_der.clone()).await?;
@@ -217,41 +210,31 @@ mod v2 {
             let pj_uri = Uri::from_str(&pj_uri_string).unwrap().assume_checked();
             let psbt = build_original_psbt(&sender, &pj_uri)?;
             // debug!("Original psbt: {:#?}", psbt);
-            let (send_req, send_ctx) = RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
-                .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
-                .extract_v1()?;
+            let (Request { url, body, .. }, send_ctx) =
+                RequestBuilder::from_psbt_and_uri(psbt, pj_uri)?
+                    .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
+                    .extract_v1()?;
             log::info!("send fallback v1 to offline receiver fail");
-            let res = {
-                let Request { url, body, .. } = send_req.clone();
-                let agent_clone = agent.clone();
-                spawn_blocking(move || {
-                    agent_clone
-                        .post(url.as_str())
-                        .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
-                        .send_bytes(&body)
-                })
-                .await?
-            };
-            match res {
-                Err(ureq::Error::Status(code, _)) => assert_eq!(code, 503),
-                _ => panic!("Expected response status code 503, found {:?}", res),
-            }
+            let res = agent
+                .post(url.clone())
+                .header("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
+                .body(body.clone())
+                .send()
+                .await;
+            assert!(res.as_ref().unwrap().status() == StatusCode::SERVICE_UNAVAILABLE);
 
             // **********************
             // Inside the Receiver:
-            let agent_clone = agent.clone();
+            let agent_clone: Arc<Client> = agent.clone();
             let receiver_loop = tokio::task::spawn(async move {
+                let agent_clone = agent_clone.clone();
                 let (response, ctx) = loop {
                     let (req, ctx) = enrolled.extract_req().unwrap();
-                    let agent_clone = agent_clone.clone();
-                    let response = spawn_blocking(move || {
-                        agent_clone.post(req.url.as_str()).send_bytes(&req.body)
-                    })
-                    .await??;
+                    let response = agent_clone.post(req.url).body(req.body).send().await?;
 
                     if response.status() == 200 {
                         // debug!("GET'd fallback_psbt");
-                        break (response.into_reader(), ctx);
+                        break (response.bytes().await?.to_vec(), ctx);
                     } else if response.status() == 202 {
                         log::info!(
                             "No response yet for POST payjoin request, retrying some seconds"
@@ -263,18 +246,15 @@ mod v2 {
                     }
                 };
                 // debug!("handle directory response");
-                let proposal = enrolled.process_res(response, ctx).unwrap().unwrap();
+                let proposal = enrolled.process_res(response.as_slice(), ctx).unwrap().unwrap();
                 let mut payjoin_proposal = handle_directory_proposal(receiver, proposal);
                 // Respond with payjoin psbt within the time window the sender is willing to wait
                 // this response would be returned as http response to the sender
                 let (req, ctx) = payjoin_proposal.extract_v2_req().unwrap();
-                let response = spawn_blocking(move || {
-                    agent_clone.post(req.url.as_str()).send_bytes(&req.body)
-                })
-                .await??;
-                let mut res = Vec::new();
-                response.into_reader().read_to_end(&mut res)?;
-                let _response = payjoin_proposal.deserialize_res(res, ctx).unwrap();
+                let response = agent_clone.post(req.url).body(req.body).send().await?;
+                let _response = payjoin_proposal
+                    .deserialize_res(response.bytes().await?.to_vec(), ctx)
+                    .map_err(|e| e.to_string())?;
                 // debug!("Post payjoin_psbt to directory");
                 // assert!(_response.status() == 204);
                 Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
@@ -283,23 +263,17 @@ mod v2 {
             // **********************
             // send fallback v1 to online receiver
             log::info!("send fallback v1 to online receiver should succeed");
-            let response = {
-                let Request { url, body, .. } = send_req.clone();
-                let agent_clone = agent.clone();
-                spawn_blocking(move || {
-                    agent_clone
-                        .post(url.as_str())
-                        .set("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
-                        .send_bytes(&body)
-                        .expect("Failed to send request")
-                })
-                .await?
-            };
+            let response = agent
+                .post(url)
+                .header("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
+                .body(body)
+                .send()
+                .await?;
             log::info!("Response: {:#?}", &response);
-            assert!(is_success(response.status()));
+            assert!(response.status().is_success());
 
-            let checked_payjoin_proposal_psbt =
-                send_ctx.process_response(&mut response.into_reader())?;
+            let res = response.bytes().await?.to_vec();
+            let checked_payjoin_proposal_psbt = send_ctx.process_response(&mut res.as_slice())?;
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
             log::info!("sent");
@@ -329,20 +303,6 @@ mod v2 {
         (cert_der, key_der)
     }
 
-    async fn fetch_ohttp_keys(
-        ohttp_relay: Url,
-        directory: Url,
-        cert_der: Vec<u8>,
-    ) -> Result<payjoin::OhttpKeys, BoxError> {
-        let res = tokio::task::spawn_blocking(move || {
-            payjoin_defaults::fetch_ohttp_keys(ohttp_relay.clone(), directory.clone(), cert_der)
-        })
-        .await
-        .map_err(|e| e.to_string())?
-        .map_err(|e| e.to_string())?;
-        Ok(res)
-    }
-
     async fn enroll_with_directory(
         directory: Url,
         ohttp_keys: OhttpKeys,
@@ -356,12 +316,9 @@ mod v2 {
         );
         let (req, ctx) = enroller.extract_req()?;
         println!("enroll req: {:#?}", &req);
-        let res = spawn_blocking(move || {
-            http_agent(cert_der).unwrap().post(req.url.as_str()).send_bytes(&req.body)
-        })
-        .await??;
-        assert!(is_success(res.status()));
-        Ok(enroller.process_res(res.into_reader(), ctx)?)
+        let response = http_agent(cert_der).unwrap().post(req.url).body(req.body).send().await?;
+        assert!(response.status().is_success());
+        Ok(enroller.process_res(response.bytes().await?.to_vec().as_slice(), ctx)?)
     }
 
     /// The receiver outputs a string to be passed to the sender as a string or QR code
@@ -472,24 +429,18 @@ mod v2 {
         payjoin_proposal
     }
 
-    fn http_agent(cert_der: Vec<u8>) -> Result<Agent, BoxError> {
-        Ok(http_agent_builder(cert_der)?.build())
+    fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxError> {
+        Ok(http_agent_builder(cert_der)?.build()?)
     }
 
-    fn http_agent_builder(cert_der: Vec<u8>) -> Result<AgentBuilder, BoxError> {
-        use rustls::client::ClientConfig;
-        use rustls::pki_types::CertificateDer;
-        use rustls::RootCertStore;
-
-        let mut root_cert_store = RootCertStore::empty();
-        root_cert_store.add(CertificateDer::from(cert_der.as_slice()))?;
-        let client_config =
-            ClientConfig::builder().with_root_certificates(root_cert_store).with_no_client_auth();
-
-        Ok(AgentBuilder::new().tls_config(Arc::new(client_config)))
+    fn http_agent_builder(cert_der: Vec<u8>) -> Result<ClientBuilder, BoxError> {
+        Ok(ClientBuilder::new()
+            .danger_accept_invalid_certs(true)
+            .use_rustls_tls()
+            .add_root_certificate(
+                reqwest::tls::Certificate::from_der(cert_der.as_slice()).unwrap(),
+            ))
     }
-
-    fn is_success(status: u16) -> bool { status >= 200 && status < 300 }
 
     fn find_free_port() -> u16 {
         let listener = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
@@ -498,27 +449,23 @@ mod v2 {
 
     async fn wait_for_service_ready(
         service_url: Url,
-        agent: Arc<Agent>,
+        agent: Arc<Client>,
     ) -> Result<(), &'static str> {
         let health_url = service_url.join("/health").map_err(|_| "Invalid URL")?;
-        let res = spawn_blocking(move || {
-            let start = std::time::Instant::now();
+        let start = std::time::Instant::now();
 
-            while start.elapsed() < *TESTS_TIMEOUT {
-                let request_result = agent.get(health_url.as_str()).call();
+        while start.elapsed() < *TESTS_TIMEOUT {
+            let request_result =
+                agent.get(health_url.as_str()).send().await.map_err(|_| "Bad request")?;
 
-                match request_result {
-                    Ok(response) if response.status() == 200 => return Ok(()),
-                    Err(Error::Status(404, _)) => return Err("Endpoint not found"),
-                    _ => std::thread::sleep(*WAIT_SERVICE_INTERVAL),
-                }
+            match request_result.status() {
+                StatusCode::OK => return Ok(()),
+                StatusCode::NOT_FOUND => return Err("Endpoint not found"),
+                _ => std::thread::sleep(*WAIT_SERVICE_INTERVAL),
             }
+        }
 
-            Err("Timeout waiting for service to be ready")
-        })
-        .await
-        .map_err(|_| "JoinError")?;
-        res
+        Err("Timeout waiting for service to be ready")
     }
 
     fn init_tracing() {

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -39,13 +39,13 @@ payjoin-directory = { path = "../payjoin-directory", features = ["danger-local-h
 ohttp-relay = "0.0.7"
 once_cell = "1"
 rcgen = { version = "0.11" }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rustls = "0.22.2"
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["redis"] }
 tokio = { version = "1.12.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-ureq = "2.9.4"
 
 [package.metadata.docs.rs]
 features = ["send", "receive", "base64", "v2"]    


### PR DESCRIPTION
`reqwest` is a more common library amongst downstream.

Originally, `ureq` was used to support MSRV, but now `reqwest` is MSRV.

This PR takes an opinionated stance to use `async` since all of the downstream libraries I've tried to integrate also do. There's no `into_reader()` on a `reqwest::Response`, so there's some repeated boilerplate to make a conversion into a slice that is `io::Read`.

Consider whether this is sufficiently minimal or otherwise perhaps should use a helper.

fix #237 