### PR TITLE
Depend on bitcoin/rand for rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,7 +1672,6 @@ dependencies = [
  "ohttp-relay 0.0.7",
  "once_cell",
  "payjoin-directory",
- "rand",
  "rcgen",
  "rustls 0.22.3",
  "serde",

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -16,9 +16,9 @@ exclude = ["tests"]
 
 [features]
 send = []
-receive = ["rand"]
+receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand-std", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde"]
+v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde"]
 
 [dependencies]
 bitcoin = { version = "0.30.0", features = ["base64"] }
@@ -27,7 +27,6 @@ chacha20poly1305 = { version = "0.10.1", optional = true }
 log = { version = "0.4.14"}
 ohttp = { version = "0.5.1", optional = true }
 bhttp = { version = "0.5.1", optional = true }
-rand = { version = "0.8.4", optional = true }
 serde = { version = "1.0.186", default-features = false, optional = true }
 url = "2.2.2"
 serde_json = "1.0.108"

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -35,11 +35,11 @@ mod optional_parameters;
 #[cfg(feature = "v2")]
 pub mod v2;
 
+use bitcoin::secp256k1::rand::seq::SliceRandom;
+use bitcoin::secp256k1::rand::{self, Rng};
 pub use error::{Error, RequestError, SelectionError};
 use error::{InternalRequestError, InternalSelectionError};
 use optional_parameters::Params;
-use rand::seq::SliceRandom;
-use rand::Rng;
 
 use crate::input_type::InputType;
 use crate::psbt::PsbtExt;

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use bitcoin::psbt::Psbt;
+use bitcoin::secp256k1::rand;
 use bitcoin::{base64, Amount, FeeRate, OutPoint, Script, TxOut};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -29,6 +29,8 @@ use std::str::FromStr;
 use bitcoin::address::NetworkChecked;
 use bitcoin::psbt::Psbt;
 #[cfg(feature = "v2")]
+use bitcoin::secp256k1::rand;
+#[cfg(feature = "v2")]
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::{FeeRate, Script, ScriptBuf, Sequence, TxOut, Weight};
 pub use error::{CreateRequestError, ResponseError, ValidationError};


### PR DESCRIPTION
Rand is already available in secp256k1/rand transiently through rust bitcoin. rand-std is also an option to for std environments but having wide support seems more important in the near term than adding all of those feature flags.

This should fix https://github.com/payjoin/rust-payjoin/issues/258 which may have been triggering in an environment where bitcoin/rand was not available.