### PR TITLE
Read v2 pj_directory, not v1 pj_endpoint

### DIFF
--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -84,7 +84,7 @@ impl AppTrait for App {
             );
             let (req, ctx) =
                 enroller.extract_req().map_err(|e| anyhow!("Failed to extract request {}", e))?;
-            println!("Starting new Payjoin session with {}", self.config.pj_endpoint);
+            println!("Starting new Payjoin session with {}", self.config.pj_directory);
             let http = http_agent()?;
             let ohttp_response = http
                 .post(req.url)


### PR DESCRIPTION
#275 accidentally referenced an old config and failed CI. This fixes that