### PR TITLE
Separate v1 `pj_endpoint` and v2 `pj_directory` config params / cli arguments

### DIFF
--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -47,7 +47,7 @@ In addition to the rpc configuration above, specify relevant ohttp and payjoin d
 # config.toml
 ...
 # a production payjoin directory server
-pj_endpoint="https://payjo.in"
+pj_directory="https://payjo.in"
 # payjo.in's ohttp_keys can now be fetched rather than configured ahead of time
  # an ohttp relay with ingress to payjo.in
 ohttp_relay="https://pj.bobspacebkk.com"

--- a/payjoin-cli/example.config.toml
+++ b/payjoin-cli/example.config.toml
@@ -36,8 +36,16 @@ bitcoind_rpcpassword="password"
 ## ----------------
 
 
-# The payjoin endpoint which coordinates the transaction. In v2, this is the payjoin directory.
-pj_endpoint="https://payjo.in"
+# (v1, receiver only) The port for v1 receiving servers to bind to.
+port="3000"
+
+
+# (v1, receiver only) The payjoin endpoint which coordinates the transaction.
+pj_endpoint="https://localhost:3000"
+
+
+# (v2 only) The payjoin directory to rendezvous at.
+pj_directory = "https://payjo.in"
 
 
 # (v2 only) The OHTTP relay that will forward requests to the OHTTP Gateway, which will forward to the pj_endpoint directory.
@@ -47,7 +55,3 @@ ohttp_relay="https://pj.bobspacebkk.com"
 # (v2 only, optional) The HPKE keys which need to be fetched ahead of time from the pj_endpoint for the payjoin packets to be encrypted.
 # These can now be fetched and no longer need to be configured.
 ohttp_keys="AQAg3c9qovMZvPzLh8XHgD8q86WG7SmPQvPamCTvEoueKBsABAABAAM"
-
-
-# (v1, receiver only) The port for v1 receiving servers to bind to.
-port="3000"

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -79,7 +79,7 @@ impl AppConfig {
 
                 builder.set_override_option(
                     "pj_endpoint",
-                    matches.get_one::<Url>("endpoint").map(|s| s.as_str()),
+                    matches.get_one::<Url>("pj_endpoint").map(|s| s.as_str()),
                 )?
             }
             _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -59,10 +59,6 @@ impl AppConfig {
         #[cfg(feature = "v2")]
         let builder = builder
             .set_override_option(
-                "ohttp_keys",
-                matches.get_one::<String>("ohttp_keys").map(|s| s.as_str()),
-            )?
-            .set_override_option(
                 "ohttp_relay",
                 matches.get_one::<Url>("ohttp_relay").map(|s| s.as_str()),
             )?
@@ -88,10 +84,15 @@ impl AppConfig {
 
                 #[cfg(feature = "v2")]
                 let builder = {
-                    builder.set_override_option(
-                        "pj_directory",
-                        matches.get_one::<Url>("pj_directory").map(|s| s.as_str()),
-                    )?
+                    builder
+                        .set_override_option(
+                            "pj_directory",
+                            matches.get_one::<Url>("pj_directory").map(|s| s.as_str()),
+                        )?
+                        .set_override_option(
+                            "ohttp_keys",
+                            matches.get_one::<String>("ohttp_keys").map(|s| s.as_str()),
+                        )?
                 };
 
                 builder

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -77,7 +77,7 @@ impl AppTrait for App {
         let ohttp_keys = unwrap_ohttp_keys_or_else_fetch(&self.config).await?;
         let mut enrolled = if !is_retry {
             let mut enroller = Enroller::from_directory_config(
-                self.config.pj_endpoint.clone(),
+                self.config.pj_directory.clone(),
                 ohttp_keys.clone(),
                 self.config.ohttp_relay.clone(),
             );
@@ -147,7 +147,7 @@ impl App {
         let pj_receiver_address = self.bitcoind()?.get_new_address(None, None)?.assume_checked();
         let amount = Amount::from_sat(amount_arg.parse()?);
         let pj_part = payjoin::Url::parse(fallback_target)
-            .map_err(|e| anyhow!("Failed to parse pj_endpoint: {}", e))?;
+            .map_err(|e| anyhow!("Failed to parse Payjoin subdirectory target: {}", e))?;
 
         let pj_uri = PjUriBuilder::new(pj_receiver_address, pj_part, Some(ohttp_keys))
             .amount(amount)
@@ -309,7 +309,7 @@ async fn unwrap_ohttp_keys_or_else_fetch(config: &AppConfig) -> Result<payjoin::
         Ok(keys)
     } else {
         let ohttp_relay = config.ohttp_relay.clone();
-        let payjoin_directory = config.pj_endpoint.clone();
+        let payjoin_directory = config.pj_directory.clone();
         #[cfg(feature = "danger-local-https")]
         let cert_der = rcgen::generate_simple_self_signed(vec![
             "0.0.0.0".to_string(),

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -121,6 +121,14 @@ fn cli() -> ArgMatches {
                         .num_args(1)
                         .help("The `pj=` endpoint to receive the payjoin request")
                         .value_parser(value_parser!(Url)),
+                )
+                .arg(
+                    Arg::new("pj_directory")
+                        .long("pj_directory")
+                        .short('d')
+                        .num_args(1)
+                        .help("The directory to store payjoin requests")
+                        .value_parser(value_parser!(Url)),
                 ),
         )
         .get_matches()

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -115,8 +115,8 @@ fn cli() -> ArgMatches {
                         .help("The local port to listen on"),
                 )
                 .arg(
-                    Arg::new("endpoint")
-                        .long("endpoint")
+                    Arg::new("pj_endpoint")
+                        .long("pj_endpoint")
                         .short('e')
                         .num_args(1)
                         .help("The `pj=` endpoint to receive the payjoin request")

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -62,7 +62,7 @@ mod e2e {
             .arg(RECEIVE_SATS)
             .arg("--port")
             .arg(&port.to_string())
-            .arg("--endpoint")
+            .arg("--pj_endpoint")
             .arg(&pj_endpoint)
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())


### PR DESCRIPTION
- Separate pj_endpoint from pj_directory for v1 and v2 respectively. They're totally different program inputs.
- Conditionally compile the appropriate config building
- Set defaults that are only appropriate in the context of a subcommand in that subcommand