### PR TITLE
Depend on reqwest/rustls-tls for HTTPS-in-HTTPS bootstrap

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -19,7 +19,7 @@ send = []
 receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
 v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde"]
-io = ["reqwest"]
+io = ["reqwest/rustls-tls"]
 danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
 [dependencies]


### PR DESCRIPTION
`fetch_ohttp_keys` relies on an HTTP CONNECT method that tunnels an encrypted HTTPS request. This was broken in fixing #237 because reqwest must depend on `reqwest/rustls-tls` in order to establish this tunnel.

This change should be accompanied by a test, which would require hosting the `ohttp_relay` behind a TLS certificate in testing, perhaps via a `danger-local-https` feature in that crate akin to the one in `payjoin-directory`. We could also use a reverse proxy to do TLS termination just within the tests, which would be a more clean single-use-principle design.