### PR TITLE
Format all projects in the repository

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,13 +46,8 @@ jobs:
         if: matrix.rust != '1.63.0'
         run: cargo build --package payjoin-cli --verbose --features=danger-local-https,v2
 
-  fmt:
+  rustfmt:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        package: [payjoin, payjoin-cli]
-
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1.2.0
@@ -62,6 +57,4 @@ jobs:
           override: true
       - run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: fmt check
-        run: |
-          cd ${{ matrix.package }}
-          cargo fmt --all -- --check
+        run: cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ cargo update -p time@0.3.36 --precise 0.3.20
 cargo update -p reqwest --precise 0.12.4
 ```
 
+## Code Formatting
+
+We use the nightly Rust formatter for this project. Please run `rustfmt` using the nightly toolchain before submitting any changes.
+
 ## License
 
 MIT


### PR DESCRIPTION
And state our rustfmt policy in the README.

IMO there is no solution that pleases everyone. This is what we've been using and it hasn't caused any fires yet.

Using nightly is not the most beautiful from a toolchain perspective but it's where we're at and it lets us not reformat the whole codebase.