### PR TITLE
Bump ohttp-relay dev-dep even

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,29 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "ohttp-relay"
-version = "0.0.4"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddab3de76fbc6c40de9ff3abc9bbad398ae3ce247e9fdf579fa42a69d078c76f"
-dependencies = [
- "futures",
- "http 1.1.0",
- "http-body-util",
- "hyper 1.2.0",
- "hyper-rustls 0.26.0",
- "hyper-tungstenite",
- "hyper-util",
- "once_cell",
- "rustls 0.22.3",
- "tokio",
- "tokio-tungstenite",
- "tokio-util",
-]
-
-[[package]]
-name = "ohttp-relay"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b0473bd279cdfaf5983a15fa3d2d7e1826b0cd041f0fc51eb10af901a8bf94"
+checksum = "7850c40a0aebcba289d3252c0a45f93cba6ad4b0c46b88a5fc51dba6ddce8632"
 dependencies = [
  "futures",
  "http 1.1.0",
@@ -1669,7 +1649,7 @@ dependencies = [
  "http 1.1.0",
  "log",
  "ohttp 0.5.1",
- "ohttp-relay 0.0.7",
+ "ohttp-relay",
  "once_cell",
  "payjoin-directory",
  "rand",
@@ -1702,7 +1682,7 @@ dependencies = [
  "hyper 0.14.28",
  "hyper-rustls 0.25.0",
  "log",
- "ohttp-relay 0.0.4",
+ "ohttp-relay",
  "payjoin",
  "payjoin-defaults",
  "rcgen",
@@ -1721,7 +1701,7 @@ dependencies = [
  "bitcoind",
  "http 1.1.0",
  "log",
- "ohttp-relay 0.0.7",
+ "ohttp-relay",
  "once_cell",
  "payjoin",
  "payjoin-directory",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -45,5 +45,5 @@ url = { version = "2.3.1", features = ["serde"] }
 [dev-dependencies]
 bitcoind = { version = "0.31.1", features = ["0_21_2"] }
 http = "1"
-ohttp-relay = "0.0.4"
+ohttp-relay = "0.0.8"
 tokio = { version = "1.12.0", features = ["full"] }

--- a/payjoin-defaults/Cargo.toml
+++ b/payjoin-defaults/Cargo.toml
@@ -24,7 +24,7 @@ bitcoin = { version = "0.30.0", features = ["base64"] }
 bitcoind = { version = "0.31.1", features = ["0_21_2"] }
 http = "1"
 log = { version = "0.4.14"}
-ohttp-relay = "0.0.7"
+ohttp-relay = "0.0.8"
 once_cell = "1"
 payjoin-directory = { path = "../payjoin-directory", features = ["danger-local-https"] }
 rcgen = { version = "0.11" }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.108"
 bitcoind = { version = "0.31.1", features = ["0_21_2"] }
 http = "1"
 payjoin-directory = { path = "../payjoin-directory", features = ["danger-local-https"] }
-ohttp-relay = "0.0.7"
+ohttp-relay = "0.0.8"
 once_cell = "1"
 rcgen = { version = "0.11" }
 rustls = "0.22.2"


### PR DESCRIPTION
All other locations depend on 0.0.8 and that's compatible too.