### PR TITLE
Error if send or receive session expired

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,6 @@ dependencies = [
  "ohttp-relay",
  "once_cell",
  "payjoin-directory",
- "percent-encoding-rfc3986",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -84,7 +84,7 @@ impl AppTrait for App {
             self.config.pj_directory.clone(),
             ohttp_keys.clone(),
             self.config.ohttp_relay.clone(),
-            std::time::Duration::from_secs(60 * 60),
+            None,
         );
         let (req, ctx) =
             initializer.extract_req().map_err(|e| anyhow!("Failed to extract request {}", e))?;
@@ -246,8 +246,7 @@ impl App {
         session: &mut payjoin::receive::v2::ActiveSession,
     ) -> Result<payjoin::receive::v2::UncheckedProposal> {
         loop {
-            let (req, context) =
-                session.extract_req().map_err(|_| anyhow!("Failed to extract request"))?;
+            let (req, context) = session.extract_req()?;
             println!("Polling receive request...");
             let http = http_agent()?;
             let ohttp_response = http

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["tests"]
 send = []
 receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "dep:http", "bhttp", "ohttp", "dep:percent-encoding", "serde", "url/serde"]
+v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "dep:http", "bhttp", "ohttp", "serde", "url/serde"]
 io = ["reqwest/rustls-tls"]
 danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
@@ -31,7 +31,6 @@ log = { version = "0.4.14"}
 http = { version = "1", optional = true }
 bhttp = { version = "=0.5.1", optional = true }
 ohttp = { version = "0.5.1", optional = true }
-percent-encoding = { version = "0.1.3", optional = true, package = "percent-encoding-rfc3986" }
 serde = { version = "1.0.186", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 rustls = { version = "0.22.2", optional = true }

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -1,0 +1,44 @@
+use core::fmt;
+use std::error;
+
+use crate::v2::OhttpEncapsulationError;
+
+#[derive(Debug)]
+pub struct SessionError(InternalSessionError);
+
+#[derive(Debug)]
+pub(crate) enum InternalSessionError {
+    /// The session has expired
+    Expired(std::time::SystemTime),
+    /// OHTTP Encapsulation failed
+    OhttpEncapsulationError(OhttpEncapsulationError),
+}
+
+impl fmt::Display for SessionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            InternalSessionError::Expired(expiry) => write!(f, "Session expired at {:?}", expiry),
+            InternalSessionError::OhttpEncapsulationError(e) =>
+                write!(f, "OHTTP Encapsulation Error: {}", e),
+        }
+    }
+}
+
+impl error::Error for SessionError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.0 {
+            InternalSessionError::Expired(_) => None,
+            InternalSessionError::OhttpEncapsulationError(e) => Some(e),
+        }
+    }
+}
+
+impl From<InternalSessionError> for SessionError {
+    fn from(e: InternalSessionError) -> Self { SessionError(e) }
+}
+
+impl From<OhttpEncapsulationError> for SessionError {
+    fn from(e: OhttpEncapsulationError) -> Self {
+        SessionError(InternalSessionError::OhttpEncapsulationError(e))
+    }
+}

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -195,8 +195,6 @@ pub(crate) enum InternalCreateRequestError {
     ParseSubdirectory(ParseSubdirectoryError),
     #[cfg(feature = "v2")]
     MissingOhttpConfig,
-    #[cfg(feature = "v2")]
-    PercentEncoding,
 }
 
 impl fmt::Display for CreateRequestError {
@@ -226,9 +224,7 @@ impl fmt::Display for CreateRequestError {
             ParseSubdirectory(e) => write!(f, "cannot parse subdirectory: {}", e),
             #[cfg(feature = "v2")]
             MissingOhttpConfig => write!(f, "no ohttp configuration with which to make a v2 request available"),
-            #[cfg(feature = "v2")]
-            PercentEncoding => write!(f, "fragment is not RFC 3986 percent-encoded"),
-        }
+}
     }
 }
 
@@ -259,8 +255,6 @@ impl std::error::Error for CreateRequestError {
             ParseSubdirectory(error) => Some(error),
             #[cfg(feature = "v2")]
             MissingOhttpConfig => None,
-            #[cfg(feature = "v2")]
-            PercentEncoding => None,
         }
     }
 }

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -195,6 +195,8 @@ pub(crate) enum InternalCreateRequestError {
     ParseSubdirectory(ParseSubdirectoryError),
     #[cfg(feature = "v2")]
     MissingOhttpConfig,
+    #[cfg(feature = "v2")]
+    Expired(std::time::SystemTime),
 }
 
 impl fmt::Display for CreateRequestError {
@@ -224,7 +226,9 @@ impl fmt::Display for CreateRequestError {
             ParseSubdirectory(e) => write!(f, "cannot parse subdirectory: {}", e),
             #[cfg(feature = "v2")]
             MissingOhttpConfig => write!(f, "no ohttp configuration with which to make a v2 request available"),
-}
+            #[cfg(feature = "v2")]
+            Expired(expiry) => write!(f, "session expired at {:?}", expiry),
+        }
     }
 }
 
@@ -255,6 +259,8 @@ impl std::error::Error for CreateRequestError {
             ParseSubdirectory(error) => Some(error),
             #[cfg(feature = "v2")]
             MissingOhttpConfig => None,
+            #[cfg(feature = "v2")]
+            Expired(_) => None,
         }
     }
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -315,6 +315,12 @@ impl RequestContext {
         ohttp_relay: Url,
     ) -> Result<(Request, ContextV2), CreateRequestError> {
         use crate::uri::UrlExt;
+
+        if let Some(expiry) = self.endpoint.exp() {
+            if std::time::SystemTime::now() > expiry {
+                return Err(InternalCreateRequestError::Expired(expiry).into());
+            }
+        }
         let rs = Self::rs_pubkey_from_dir_endpoint(&self.endpoint)?;
         let url = self.endpoint.clone();
         let body = serialize_v2_body(

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -325,11 +325,8 @@ impl RequestContext {
         )?;
         let body = crate::v2::encrypt_message_a(body, self.e, rs)
             .map_err(InternalCreateRequestError::Hpke)?;
-        let mut ohttp = self
-            .endpoint
-            .ohttp()
-            .map_err(|_| InternalCreateRequestError::PercentEncoding)?
-            .ok_or(InternalCreateRequestError::MissingOhttpConfig)?;
+        let mut ohttp =
+            self.endpoint.ohttp().ok_or(InternalCreateRequestError::MissingOhttpConfig)?;
         let (body, ohttp_res) =
             crate::v2::ohttp_encapsulate(&mut ohttp, "POST", url.as_str(), Some(&body))
                 .map_err(InternalCreateRequestError::OhttpEncapsulation)?;

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -107,15 +107,19 @@ impl PjUriBuilder {
     /// - `address`: Represents a bitcoin address.
     /// - `origin`: Represents either the payjoin endpoint in v1 or the directory in v2.
     /// - `ohttp_keys`: Optional OHTTP keys for v2 (only available if the "v2" feature is enabled).
+    /// - `expiry`: Optional non-default expiry for the payjoin session (only available if the "v2" feature is enabled).
     pub fn new(
         address: Address,
         origin: Url,
         #[cfg(feature = "v2")] ohttp_keys: Option<OhttpKeys>,
+        #[cfg(feature = "v2")] expiry: Option<std::time::SystemTime>,
     ) -> Self {
         #[allow(unused_mut)]
         let mut pj = origin;
         #[cfg(feature = "v2")]
         pj.set_ohttp(ohttp_keys);
+        #[cfg(feature = "v2")]
+        pj.set_exp(expiry);
         Self { address, amount: None, message: None, label: None, pj, pjos: false }
     }
     /// Set the amount you want to receive.
@@ -350,6 +354,8 @@ mod tests {
                 let builder = PjUriBuilder::new(
                     address.clone(),
                     Url::parse(pj).unwrap(),
+                    #[cfg(feature = "v2")]
+                    None,
                     #[cfg(feature = "v2")]
                     None,
                 )

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -115,7 +115,7 @@ impl PjUriBuilder {
         #[allow(unused_mut)]
         let mut pj = origin;
         #[cfg(feature = "v2")]
-        let _ = pj.set_ohttp(ohttp_keys);
+        pj.set_ohttp(ohttp_keys);
         Self { address, amount: None, message: None, label: None, pj, pjos: false }
     }
     /// Set the amount you want to receive.

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -337,7 +337,7 @@ mod integration {
                     directory,
                     bad_ohttp_keys,
                     mock_ohttp_relay,
-                    Duration::from_secs(60),
+                    None,
                 );
                 let (req, _ctx) = bad_initializer.extract_req().expect("Failed to extract request");
                 agent.post(req.url).body(req.body).send().await
@@ -616,7 +616,7 @@ mod integration {
                 directory.clone(),
                 ohttp_keys,
                 mock_ohttp_relay.clone(),
-                Duration::from_secs(60),
+                None,
             );
             let (req, ctx) = initializer.extract_req()?;
             println!("enroll req: {:#?}", &req);


### PR DESCRIPTION
Payjoin V2 is asynchronous and introduces an expiration parameter after which sessions are no longer valid. The payjoin directory should dictate the length of time for which it is willing to maintain an open session and communicate that during session initialization. The expiration can then be communicated in the bip21 URI for the sender to stop attempts after expiration. The receiver should also stop after expiration.

This PR is a simple implementation of this idea that only filters expired send/recv sessions at the time their request is extracted.

A more sophisticated expiration method would have the directory put an expiration ceiling at the time the session was initialized, since ultimately the directory only wants to hold sessions in storage for a limited time.

An even more sophisticated way to deal with expiration would to have the database filter expired requests so that no attempts are made to resume expired requests.

Note that the first commit changes the `UrlExt` trait NOT to percent encode the fragment, since I found out that `bip21::Uri` already percent-encodes the parameter in its [`Display` implementation](https://github.com/Kixunil/bip21/blob/88ac4516ccf19ccbf747a874f9725accac08fe17/src/ser.rs#L72-L89)