### PR TITLE
Refactor output substitution

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -309,14 +309,15 @@ impl App {
         _ = try_contributing_inputs(&mut provisional_payjoin, &bitcoind)
             .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
 
-        if !provisional_payjoin.is_output_substitution_disabled() {
-            // Substitute the receiver output address.
-            let receiver_substitute_address = bitcoind
-                .get_new_address(None, None)
-                .map_err(|e| Error::Server(e.into()))?
-                .assume_checked();
-            provisional_payjoin.substitute_output_address(receiver_substitute_address);
-        }
+        _ = provisional_payjoin
+            .try_substituting_output_address(|| {
+                bitcoind
+                    .get_new_address(None, None)
+                    .map_err(|e| Error::Server(e.into()))?
+                    .require_network(network)
+                    .map_err(|e| Error::Server(e.into()))
+            })
+            .map_err(|e| log::warn!("Failed to substitute output address: {}", e));
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -310,14 +310,15 @@ impl App {
             .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
 
         _ = provisional_payjoin
-            .try_substituting_output_address(|| {
-                bitcoind
+            .try_substitute_receiver_output(|| {
+                Ok(bitcoind
                     .get_new_address(None, None)
                     .map_err(|e| Error::Server(e.into()))?
                     .require_network(network)
-                    .map_err(|e| Error::Server(e.into()))
+                    .map_err(|e| Error::Server(e.into()))?
+                    .script_pubkey())
             })
-            .map_err(|e| log::warn!("Failed to substitute output address: {}", e));
+            .map_err(|e| log::warn!("Failed to substitute output: {}", e));
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -306,14 +306,15 @@ impl App {
             .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
 
         _ = provisional_payjoin
-            .try_substituting_output_address(|| {
-                bitcoind
+            .try_substitute_receiver_output(|| {
+                Ok(bitcoind
                     .get_new_address(None, None)
                     .map_err(|e| Error::Server(e.into()))?
                     .require_network(network)
-                    .map_err(|e| Error::Server(e.into()))
+                    .map_err(|e| Error::Server(e.into()))?
+                    .script_pubkey())
             })
-            .map_err(|e| log::warn!("Failed to substitute output address: {}", e));
+            .map_err(|e| log::warn!("Failed to substitute output: {}", e));
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -305,17 +305,6 @@ impl App {
         _ = try_contributing_inputs(&mut provisional_payjoin.inner, &bitcoind)
             .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
 
-        _ = provisional_payjoin
-            .try_substitute_receiver_output(|| {
-                Ok(bitcoind
-                    .get_new_address(None, None)
-                    .map_err(|e| Error::Server(e.into()))?
-                    .require_network(network)
-                    .map_err(|e| Error::Server(e.into()))?
-                    .script_pubkey())
-            })
-            .map_err(|e| log::warn!("Failed to substitute output: {}", e));
-
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {
                 bitcoind

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -305,14 +305,15 @@ impl App {
         _ = try_contributing_inputs(&mut provisional_payjoin.inner, &bitcoind)
             .map_err(|e| log::warn!("Failed to contribute inputs: {}", e));
 
-        if !provisional_payjoin.is_output_substitution_disabled() {
-            // Substitute the receiver output address.
-            let receiver_substitute_address = bitcoind
-                .get_new_address(None, None)
-                .map_err(|e| Error::Server(e.into()))?
-                .assume_checked();
-            provisional_payjoin.substitute_output_address(receiver_substitute_address);
-        }
+        _ = provisional_payjoin
+            .try_substituting_output_address(|| {
+                bitcoind
+                    .get_new_address(None, None)
+                    .map_err(|e| Error::Server(e.into()))?
+                    .require_network(network)
+                    .map_err(|e| Error::Server(e.into()))
+            })
+            .map_err(|e| log::warn!("Failed to substitute output address: {}", e));
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -477,10 +477,18 @@ impl ProvisionalProposal {
         self.params.disable_output_substitution
     }
 
-    /// Just replace an output address with
-    pub fn substitute_output_address(&mut self, substitute_address: bitcoin::Address) {
+    /// If output substitution is enabled, replace the receiver's output address with a new one.
+    pub fn try_substituting_output_address(
+        &mut self,
+        generate_address: impl Fn() -> Result<bitcoin::Address, Error>,
+    ) -> Result<(), Error> {
+        if self.params.disable_output_substitution {
+            return Err(Error::Server("Output substitution is disabled.".into()));
+        }
+        let substitute_address = generate_address()?;
         self.payjoin_psbt.unsigned_tx.output[self.owned_vouts[0]].script_pubkey =
             substitute_address.script_pubkey();
+        Ok(())
     }
 
     /// Apply additional fee contribution now that the receiver has contributed input

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -477,17 +477,16 @@ impl ProvisionalProposal {
         self.params.disable_output_substitution
     }
 
-    /// If output substitution is enabled, replace the receiver's output address with a new one.
-    pub fn try_substituting_output_address(
+    /// If output substitution is enabled, replace the receiver's output script with a new one.
+    pub fn try_substitute_receiver_output(
         &mut self,
-        generate_address: impl Fn() -> Result<bitcoin::Address, Error>,
+        generate_script: impl Fn() -> Result<bitcoin::ScriptBuf, Error>,
     ) -> Result<(), Error> {
         if self.params.disable_output_substitution {
             return Err(Error::Server("Output substitution is disabled.".into()));
         }
-        let substitute_address = generate_address()?;
-        self.payjoin_psbt.unsigned_tx.output[self.owned_vouts[0]].script_pubkey =
-            substitute_address.script_pubkey();
+        let substitute_script = generate_script()?;
+        self.payjoin_psbt.unsigned_tx.output[self.owned_vouts[0]].script_pubkey = substitute_script;
         Ok(())
     }
 

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -387,12 +387,12 @@ impl ProvisionalProposal {
         self.inner.is_output_substitution_disabled()
     }
 
-    /// If output substitution is enabled, replace the receiver's output address with a new one.
-    pub fn try_substituting_output_address(
+    /// If output substitution is enabled, replace the receiver's output script with a new one.
+    pub fn try_substitute_receiver_output(
         &mut self,
-        generate_address: impl Fn() -> Result<bitcoin::Address, Error>,
+        generate_script: impl Fn() -> Result<bitcoin::ScriptBuf, Error>,
     ) -> Result<(), Error> {
-        self.inner.try_substituting_output_address(generate_address)
+        self.inner.try_substitute_receiver_output(generate_script)
     }
 
     pub fn finalize_proposal(

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -387,9 +387,12 @@ impl ProvisionalProposal {
         self.inner.is_output_substitution_disabled()
     }
 
-    /// Just replace an output address with
-    pub fn substitute_output_address(&mut self, substitute_address: bitcoin::Address) {
-        self.inner.substitute_output_address(substitute_address)
+    /// If output substitution is enabled, replace the receiver's output address with a new one.
+    pub fn try_substituting_output_address(
+        &mut self,
+        generate_address: impl Fn() -> Result<bitcoin::Address, Error>,
+    ) -> Result<(), Error> {
+        self.inner.try_substituting_output_address(generate_address)
     }
 
     pub fn finalize_proposal(

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -170,9 +170,9 @@ mod integration {
                 bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
             payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
-            let receiver_substitute_address =
-                receiver.get_new_address(None, None).unwrap().assume_checked();
-            payjoin.substitute_output_address(receiver_substitute_address);
+            _ = payjoin.try_substituting_output_address(|| {
+                Ok(receiver.get_new_address(None, None).unwrap().assume_checked())
+            });
             let payjoin_proposal = payjoin
                 .finalize_proposal(
                     |psbt: &Psbt| {
@@ -699,9 +699,9 @@ mod integration {
                 bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
             payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
-            let receiver_substitute_address =
-                receiver.get_new_address(None, None).unwrap().assume_checked();
-            payjoin.substitute_output_address(receiver_substitute_address);
+            _ = payjoin.try_substituting_output_address(|| {
+                Ok(receiver.get_new_address(None, None).unwrap().assume_checked())
+            });
             let payjoin_proposal = payjoin
                 .finalize_proposal(
                     |psbt: &Psbt| {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -170,8 +170,8 @@ mod integration {
                 bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
             payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
-            _ = payjoin.try_substituting_output_address(|| {
-                Ok(receiver.get_new_address(None, None).unwrap().assume_checked())
+            _ = payjoin.try_substitute_receiver_output(|| {
+                Ok(receiver.get_new_address(None, None).unwrap().assume_checked().script_pubkey())
             });
             let payjoin_proposal = payjoin
                 .finalize_proposal(
@@ -699,8 +699,8 @@ mod integration {
                 bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
             payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
-            _ = payjoin.try_substituting_output_address(|| {
-                Ok(receiver.get_new_address(None, None).unwrap().assume_checked())
+            _ = payjoin.try_substitute_receiver_output(|| {
+                Ok(receiver.get_new_address(None, None).unwrap().assume_checked().script_pubkey())
             });
             let payjoin_proposal = payjoin
                 .finalize_proposal(


### PR DESCRIPTION
As per discussion in https://github.com/payjoin/rust-payjoin/pull/239#issuecomment-2089097964, never allow output substitution if `disable_output_substitution` is true.

Consider whether there should be a custom `SubstituteOutputError` type, similar to `SelectionError`.