### PR TITLE
cli: read Network::from_core_arg

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -254,10 +254,12 @@ impl App {
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network =
-            bitcoind.get_blockchain_info().map_err(|e| Error::Server(e.into())).and_then(
-                |info| bitcoin::Network::from_str(&info.chain).map_err(|e| Error::Server(e.into())),
-            )?;
+        let network = bitcoind
+            .get_blockchain_info()
+            .map_err(|e| Error::Server(e.into()))
+            .and_then(|info| {
+                bitcoin::Network::from_core_arg(&info.chain).map_err(|e| Error::Server(e.into()))
+            })?;
 
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -250,10 +250,12 @@ impl App {
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network =
-            bitcoind.get_blockchain_info().map_err(|e| Error::Server(e.into())).and_then(
-                |info| bitcoin::Network::from_str(&info.chain).map_err(|e| Error::Server(e.into())),
-            )?;
+        let network = bitcoind
+            .get_blockchain_info()
+            .map_err(|e| Error::Server(e.into()))
+            .and_then(|info| {
+                bitcoin::Network::from_core_arg(&info.chain).map_err(|e| Error::Server(e.into()))
+            })?;
 
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {


### PR DESCRIPTION
Previously Network::from_str was being used [which expected "bitcoin"](https://docs.rs/bitcoin/latest/bitcoin/enum.Network.html#method.from_core_arg) to give a mainnet chain, however core's `bitcoin-cli` returns "main" from `get_blockchain_info`.

There's a rust-bitcoin [Network::from_core_arg](https://docs.rs/bitcoin/latest/bitcoin/enum.Network.html#method.from_core_arg) meant to handle this.