### PR TITLE
Handle response status

### DIFF
--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -130,7 +130,7 @@ impl AppTrait for App {
             .await
             .map_err(map_reqwest_err)?;
         let _res = payjoin_proposal
-            .deserialize_res(res.bytes().await?.to_vec(), ohttp_ctx)
+            .process_res(res.bytes().await?.to_vec(), ohttp_ctx)
             .map_err(|e| anyhow!("Failed to deserialize response {}", e))?;
         let payjoin_psbt = payjoin_proposal.psbt().clone();
         println!(

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["tests"]
 send = []
 receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "ohttp", "bhttp", "serde", "url/serde"]
+v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "dep:http", "bhttp", "ohttp", "serde", "url/serde"]
 io = ["reqwest/rustls-tls"]
 danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
@@ -27,8 +27,9 @@ bitcoin = { version = "0.30.0", features = ["base64"] }
 bip21 = "0.3.1"
 chacha20poly1305 = { version = "0.10.1", optional = true }
 log = { version = "0.4.14"}
-ohttp = { version = "0.5.1", optional = true }
+http = { version = "1", optional = true }
 bhttp = { version = "0.5.1", optional = true }
+ohttp = { version = "0.5.1", optional = true }
 serde = { version = "1.0.186", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 rustls = { version = "0.22.2", optional = true }

--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -63,7 +63,12 @@ impl Enroller {
         // TODO decapsulate enroll response, for now it does no auth or nothing
         let mut buf = Vec::new();
         let _ = res.read_to_end(&mut buf);
-        let _success = crate::v2::ohttp_decapsulate(ctx, &buf)?;
+        let response = crate::v2::ohttp_decapsulate(ctx, &buf)?;
+        if !response.status().is_success() {
+            return Err(Error::Server(
+                format!("Enrollment failed, expected success status",).into(),
+            ));
+        }
 
         let ctx = Enrolled {
             directory: self.directory,
@@ -202,15 +207,15 @@ impl Enrolled {
         let _ = body.read_to_end(&mut buf);
         log::trace!("decapsulating directory response");
         let response = crate::v2::ohttp_decapsulate(context, &buf)?;
-        if response.is_empty() {
+        if response.body().is_empty() {
             log::debug!("response is empty");
             return Ok(None);
         }
-        match String::from_utf8(response.clone()) {
+        match String::from_utf8(response.body().to_vec()) {
             // V1 response bodies are utf8 plaintext
             Ok(response) => Ok(Some(self.extract_proposal_from_v1(response)?)),
             // V2 response bodies are encrypted binary
-            Err(_) => Ok(Some(self.extract_proposal_from_v2(response)?)),
+            Err(_) => Ok(Some(self.extract_proposal_from_v2(response.body().to_vec())?)),
         }
     }
 
@@ -526,10 +531,12 @@ impl PayjoinProposal {
         res: Vec<u8>,
         ohttp_context: ohttp::ClientResponse,
     ) -> Result<Vec<u8>, Error> {
-        // TODO return error code
-        // display success or failure
         let res = crate::v2::ohttp_decapsulate(ohttp_context, &res)?;
-        Ok(res)
+        res.status().is_success().then(|| res.body().to_vec()).ok_or_else(|| {
+            Error::Server(
+                format!("Enrollment failed, expected Success status, got {}", res.status()).into(),
+            )
+        })
     }
 }
 

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -62,6 +62,8 @@ pub(crate) enum InternalValidationError {
     OhttpEncapsulation(crate::v2::OhttpEncapsulationError),
     #[cfg(feature = "v2")]
     Psbt(bitcoin::psbt::Error),
+    #[cfg(feature = "v2")]
+    UnexpectedStatusCode,
 }
 
 impl From<InternalValidationError> for ValidationError {
@@ -110,6 +112,8 @@ impl fmt::Display for ValidationError {
             OhttpEncapsulation(e) => write!(f, "Ohttp encapsulation error: {}", e),
             #[cfg(feature = "v2")]
             Psbt(e) => write!(f, "psbt error: {}", e),
+            #[cfg(feature = "v2")]
+            UnexpectedStatusCode => write!(f, "unexpected status code"),
         }
     }
 }
@@ -153,6 +157,8 @@ impl std::error::Error for ValidationError {
             OhttpEncapsulation(error) => Some(error),
             #[cfg(feature = "v2")]
             Psbt(error) => Some(error),
+            #[cfg(feature = "v2")]
+            UnexpectedStatusCode => None,
         }
     }
 }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -348,7 +348,7 @@ mod integration {
             tokio::select!(
             _ = ohttp_relay::listen_tcp(ohttp_relay_port, gateway_origin) => assert!(false, "Ohttp relay is long running"),
             _ = init_directory(directory_port, (cert.clone(), key)) => assert!(false, "Directory server is long running"),
-            res = do_v2_send_receive(ohttp_relay, directory, cert) => assert!(res.is_ok())
+            res = do_v2_send_receive(ohttp_relay, directory, cert) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
             );
 
             async fn do_v2_send_receive(

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -414,7 +414,7 @@ mod integration {
                 let (req, ctx) = payjoin_proposal.extract_v2_req()?;
                 let response = agent.post(req.url).body(req.body).send().await?;
                 let res = response.bytes().await?.to_vec();
-                let _response = payjoin_proposal.deserialize_res(res, ctx)?;
+                payjoin_proposal.process_res(res, ctx)?;
                 // response should be 204 http
 
                 // **********************
@@ -522,8 +522,8 @@ mod integration {
                     // this response would be returned as http response to the sender
                     let (req, ctx) = payjoin_proposal.extract_v2_req().unwrap();
                     let response = agent_clone.post(req.url).body(req.body).send().await?;
-                    let _response = payjoin_proposal
-                        .deserialize_res(response.bytes().await?.to_vec(), ctx)
+                    payjoin_proposal
+                        .process_res(response.bytes().await?.to_vec(), ctx)
                         .map_err(|e| e.to_string())?;
                     Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
                 });


### PR DESCRIPTION
Oblivious HTTP wraps an HTTP message that contains content and control information. We were ignoring content information like status even though it is essential to the Payjoin V2 protocol. Handle it.

I noticed this issue when trying to send async payjoin. Even if the directory returns a 202 ACCEPTED message to wait for the receiver's proposal, the polling stops because we try to decrypt the content (which is empty, and errors) rather than short circuit the function and return None