### PR TITLE
Parse and set `ohttp=` parameter from `pj` URL fragment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,7 @@ dependencies = [
  "ohttp-relay",
  "once_cell",
  "payjoin-directory",
+ "percent-encoding-rfc3986",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["tests"]
 send = []
 receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "dep:http", "bhttp", "ohttp", "serde", "url/serde"]
+v2 = ["bitcoin/rand", "bitcoin/serde", "chacha20poly1305", "dep:http", "bhttp", "ohttp", "dep:percent-encoding", "serde", "url/serde"]
 io = ["reqwest/rustls-tls"]
 danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
@@ -30,6 +30,7 @@ log = { version = "0.4.14"}
 http = { version = "1", optional = true }
 bhttp = { version = "=0.5.1", optional = true }
 ohttp = { version = "0.5.1", optional = true }
+percent-encoding = { version = "0.1.3", optional = true, package = "percent-encoding-rfc3986" }
 serde = { version = "1.0.186", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 rustls = { version = "0.22.2", optional = true }

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "v2")]
-use crate::v2::ParseOhttpKeysError;
-
 #[derive(Debug)]
 pub struct PjParseError(InternalPjParseError);
 
@@ -11,8 +8,6 @@ pub(crate) enum InternalPjParseError {
     MissingEndpoint,
     NotUtf8,
     BadEndpoint,
-    #[cfg(feature = "v2")]
-    BadOhttpKeys(ParseOhttpKeysError),
     UnsecureEndpoint,
 }
 
@@ -31,8 +26,6 @@ impl std::fmt::Display for PjParseError {
             MissingEndpoint => write!(f, "Missing payjoin endpoint"),
             NotUtf8 => write!(f, "Endpoint is not valid UTF-8"),
             BadEndpoint => write!(f, "Endpoint is not valid"),
-            #[cfg(feature = "v2")]
-            BadOhttpKeys(e) => write!(f, "OHTTP keys are not valid: {}", e),
             UnsecureEndpoint => {
                 write!(f, "Endpoint scheme is not secure (https or onion)")
             }

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -22,17 +22,18 @@ impl From<InternalPjParseError> for PjParseError {
 
 impl std::fmt::Display for PjParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use InternalPjParseError::*;
         match &self.0 {
-            InternalPjParseError::BadPjOs => write!(f, "Bad pjos parameter"),
-            InternalPjParseError::DuplicateParams(param) => {
+            BadPjOs => write!(f, "Bad pjos parameter"),
+            DuplicateParams(param) => {
                 write!(f, "Multiple instances of parameter '{}'", param)
             }
-            InternalPjParseError::MissingEndpoint => write!(f, "Missing payjoin endpoint"),
-            InternalPjParseError::NotUtf8 => write!(f, "Endpoint is not valid UTF-8"),
-            InternalPjParseError::BadEndpoint => write!(f, "Endpoint is not valid"),
+            MissingEndpoint => write!(f, "Missing payjoin endpoint"),
+            NotUtf8 => write!(f, "Endpoint is not valid UTF-8"),
+            BadEndpoint => write!(f, "Endpoint is not valid"),
             #[cfg(feature = "v2")]
-            InternalPjParseError::BadOhttpKeys(e) => write!(f, "OHTTP keys are not valid: {}", e),
-            InternalPjParseError::UnsecureEndpoint => {
+            BadOhttpKeys(e) => write!(f, "OHTTP keys are not valid: {}", e),
+            UnsecureEndpoint => {
                 write!(f, "Endpoint scheme is not secure (https or onion)")
             }
         }

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "v2")]
+use crate::v2::ParseOhttpKeysError;
+
+#[derive(Debug)]
+pub struct PjParseError(InternalPjParseError);
+
+#[derive(Debug)]
+pub(crate) enum InternalPjParseError {
+    BadPjOs,
+    MultipleParams(&'static str),
+    MissingEndpoint,
+    NotUtf8,
+    BadEndpoint,
+    #[cfg(feature = "v2")]
+    BadOhttpKeys(ParseOhttpKeysError),
+    UnsecureEndpoint,
+}
+
+impl From<InternalPjParseError> for PjParseError {
+    fn from(value: InternalPjParseError) -> Self { PjParseError(value) }
+}
+
+impl std::fmt::Display for PjParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            InternalPjParseError::BadPjOs => write!(f, "Bad pjos parameter"),
+            InternalPjParseError::MultipleParams(param) => {
+                write!(f, "Multiple instances of parameter '{}'", param)
+            }
+            InternalPjParseError::MissingEndpoint => write!(f, "Missing payjoin endpoint"),
+            InternalPjParseError::NotUtf8 => write!(f, "Endpoint is not valid UTF-8"),
+            InternalPjParseError::BadEndpoint => write!(f, "Endpoint is not valid"),
+            #[cfg(feature = "v2")]
+            InternalPjParseError::BadOhttpKeys(e) => write!(f, "OHTTP keys are not valid: {}", e),
+            InternalPjParseError::UnsecureEndpoint => {
+                write!(f, "Endpoint scheme is not secure (https or onion)")
+            }
+        }
+    }
+}

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -7,7 +7,7 @@ pub struct PjParseError(InternalPjParseError);
 #[derive(Debug)]
 pub(crate) enum InternalPjParseError {
     BadPjOs,
-    MultipleParams(&'static str),
+    DuplicateParams(&'static str),
     MissingEndpoint,
     NotUtf8,
     BadEndpoint,
@@ -24,7 +24,7 @@ impl std::fmt::Display for PjParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.0 {
             InternalPjParseError::BadPjOs => write!(f, "Bad pjos parameter"),
-            InternalPjParseError::MultipleParams(param) => {
+            InternalPjParseError::DuplicateParams(param) => {
                 write!(f, "Multiple instances of parameter '{}'", param)
             }
             InternalPjParseError::MissingEndpoint => write!(f, "Missing payjoin endpoint"),

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -311,10 +311,14 @@ mod tests {
 
         for address in [base58, bech32_upper, bech32_lower].iter() {
             for pj in [https, onion].iter() {
-                // TODO add with and without amount
-                // TODO shuffle params
-                let uri = format!("{}?amount=1&pj={}", address, pj);
-                assert!(Uri::try_from(&*uri).is_ok());
+                let uri_with_amount = format!("{}?amount=1&pj={}", address, pj);
+                assert!(Uri::try_from(uri_with_amount).is_ok());
+
+                let uri_without_amount = format!("{}?pj={}", address, pj);
+                assert!(Uri::try_from(uri_without_amount).is_ok());
+
+                let uri_shuffled_params = format!("{}?pj={}&amount=1", address, pj);
+                assert!(Uri::try_from(uri_shuffled_params).is_ok());
             }
         }
     }

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -244,7 +244,7 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
                 Ok(bip21::de::ParamKind::Known)
             }
             #[cfg(feature = "v2")]
-            "ohttp" => Err(InternalPjParseError::MultipleParams("ohttp").into()),
+            "ohttp" => Err(InternalPjParseError::DuplicateParams("ohttp").into()),
             "pj" if self.pj.is_none() => {
                 let endpoint = Cow::try_from(value).map_err(|_| InternalPjParseError::NotUtf8)?;
                 let url = Url::parse(&endpoint).map_err(|_| InternalPjParseError::BadEndpoint)?;
@@ -252,7 +252,7 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
 
                 Ok(bip21::de::ParamKind::Known)
             }
-            "pj" => Err(InternalPjParseError::MultipleParams("pj").into()),
+            "pj" => Err(InternalPjParseError::DuplicateParams("pj").into()),
             "pjos" if self.pjos.is_none() => {
                 match &*Cow::try_from(value).map_err(|_| InternalPjParseError::BadPjOs)? {
                     "0" => self.pjos = Some(false),
@@ -261,7 +261,7 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
                 }
                 Ok(bip21::de::ParamKind::Known)
             }
-            "pjos" => Err(InternalPjParseError::MultipleParams("pjos").into()),
+            "pjos" => Err(InternalPjParseError::DuplicateParams("pjos").into()),
             _ => Ok(bip21::de::ParamKind::Unknown),
         }
     }

--- a/payjoin/src/uri/url_ext.rs
+++ b/payjoin/src/uri/url_ext.rs
@@ -1,0 +1,106 @@
+use std::borrow::Cow;
+
+use percent_encoding::{AsciiSet, PercentDecodeError, CONTROLS};
+use url::Url;
+
+use crate::OhttpKeys;
+
+/// Parse and set fragment parameters from `&pj=` URI parameter URLs
+pub(crate) trait UrlExt {
+    fn ohttp(&self) -> Result<Option<OhttpKeys>, PercentDecodeError>;
+    fn set_ohttp(&mut self, ohttp: Option<OhttpKeys>) -> Result<(), PercentDecodeError>;
+}
+
+// Characters '=' and '&' conflict with BIP21 URI parameters and must be percent-encoded
+const BIP21_CONFLICTING: &AsciiSet = &CONTROLS.add(b'=').add(b'&');
+
+impl UrlExt for Url {
+    /// Retrieve the ohttp parameter from the URL fragment
+    fn ohttp(&self) -> Result<Option<OhttpKeys>, PercentDecodeError> {
+        use std::str::FromStr;
+        if let Some(fragment) = self.fragment() {
+            let decoded_fragment =
+                percent_encoding::percent_decode_str(fragment)?.decode_utf8_lossy();
+            for param in decoded_fragment.split('&') {
+                if let Some(value) = param.strip_prefix("ohttp=") {
+                    let ohttp = Cow::from(value);
+                    return Ok(OhttpKeys::from_str(&ohttp).ok());
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Set the ohttp parameter in the URL fragment
+    fn set_ohttp(&mut self, ohttp: Option<OhttpKeys>) -> Result<(), PercentDecodeError> {
+        let fragment = self.fragment().unwrap_or("").to_string();
+        let mut fragment =
+            percent_encoding::percent_decode_str(&fragment)?.decode_utf8_lossy().to_string();
+        if let Some(start) = fragment.find("ohttp=") {
+            let end = fragment[start..].find('&').map_or(fragment.len(), |i| start + i);
+            fragment.replace_range(start..end, "");
+            if fragment.ends_with('&') {
+                fragment.pop();
+            }
+        }
+        if let Some(ohttp) = ohttp {
+            let new_ohttp = format!("ohttp={}", ohttp);
+            if !fragment.is_empty() {
+                fragment.push('&');
+            }
+            fragment.push_str(&new_ohttp);
+        }
+        let encoded_fragment =
+            percent_encoding::utf8_percent_encode(&fragment, BIP21_CONFLICTING).to_string();
+        self.set_fragment(if encoded_fragment.is_empty() { None } else { Some(&encoded_fragment) });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use url::Url;
+
+    use super::*;
+    use crate::{Uri, UriExt};
+
+    #[test]
+    fn test_ohttp_get_set() {
+        let mut url = Url::parse("https://example.com").unwrap();
+
+        let ohttp_keys =
+            OhttpKeys::from_str("AQAg3WpRjS0aqAxQUoLvpas2VYjT2oIg6-3XSiB-QiYI1BAABAABAAM").unwrap();
+        let _ = url.set_ohttp(Some(ohttp_keys.clone()));
+        assert_eq!(
+            url.fragment(),
+            Some("ohttp%3DAQAg3WpRjS0aqAxQUoLvpas2VYjT2oIg6-3XSiB-QiYI1BAABAABAAM")
+        );
+
+        let retrieved_ohttp = url.ohttp().unwrap();
+        assert_eq!(retrieved_ohttp, Some(ohttp_keys));
+
+        let _ = url.set_ohttp(None);
+        assert_eq!(url.fragment(), None);
+    }
+
+    #[test]
+    fn test_invalid_v2_url_fragment_on_bip21() {
+        // fragment is not percent encoded so `&ohttp=` is parsed as a query parameter, not a fragment parameter
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
+                   &pj=https://example.com\
+                   #exp=1720547781&ohttp=AQAg3WpRjS0aqAxQUoLvpas2VYjT2oIg6-3XSiB-QiYI1BAABAABAAM";
+        let uri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
+        assert!(uri.extras.endpoint().ohttp().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_valid_v2_url_fragment_on_bip21() {
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
+                   &pj=https://example.com\
+                   #ohttp%3DAQAg3WpRjS0aqAxQUoLvpas2VYjT2oIg6-3XSiB-QiYI1BAABAABAAM%26exp%3D1720547781";
+        let uri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
+        assert!(uri.extras.endpoint().ohttp().unwrap().is_some());
+    }
+}


### PR DESCRIPTION
Close #298

This introduces a `Url` extension trait called `payjoin::uri::UrlExt` which can set and get `ohttp=` as a fragment rather than a URI parameter. Doing so allows BIP 77 payjoin v2 parameters to be compliant with any BIP 21 bitcoin URI parser that already supports &pj= without introducing new params. This seems to simplify the v1/v2 feature gates too.

This change also handles subdirectory parsing differently since the URL no longer ends with the subdirectory, but also the fragment. This introduces new V2 errors. On my first attempt I added subdirectory parsing and setting to `UrlExt`, but opted to remove that since it's out of scope for fragment handling and it would probably need to be considered to be feature gated behind `send`/`receive` which could make the `uri` module messier. (But also perhaps not since `UriExt` is private and `send`/`receive` gates can be enforced in those higher module abstractions where `UriExt` is depended upon).

The `UriExt` is unit tested.

I'm not sure how to best handle the difference between Ul paths with or without a trailing slash. Technically the latter is a true subdirectory but for our purposes, we're actually using HTTP endpoints that don't differentiate. Our parser should probably prefer one to another. I'm inclined to prefer fewer characters for simplicity.

e.g.

```
https://localhost:53429/A8xaMow612_1aiU15nyhQz0RorgIegqftrT7Yo19xKWc#ohttp=AQAgJLHcnSjkWH3Qc6ix2GOSPdyPH3OSu0-YL3NPbLd2Dx8ABAABAAM
```

vs

```
https://localhost:53429/A8xaMow612_1aiU15nyhQz0RorgIegqftrT7Yo19xKWc/#ohttp=AQAgJLHcnSjkWH3Qc6ix2GOSPdyPH3OSu0-YL3NPbLd2Dx8ABAABAAM
```

This was done as prerequisite to #299 since I believe `exp` should be a payjoin-specific fragment parameter as well that gets added to `UriExt`