### PR TITLE
payjoin-cli: Add version

### DIFF
--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -40,7 +40,9 @@ async fn main() -> Result<()> {
 }
 
 fn cli() -> ArgMatches {
-    Command::new("payjoin")
+    let version = env!("CARGO_PKG_VERSION");
+    Command::new("payjoin-cli")
+        .version(version)
         .about("Payjoin - bitcoin scaling, savings, and privacy by default")
         .arg(Arg::new("rpchost")
             .long("rpchost")

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -40,9 +40,8 @@ async fn main() -> Result<()> {
 }
 
 fn cli() -> ArgMatches {
-    let version = env!("CARGO_PKG_VERSION");
-    Command::new("payjoin-cli")
-        .version(version)
+    Command::new("payjoin")
+        .version(env!("CARGO_PKG_VERSION"))
         .about("Payjoin - bitcoin scaling, savings, and privacy by default")
         .arg(Arg::new("rpchost")
             .long("rpchost")


### PR DESCRIPTION
Adds ability to get the version from `payjoin-cli` which will be really helpful for people debugging errors/in tutorials. `--help` option now has:

```
  -V, --version                    Print version information
```