### PR TITLE
Normalize dash-separated long args

### DIFF
--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -121,7 +121,7 @@ fn cli() -> ArgMatches {
         );
         receive_cmd = receive_cmd.arg(
             Arg::new("pj_endpoint")
-                .long("pj_endpoint")
+                .long("pj-endpoint")
                 .short('e')
                 .num_args(1)
                 .help("The `pj=` endpoint to receive the payjoin request")
@@ -133,7 +133,7 @@ fn cli() -> ArgMatches {
     {
         receive_cmd = receive_cmd.arg(
             Arg::new("pj_directory")
-                .long("pj_directory")
+                .long("pj-directory")
                 .num_args(1)
                 .help("The directory to store payjoin requests")
                 .value_parser(value_parser!(Url)),

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -62,7 +62,7 @@ mod e2e {
             .arg(RECEIVE_SATS)
             .arg("--port")
             .arg(&port.to_string())
-            .arg("--pj_endpoint")
+            .arg("--pj-endpoint")
             .arg(&pj_endpoint)
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())


### PR DESCRIPTION
Make pj_directory pj-directory and pj_endpoint pj-endpoint.