### PR TITLE
Contribute even when a sender makes no change

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -374,7 +374,7 @@ impl ProvisionalProposal {
     /// UIH "Unnecessary input heuristic" is one class of heuristics to avoid. We define
     /// UIH1 and UIH2 according to the BlockSci practice
     /// BlockSci UIH1 and UIH2:
-    // if min(out) < min(in) then UIH1 else UIH2
+    // if min(in) > min(out) then UIH1 else UIH2
     // https://eprint.iacr.org/2022/589.pdf
     fn avoid_uih(
         &self,
@@ -403,7 +403,7 @@ impl ProvisionalProposal {
             let candidate_min_out = min(min_original_out_sats, prior_payment_sats + candidate_sats);
             let candidate_min_in = min(min_original_in_sats, candidate_sats);
 
-            if candidate_min_out < candidate_min_in {
+            if candidate_min_in > candidate_min_out {
                 // The candidate avoids UIH2 but conforms to UIH1: Optimal change heuristic.
                 // It implies the smallest output is the sender's change address.
                 return Ok(candidate.1);

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -348,11 +348,8 @@ impl ProvisionalProposal {
     /// Proper coin selection allows payjoin to resemble ordinary transactions.
     /// To ensure the resemblance, a number of heuristics must be avoided.
     ///
-    /// UIH "Unnecessary input heuristic" is one class of them to avoid. We define
-    /// UIH1 and UIH2 according to the BlockSci practice
-    /// BlockSci UIH1 and UIH2:
-    // if min(out) < min(in) then UIH1 else UIH2
-    // https://eprint.iacr.org/2022/589.pdf
+    /// UIH "Unnecessary input heuristic" is avoided for multi-output transactions.
+    /// A simple consolidation is otherwise chosen if available.
     pub fn try_preserving_privacy(
         &self,
         candidate_inputs: HashMap<Amount, OutPoint>,
@@ -365,50 +362,67 @@ impl ProvisionalProposal {
             // This UIH avoidance function supports only
             // many-input, n-output transactions such that n <= 2 for now
             return Err(SelectionError::from(InternalSelectionError::TooManyOutputs));
-        } else if self.payjoin_psbt.outputs.len() == 2 {
-            let min_original_out_sats = self
-                .payjoin_psbt
-                .unsigned_tx
-                .output
-                .iter()
-                .map(|output| output.value)
-                .min()
-                .unwrap_or_else(|| Amount::MAX_MONEY.to_sat());
+        }
 
-            let min_original_in_sats = self
-                .payjoin_psbt
-                .input_pairs()
-                .filter_map(|input| input.previous_txout().ok().map(|txo| txo.value))
-                .min()
-                .unwrap_or_else(|| Amount::MAX_MONEY.to_sat());
-
-            // Assume many-input, two output to select the vout for now
-            let prior_payment_sats =
-                self.payjoin_psbt.unsigned_tx.output[self.owned_vouts[0]].value;
-            for candidate in candidate_inputs {
-                // TODO bound loop by timeout / iterations
-
-                let candidate_sats = candidate.0.to_sat();
-                let candidate_min_out =
-                    min(min_original_out_sats, prior_payment_sats + candidate_sats);
-                let candidate_min_in = min(min_original_in_sats, candidate_sats);
-
-                if candidate_min_out < candidate_min_in {
-                    // The candidate avoids UIH2 but conforms to UIH1: Optimal change heuristic.
-                    // It implies the smallest output is the sender's change address.
-                    return Ok(candidate.1);
-                } else {
-                    // The candidate conforms to UIH2: Unnecessary input
-                    // and could be identified as a potential payjoin
-                    continue;
-                }
-            }
+        if self.payjoin_psbt.outputs.len() == 2 {
+            self.avoid_uih(candidate_inputs)
         } else {
-            return Ok(candidate_inputs.values().next().expect("empty already checked").clone());
+            self.select_first_candidate(candidate_inputs)
+        }
+    }
+
+    /// UIH "Unnecessary input heuristic" is one class of heuristics to avoid. We define
+    /// UIH1 and UIH2 according to the BlockSci practice
+    /// BlockSci UIH1 and UIH2:
+    // if min(out) < min(in) then UIH1 else UIH2
+    // https://eprint.iacr.org/2022/589.pdf
+    fn avoid_uih(
+        &self,
+        candidate_inputs: HashMap<Amount, OutPoint>,
+    ) -> Result<OutPoint, SelectionError> {
+        let min_original_out_sats = self
+            .payjoin_psbt
+            .unsigned_tx
+            .output
+            .iter()
+            .map(|output| output.value)
+            .min()
+            .unwrap_or_else(|| Amount::MAX_MONEY.to_sat());
+
+        let min_original_in_sats = self
+            .payjoin_psbt
+            .input_pairs()
+            .filter_map(|input| input.previous_txout().ok().map(|txo| txo.value))
+            .min()
+            .unwrap_or_else(|| Amount::MAX_MONEY.to_sat());
+
+        let prior_payment_sats = self.payjoin_psbt.unsigned_tx.output[self.owned_vouts[0]].value;
+
+        for candidate in candidate_inputs {
+            let candidate_sats = candidate.0.to_sat();
+            let candidate_min_out = min(min_original_out_sats, prior_payment_sats + candidate_sats);
+            let candidate_min_in = min(min_original_in_sats, candidate_sats);
+
+            if candidate_min_out < candidate_min_in {
+                // The candidate avoids UIH2 but conforms to UIH1: Optimal change heuristic.
+                // It implies the smallest output is the sender's change address.
+                return Ok(candidate.1);
+            }
         }
 
         // No suitable privacy preserving selection found
         Err(SelectionError::from(InternalSelectionError::NotFound))
+    }
+
+    fn select_first_candidate(
+        &self,
+        candidate_inputs: HashMap<Amount, OutPoint>,
+    ) -> Result<OutPoint, SelectionError> {
+        candidate_inputs
+            .values()
+            .next()
+            .cloned()
+            .ok_or_else(|| SelectionError::from(InternalSelectionError::NotFound))
     }
 
     pub fn contribute_witness_input(&mut self, txo: TxOut, outpoint: OutPoint) {

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -382,7 +382,7 @@ impl ProvisionalProposal {
     /// UIH "Unnecessary input heuristic" is one class of them to avoid. We define
     /// UIH1 and UIH2 according to the BlockSci practice
     /// BlockSci UIH1 and UIH2:
-    // if min(out) < min(in) then UIH1 else UIH2
+    // if min(in) > min(out) then UIH1 else UIH2
     // https://eprint.iacr.org/2022/589.pdf
     pub fn try_preserving_privacy(
         &self,

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -62,6 +62,11 @@ pub struct RequestBuilder<'a> {
     uri: PjUri<'a>,
     disable_output_substitution: bool,
     fee_contribution: Option<(bitcoin::Amount, Option<usize>)>,
+    /// Decreases the fee contribution instead of erroring.
+    ///
+    /// If this option is true and a transaction with change amount lower than fee
+    /// contribution is provided then instead of returning error the fee contribution will
+    /// be just lowered in the request to match the change amount.
     clamp_fee_contribution: bool,
     min_fee_rate: FeeRate,
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -118,7 +118,7 @@ impl<'a> RequestBuilder<'a> {
         if self.psbt.unsigned_tx.output.len() == 1
             && payout_scripts.all(|script| script == self.psbt.unsigned_tx.output[0].script_pubkey)
         {
-            return self.build_non_incentivizing();
+            return self.build_non_incentivizing(min_fee_rate);
         }
 
         if let Some((additional_fee_index, fee_available)) = self
@@ -167,7 +167,7 @@ impl<'a> RequestBuilder<'a> {
                 false,
             );
         }
-        self.build_non_incentivizing()
+        self.build_non_incentivizing(min_fee_rate)
     }
 
     /// Offer the receiver contribution to pay for his input.
@@ -200,12 +200,15 @@ impl<'a> RequestBuilder<'a> {
     ///
     /// While it's generally better to offer some contribution some users may wish not to.
     /// This function disables contribution.
-    pub fn build_non_incentivizing(mut self) -> Result<RequestContext, CreateRequestError> {
+    pub fn build_non_incentivizing(
+        mut self,
+        min_fee_rate: FeeRate,
+    ) -> Result<RequestContext, CreateRequestError> {
         // since this is a builder, these should already be cleared
         // but we'll reset them to be sure
         self.fee_contribution = None;
         self.clamp_fee_contribution = false;
-        self.min_fee_rate = FeeRate::ZERO;
+        self.min_fee_rate = min_fee_rate;
         self.build()
     }
 

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -113,6 +113,14 @@ impl<'a> RequestBuilder<'a> {
         // TODO support optional batched payout scripts. This would require a change to
         // build() which now checks for a single payee.
         let mut payout_scripts = std::iter::once(self.uri.address.script_pubkey());
+
+        // Check if the PSBT is a sweep transaction with only one output that's a payout script and no change
+        if self.psbt.unsigned_tx.output.len() == 1
+            && payout_scripts.all(|script| script == self.psbt.unsigned_tx.output[0].script_pubkey)
+        {
+            return self.build_non_incentivizing();
+        }
+
         if let Some((additional_fee_index, fee_available)) = self
             .psbt
             .unsigned_tx

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -404,7 +404,7 @@ mod integration {
                     .unwrap();
                 let psbt = build_sweep_psbt(&sender, &pj_uri)?;
                 let mut req_ctx = RequestBuilder::from_psbt_and_uri(psbt.clone(), pj_uri.clone())?
-                    .build_non_incentivizing()?;
+                    .build_recommended(payjoin::bitcoin::FeeRate::BROADCAST_MIN)?;
                 let (Request { url, body, .. }, send_ctx) =
                     req_ctx.extract_v2(directory.to_owned())?;
                 let response = agent


### PR DESCRIPTION
A pure consolidation does not suffer from Unnecessary Input Heuristic. A Payjoin consolidation without sender change still breaks Common Input Heuristic. Allow it.

---

This is incomplete because the UIH checking should not be happening if only a consolidation is to occur. That does not suffer from change interpretation nor unnecessary input issues because there is no change to interpret, just a single output funded by all necessary inputs.

Supporting sweeps themselves introduce NO API change. It only allows a payjoin to be created with exactly 1 output paying the receiver.

HOWEVER I have taken the liberty to change `RequestBuilder::build_non_incentivising` to take a min_fee_rate as parameter. Without this, a sender could sign and broadcast transactions that have no chance of being mined. I've seen a persistent mempool for months!

These are [my notes on Unnecessary Input Heuristic](https://gist.github.com/DanGould/7af261a5e6dfabb52eef304ecd0f579b) that a reviewer may find helpful in understanding the constraints of the `try_preserving_privacy` function modified here.

This ability ~should be~ is tested with both a sender / receiver integration test and data to show that these types of transactions might be ambiguous with existing payment activity (self spends or sweeps to others)

## Data:

As of Jul 8, 2024, Out of Blockchair's 1,037,565,391 transactions, 53,232,056 of them
- Have 2 or more inputs
- Have exactly 1 non-zero output (i.e. not OP_RETURN)
- Are not coinbase transactions
 transactions that are not Coinbase transactions have exactly one output with a non-zero amount.

This means approximately 5.13% of all transactions are sweeps that might suffer from Common-input heuristic.

Source monetary non-coinbase transactions count: https://blockchair.com/bitcoin/transactions?q=is_coinbase(false)#f=hash,is_coinbase,time

source sweeps: https://blockchair.com/bitcoin/transactions?s=time(desc)&q=output_count(1),is_coinbase(false),fee(1..),input_count(2..),output_total(1..)#f=hash,time,output_total,fee,is_coinbase,output_count,block_id,input_count

Of the transactions in the past year, since height 797844

There have been 175,639,552 transactions and 8,080,966 of them
- Have 2 or more inputs
- Have exactly 1 non-zero output (i.e. not OP_RETURN)
- Are not coinbase transactions

This means approximately 4.57% of all non-coinbase transactions in the past year are sweeps that might suffer from common input heuristic.

source all non-coinbase: https://blockchair.com/bitcoin/transactions?s=time(desc)&q=is_coinbase(false),fee(1..),block_id(797844..)#f=hash,time,output_total,is_coinbase,block_id,fee,input_count,output_count

source sweeps: https://blockchair.com/bitcoin/transactions?s=time(desc)&q=output_count(1),is_coinbase(false),fee(1..),input_count(2..),output_total(1..),block_id(797844..)#f=hash,time,output_total,is_coinbase,block_id,fee,input_count,output_count