### PR TITLE
Specify rust-version 1.63 in Cargo.toml

### DIFF
--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["bip78", "payjoin", "bitcoin"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 license = "MITNFA"
 edition = "2021"
+rust-version = "1.63"
 resolver = "2"
 exclude = ["tests"]
 

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies", "network-program
 license = "MITNFA"
 resolver = "2"
 edition = "2021"
+rust-version = "1.63"
 exclude = ["tests"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Both `payjoin` and `payjoin-cli` use 1.63.0 as MSRV. Specifying the MSRV in Cargo.toml ensures it displpays on crates.io.