### PR TITLE
Use explicit names for error enum with many fields

### DIFF
--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -1129,7 +1129,7 @@ mod test {
         })
         .to_string();
         match ctx.process_response(&mut known_json_error.as_bytes()) {
-            Err(ResponseError::WellKnown(WellKnownError::VersionUnsupported(_, _))) =>
+            Err(ResponseError::WellKnown(WellKnownError::VersionUnsupported { .. })) =>
                 assert!(true),
             _ => panic!("Expected WellKnownError"),
         }


### PR DESCRIPTION
This just changes semantics of some tuples with implied names to enum variants with explicit names. A sanity check is all it needs for a review.