### PR TITLE
Tx cut-through

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -15,6 +15,8 @@ pub struct AppConfig {
     pub bitcoind_rpcuser: String,
     pub bitcoind_rpcpassword: String,
     pub db_path: PathBuf,
+    // receive-only
+    pub max_fee_rate: Option<u64>,
 
     // v2 only
     #[cfg(feature = "v2")]
@@ -113,7 +115,14 @@ impl AppConfig {
                         )?
                 };
 
-                builder
+                let max_fee_rate = matches
+                    .get_one::<String>("max_fee_rate")
+                    .map(|max_fee_rate| max_fee_rate.parse::<u64>())
+                    .transpose()
+                    .map_err(|_| {
+                        ConfigError::Message("\"max_fee_rate\" must be a valid amount".to_string())
+                    })?;
+                builder.set_override_option("max_fee_rate", max_fee_rate)?
             }
             #[cfg(feature = "v2")]
             Some(("resume", _)) => builder,

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -94,38 +94,6 @@ pub trait App {
     }
 }
 
-fn try_contributing_inputs(
-    payjoin: &mut payjoin::receive::ProvisionalProposal,
-    bitcoind: &bitcoincore_rpc::Client,
-) -> Result<()> {
-    use bitcoin::OutPoint;
-
-    let available_inputs = bitcoind
-        .list_unspent(None, None, None, None, None)
-        .context("Failed to list unspent from bitcoind")?;
-    let candidate_inputs: HashMap<Amount, OutPoint> = available_inputs
-        .iter()
-        .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
-        .collect();
-
-    let selected_outpoint = payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
-    let selected_utxo = available_inputs
-        .iter()
-        .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
-        .context("This shouldn't happen. Failed to retrieve the privacy preserving utxo from those we provided to the seclector.")?;
-    log::debug!("selected utxo: {:#?}", selected_utxo);
-
-    //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
-    let txo_to_contribute = bitcoin::TxOut {
-        value: selected_utxo.amount,
-        script_pubkey: selected_utxo.script_pub_key.clone(),
-    };
-    let outpoint_to_contribute =
-        bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
-    payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
-    Ok(())
-}
-
 #[cfg(feature = "danger-local-https")]
 fn http_agent() -> Result<reqwest::Client> { Ok(http_agent_builder()?.build()?) }
 

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -14,7 +14,7 @@ use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use payjoin::bitcoin::psbt::Psbt;
-use payjoin::bitcoin::{self};
+use payjoin::bitcoin::{self, FeeRate};
 use payjoin::receive::{PayjoinProposal, UncheckedProposal};
 use payjoin::{Error, PjUriBuilder, Uri, UriExt};
 use tokio::net::TcpListener;
@@ -366,6 +366,9 @@ impl App {
                     .map_err(|e| Error::Server(e.into()))?
             },
             Some(bitcoin::FeeRate::MIN),
+            self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
+                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Server("Invalid fee rate".into()))
+            })?,
         )?;
         Ok(payjoin_proposal)
     }

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -348,7 +348,8 @@ impl App {
                     .require_network(network)
                     .map_err(|e| Error::Server(e.into()))?
                     .script_pubkey(),
-            )?
+            )
+            .map_err(|e| Error::Server(e.into()))?
             .commit_outputs();
 
         let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &bitcoind)
@@ -397,6 +398,7 @@ fn try_contributing_inputs(
 
     Ok(payjoin
         .contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)])
+        .expect("This shouldn't happen. Failed to contribute inputs.")
         .commit_inputs())
 }
 

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -385,13 +385,12 @@ fn try_contributing_inputs(
         .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
         .context("This shouldn't happen. Failed to retrieve the privacy preserving utxo from those we provided to the seclector.")?;
     log::debug!("selected utxo: {:#?}", selected_utxo);
-
-    //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
     let txo_to_contribute = bitcoin::TxOut {
         value: selected_utxo.amount,
         script_pubkey: selected_utxo.script_pub_key.clone(),
     };
-    Ok(payjoin.contribute_witness_input(txo_to_contribute, selected_outpoint))
+
+    Ok(payjoin.contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)]))
 }
 
 fn full<T: Into<Bytes>>(chunk: T) -> BoxBody<Bytes, hyper::Error> {

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -367,13 +367,12 @@ fn try_contributing_inputs(
         .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
         .context("This shouldn't happen. Failed to retrieve the privacy preserving utxo from those we provided to the seclector.")?;
     log::debug!("selected utxo: {:#?}", selected_utxo);
-
-    //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
     let txo_to_contribute = bitcoin::TxOut {
         value: selected_utxo.amount,
         script_pubkey: selected_utxo.script_pub_key.clone(),
     };
-    Ok(payjoin.contribute_witness_input(txo_to_contribute, selected_outpoint))
+
+    Ok(payjoin.contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)]))
 }
 
 async fn unwrap_ohttp_keys_or_else_fetch(config: &AppConfig) -> Result<payjoin::OhttpKeys> {

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::RpcApi;
 use payjoin::bitcoin::consensus::encode::serialize_hex;
 use payjoin::bitcoin::psbt::Psbt;
-use payjoin::bitcoin::Amount;
+use payjoin::bitcoin::{Amount, FeeRate};
 use payjoin::receive::v2::ActiveSession;
 use payjoin::send::RequestContext;
 use payjoin::{bitcoin, Error, Uri};
@@ -343,6 +343,9 @@ impl App {
                     .map_err(|e| Error::Server(e.into()))?
             },
             Some(bitcoin::FeeRate::MIN),
+            self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
+                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Server("Invalid fee rate".into()))
+            })?,
         )?;
         let payjoin_proposal_psbt = payjoin_proposal.psbt();
         log::debug!("Receiver's Payjoin proposal PSBT Rsponse: {:#?}", payjoin_proposal_psbt);

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -377,6 +377,7 @@ fn try_contributing_inputs(
 
     Ok(payjoin
         .contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)])
+        .expect("This shouldn't happen. Failed to contribute inputs.")
         .commit_inputs())
 }
 

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -111,6 +111,12 @@ fn cli() -> ArgMatches {
     let mut cmd = cmd.subcommand(Command::new("resume"));
 
     // Conditional arguments based on features for the receive subcommand
+    receive_cmd = receive_cmd.arg(
+        Arg::new("max_fee_rate")
+            .long("max-fee-rate")
+            .num_args(1)
+            .help("The maximum effective fee rate the receiver is willing to pay (in sat/vB)"),
+    );
     #[cfg(not(feature = "v2"))]
     {
         receive_cmd = receive_cmd.arg(

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -196,6 +196,51 @@ impl std::error::Error for RequestError {
     }
 }
 
+/// Error that may occur when output substitution fails.
+///
+/// This is currently opaque type because we aren't sure which variants will stay.
+/// You can only display it.
+#[derive(Debug)]
+pub struct OutputSubstitutionError(InternalOutputSubstitutionError);
+
+#[derive(Debug)]
+pub(crate) enum InternalOutputSubstitutionError {
+    /// Output substitution is disabled
+    OutputSubstitutionDisabled(&'static str),
+    /// Current output substitution implementation doesn't support reducing the number of outputs
+    NotEnoughOutputs,
+    /// The provided drain script could not be identified in the provided replacement outputs
+    InvalidDrainScript,
+}
+
+impl fmt::Display for OutputSubstitutionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            InternalOutputSubstitutionError::OutputSubstitutionDisabled(reason) => write!(f, "{}", &format!("Output substitution is disabled: {}", reason)),
+            InternalOutputSubstitutionError::NotEnoughOutputs => write!(
+                f,
+                "Current output substitution implementation doesn't support reducing the number of outputs"
+            ),
+            InternalOutputSubstitutionError::InvalidDrainScript =>
+                write!(f, "The provided drain script could not be identified in the provided replacement outputs"),
+        }
+    }
+}
+
+impl From<InternalOutputSubstitutionError> for OutputSubstitutionError {
+    fn from(value: InternalOutputSubstitutionError) -> Self { OutputSubstitutionError(value) }
+}
+
+impl std::error::Error for OutputSubstitutionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.0 {
+            InternalOutputSubstitutionError::OutputSubstitutionDisabled(_) => None,
+            InternalOutputSubstitutionError::NotEnoughOutputs => None,
+            InternalOutputSubstitutionError::InvalidDrainScript => None,
+        }
+    }
+}
+
 /// Error that may occur when coin selection fails.
 ///
 /// This is currently opaque type because we aren't sure which variants will stay.
@@ -229,4 +274,30 @@ impl fmt::Display for SelectionError {
 
 impl From<InternalSelectionError> for SelectionError {
     fn from(value: InternalSelectionError) -> Self { SelectionError(value) }
+}
+
+/// Error that may occur when input contribution fails.
+///
+/// This is currently opaque type because we aren't sure which variants will stay.
+/// You can only display it.
+#[derive(Debug)]
+pub struct InputContributionError(InternalInputContributionError);
+
+#[derive(Debug)]
+pub(crate) enum InternalInputContributionError {
+    /// Total input value is not enough to cover additional output value
+    ValueTooLow,
+}
+
+impl fmt::Display for InputContributionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            InternalInputContributionError::ValueTooLow =>
+                write!(f, "Total input value is not enough to cover additional output value"),
+        }
+    }
+}
+
+impl From<InternalInputContributionError> for InputContributionError {
+    fn from(value: InternalInputContributionError) -> Self { InputContributionError(value) }
 }

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -90,6 +90,8 @@ pub(crate) enum InternalRequestError {
     ///
     /// Second argument is the minimum fee rate optionaly set by the receiver.
     PsbtBelowFeeRate(bitcoin::FeeRate, bitcoin::FeeRate),
+    /// Effective receiver feerate exceeds maximum allowed feerate
+    FeeTooHigh(bitcoin::FeeRate, bitcoin::FeeRate),
 }
 
 impl From<InternalRequestError> for RequestError {
@@ -170,6 +172,14 @@ impl fmt::Display for RequestError {
                 &format!(
                     "Original PSBT fee rate too low: {} < {}.",
                     original_psbt_fee_rate, receiver_min_fee_rate
+                ),
+            ),
+            InternalRequestError::FeeTooHigh(proposed_feerate, max_feerate) => write_error(
+                f,
+                "original-psbt-rejected",
+                &format!(
+                    "Effective receiver feerate exceeds maximum allowed feerate: {} > {}",
+                    proposed_feerate, max_feerate
                 ),
             ),
         }

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -587,7 +587,7 @@ impl WantsInputs {
             let change_amount = receiver_input_amount - receiver_min_input_amount;
             payjoin_psbt.unsigned_tx.output[self.change_vout].value += change_amount;
         } else {
-            todo!("Return an error?");
+            todo!("Input amount is not enough to cover additional output value");
         }
 
         WantsInputs {
@@ -612,7 +612,7 @@ impl WantsInputs {
             .output
             .iter()
             .fold(Amount::ZERO, |acc, output| acc + output.value);
-        max(Amount::ZERO, output_amount - original_output_amount)
+        output_amount.checked_sub(original_output_amount).unwrap_or(Amount::ZERO)
     }
 
     /// Proceed to the proposal finalization step.

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -445,8 +445,11 @@ impl WantsInputs {
         self.inner.try_preserving_privacy(candidate_inputs)
     }
 
-    pub fn contribute_witness_input(self, txo: TxOut, outpoint: OutPoint) -> ProvisionalProposal {
-        let inner = self.inner.contribute_witness_input(txo, outpoint);
+    pub fn contribute_witness_inputs(
+        self,
+        inputs: impl IntoIterator<Item = (OutPoint, TxOut)>,
+    ) -> ProvisionalProposal {
+        let inner = self.inner.contribute_witness_inputs(inputs);
         ProvisionalProposal { inner, context: self.context }
     }
 }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -492,8 +492,13 @@ impl ProvisionalProposal {
         self,
         wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, Error>,
         min_feerate_sat_per_vb: Option<FeeRate>,
+        max_feerate_sat_per_vb: FeeRate,
     ) -> Result<PayjoinProposal, Error> {
-        let inner = self.inner.finalize_proposal(wallet_process_psbt, min_feerate_sat_per_vb)?;
+        let inner = self.inner.finalize_proposal(
+            wallet_process_psbt,
+            min_feerate_sat_per_vb,
+            max_feerate_sat_per_vb,
+        )?;
         Ok(PayjoinProposal { inner, context: self.context })
     }
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -846,7 +846,7 @@ impl ContextV1 {
                     ensure!(proposed_txout.value >= original_output.value, OutputValueDecreased);
                     original_outputs.next();
                 }
-                // all original outputs processed, only additional outputs remain
+                // additional output
                 _ => (),
             }
         }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -644,6 +644,7 @@ mod integration {
 
             let payjoin = payjoin
                 .contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)])
+                .unwrap()
                 .commit_inputs();
 
             // Sign and finalize the proposal PSBT
@@ -1103,7 +1104,7 @@ mod integration {
             }
         };
 
-        let payjoin = payjoin.contribute_witness_inputs(inputs).commit_inputs();
+        let payjoin = payjoin.contribute_witness_inputs(inputs).unwrap().commit_inputs();
 
         let payjoin_proposal = payjoin
             .finalize_proposal(

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -665,6 +665,7 @@ mod integration {
                             .unwrap())
                     },
                     Some(FeeRate::BROADCAST_MIN),
+                    FeeRate::from_sat_per_vb_unchecked(2),
                 )
                 .unwrap();
             payjoin_proposal
@@ -1123,6 +1124,7 @@ mod integration {
                         .unwrap())
                 },
                 Some(FeeRate::BROADCAST_MIN),
+                FeeRate::from_sat_per_vb_unchecked(2),
             )
             .unwrap();
         payjoin_proposal

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -626,9 +626,7 @@ mod integration {
                 })
                 .expect("Receiver should have at least one output");
 
-            let payjoin = payjoin
-                .try_substitute_receiver_outputs(None)
-                .expect("Could not substitute outputs");
+            let payjoin = payjoin.commit_outputs();
 
             // Select receiver payjoin inputs. TODO Lock them.
             let available_inputs = receiver.list_unspent(None, None, None, None, None).unwrap();
@@ -647,8 +645,9 @@ mod integration {
                 script_pubkey: selected_utxo.script_pub_key.clone(),
             };
 
-            let payjoin =
-                payjoin.contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)]);
+            let payjoin = payjoin
+                .contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)])
+                .commit_inputs();
 
             // Sign and finalize the proposal PSBT
             let payjoin_proposal = payjoin
@@ -874,10 +873,11 @@ mod integration {
             .expect("Receiver should have at least one output");
 
         let payjoin = payjoin
-            .try_substitute_receiver_output(|| {
-                Ok(receiver.get_new_address(None, None).unwrap().assume_checked().script_pubkey())
-            })
-            .expect("Could not substitute outputs");
+            .substitute_receiver_script(
+                &receiver.get_new_address(None, None).unwrap().assume_checked().script_pubkey(),
+            )
+            .expect("Could not substitute outputs")
+            .commit_outputs();
 
         // Select receiver payjoin inputs. TODO Lock them.
         let available_inputs = receiver.list_unspent(None, None, None, None, None).unwrap();
@@ -896,8 +896,9 @@ mod integration {
             script_pubkey: selected_utxo.script_pub_key.clone(),
         };
 
-        let payjoin =
-            payjoin.contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)]);
+        let payjoin = payjoin
+            .contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)])
+            .commit_inputs();
 
         let payjoin_proposal = payjoin
             .finalize_proposal(

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -642,17 +642,15 @@ mod integration {
                 .iter()
                 .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
                 .unwrap();
-
-            //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
             let txo_to_contribute = bitcoin::TxOut {
                 value: selected_utxo.amount,
                 script_pubkey: selected_utxo.script_pub_key.clone(),
             };
-            let outpoint_to_contribute =
-                bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
-            let payjoin =
-                payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
+            let payjoin =
+                payjoin.contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)]);
+
+            // Sign and finalize the proposal PSBT
             let payjoin_proposal = payjoin
                 .finalize_proposal(
                     |psbt: &Psbt| {
@@ -864,7 +862,7 @@ mod integration {
         let proposal = proposal.check_no_mixed_input_scripts().unwrap();
 
         // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
-        let mut payjoin = proposal
+        let payjoin = proposal
             .check_no_inputs_seen_before(|_| Ok(false))
             .unwrap()
             .identify_receiver_outputs(|output_script| {
@@ -893,15 +891,13 @@ mod integration {
             .iter()
             .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
             .unwrap();
-
-        //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
         let txo_to_contribute = bitcoin::TxOut {
             value: selected_utxo.amount,
             script_pubkey: selected_utxo.script_pub_key.clone(),
         };
-        let outpoint_to_contribute =
-            bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
-        let payjoin = payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
+
+        let payjoin =
+            payjoin.contribute_witness_inputs(vec![(selected_outpoint, txo_to_contribute)]);
 
         let payjoin_proposal = payjoin
             .finalize_proposal(


### PR DESCRIPTION
This PR changes the receiver API interface to add support for transaction cut-through. Enables #313.

Summary of changes:
- The receiver can replace all of their original outputs with a new set of outputs (if allowed by `disableoutputsubstitution` checks), while designating a change output.
- The receiver can contribute a custom set of inputs. Excess input value is added to their change output.
- The receiver may have to pay for additional fees, in which case the additional fee value is deducted from their change output.
- The receiver may specify a `max_feerate`, which ensures they wouldn't pay more in fees than their input/output contributions are worth at that max feerate.