### PR TITLE
Improve payjoin-cli ergonomics

### DIFF
--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -98,7 +98,7 @@ pub trait App {
             .bitcoind()?
             .send_raw_transaction(&tx)
             .with_context(|| "Failed to send raw transaction")?;
-        println!("Payjoin sent: {}", txid);
+        println!("Payjoin sent. TXID: {}", txid);
         Ok(txid)
     }
 }

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -176,6 +176,7 @@ impl App {
                 Err(re) => {
                     println!("{}", re);
                     log::debug!("{:?}", re);
+                    return Err(anyhow!("Response error").context(re))
                 }
             }
         }


### PR DESCRIPTION
- Don't keep polling if the server returns an unrecoverable error
- Print information to keep track of progress

This doesn't reckon with async `--retry` flows yet but sets the groundwork to do that properly, too.