### PR TITLE
Correctly set `v=2` query parameter for v2 senders

### DIFF
--- a/payjoin/src/receive/v2.rs
+++ b/payjoin/src/receive/v2.rs
@@ -234,7 +234,7 @@ impl ActiveSession {
 /// transaction with extract_tx_to_schedule_broadcast() and schedule, followed by checking
 /// that the transaction can be broadcast with check_broadcast_suitability. Otherwise it is safe to
 /// call assume_interactive_receive to proceed with validation.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UncheckedProposal {
     inner: super::UncheckedProposal,
     context: SessionContext,

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -269,6 +269,7 @@ impl RequestContext {
             self.disable_output_substitution,
             self.fee_contribution,
             self.min_fee_rate,
+            "1", // payjoin version
         )
         .map_err(InternalCreateRequestError::Url)?;
         let body = self.psbt.to_string().as_bytes().to_vec();
@@ -959,6 +960,7 @@ fn serialize_v2_body(
         disable_output_substitution,
         fee_contribution,
         min_feerate,
+        "2", // payjoin version
     )
     .map_err(InternalCreateRequestError::Url)?;
     let query_params = placeholder_url.query().unwrap_or_default();
@@ -971,9 +973,10 @@ fn serialize_url(
     disable_output_substitution: bool,
     fee_contribution: Option<(bitcoin::Amount, usize)>,
     min_fee_rate: FeeRate,
+    version: &str,
 ) -> Result<Url, url::ParseError> {
     let mut url = endpoint;
-    url.query_pairs_mut().append_pair("v", "1");
+    url.query_pairs_mut().append_pair("v", version);
     if disable_output_substitution {
         url.query_pairs_mut().append_pair("disableoutputsubstitution", "1");
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -100,6 +100,7 @@ mod integration {
             )
             .unwrap();
             let proposal = handle_proposal(proposal, receiver);
+            assert!(!proposal.is_output_substitution_disabled());
             let psbt = proposal.psbt();
             debug!("Receiver's Payjoin proposal PSBT: {:#?}", &psbt);
             psbt.to_string()
@@ -436,6 +437,7 @@ mod integration {
                 let proposal =
                     session.process_res(response.bytes().await?.to_vec().as_slice(), ctx)?.unwrap();
                 let mut payjoin_proposal = handle_directory_proposal(receiver, proposal);
+                assert!(!payjoin_proposal.is_output_substitution_disabled());
                 let (req, ctx) = payjoin_proposal.extract_v2_req()?;
                 let response = agent.post(req.url).body(req.body).send().await?;
                 let res = response.bytes().await?.to_vec();
@@ -546,6 +548,7 @@ mod integration {
                     };
                     let proposal = session.process_res(response.as_slice(), ctx).unwrap().unwrap();
                     let mut payjoin_proposal = handle_directory_proposal(receiver, proposal);
+                    assert!(payjoin_proposal.is_output_substitution_disabled());
                     // Respond with payjoin psbt within the time window the sender is willing to wait
                     // this response would be returned as http response to the sender
                     let (req, ctx) = payjoin_proposal.extract_v2_req().unwrap();


### PR DESCRIPTION
Fixes #311.

The modified test in the first commit fails without the changes in the second commit.