### PR TITLE
Prepare Payjoin PSBT with no output keypaths

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -25,7 +25,7 @@
 //! [reference implementation](https://github.com/payjoin/rust-payjoin/tree/master/payjoin-cli)
 
 use std::cmp::{max, min};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use bitcoin::psbt::Psbt;
 use bitcoin::{base64, Amount, FeeRate, OutPoint, Script, TxOut};
@@ -540,15 +540,15 @@ impl ProvisionalProposal {
         self.payjoin_psbt = processed_psbt;
         log::trace!("Preparing PSBT {:#?}", self.payjoin_psbt);
         for output in self.payjoin_psbt.outputs_mut() {
-            output.bip32_derivation = BTreeMap::new();
-            output.tap_key_origins = BTreeMap::new();
+            output.bip32_derivation.clear();
+            output.tap_key_origins.clear();
             output.tap_internal_key = None;
         }
         for input in self.payjoin_psbt.inputs_mut() {
-            input.bip32_derivation = BTreeMap::new();
-            input.tap_key_origins = BTreeMap::new();
+            input.bip32_derivation.clear();
+            input.tap_key_origins.clear();
             input.tap_internal_key = None;
-            input.partial_sigs = BTreeMap::new();
+            input.partial_sigs.clear();
         }
         for i in self.sender_input_indexes() {
             log::trace!("Clearing sender input {}", i);

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -539,8 +539,15 @@ impl ProvisionalProposal {
     fn prepare_psbt(mut self, processed_psbt: Psbt) -> Result<PayjoinProposal, RequestError> {
         self.payjoin_psbt = processed_psbt;
         log::trace!("Preparing PSBT {:#?}", self.payjoin_psbt);
+        for output in self.payjoin_psbt.outputs_mut() {
+            output.bip32_derivation = BTreeMap::new();
+            output.tap_key_origins = BTreeMap::new();
+            output.tap_internal_key = None;
+        }
         for input in self.payjoin_psbt.inputs_mut() {
             input.bip32_derivation = BTreeMap::new();
+            input.tap_key_origins = BTreeMap::new();
+            input.tap_internal_key = None;
             input.partial_sigs = BTreeMap::new();
         }
         for i in self.sender_input_indexes() {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -177,7 +177,7 @@ mod integration {
                                 &bitcoin::base64::encode(psbt.serialize()),
                                 None,
                                 None,
-                                Some(false),
+                                Some(true), // check that the receiver properly clears keypaths
                             )
                             .map(|res: WalletProcessPsbtResult| {
                                 let psbt = Psbt::from_str(&res.psbt).unwrap();
@@ -690,7 +690,7 @@ mod integration {
                                 &bitcoin::base64::encode(psbt.serialize()),
                                 None,
                                 None,
-                                Some(false),
+                                Some(true), // check that the receiver properly clears keypaths
                             )
                             .map(|res: WalletProcessPsbtResult| {
                                 let psbt = Psbt::from_str(&res.psbt).unwrap();
@@ -805,7 +805,7 @@ mod integration {
                     &outputs,
                     None, // locktime
                     Some(options),
-                    None,
+                    Some(true), // check that the sender properly clears keypaths
                 )?
                 .psbt;
             let psbt = sender.wallet_process_psbt(&psbt, None, None, None)?.psbt;


### PR DESCRIPTION
The BIP78 sender checklist "Verif[ies] that no keypaths is in the PSBT output," and this check was failing with our receiver.

This change ensures that check is satisfied.

---

https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#user-content-Senders_payjoin_proposal_checklist