### PR TITLE
Make tests less verbose

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
           cargo update -p url --precise 2.5.0
           cargo update -p which --precise 4.4.0
       - name: Run tests
-        run: bash contrib/test.sh
+        run: RUST_LOG=debug bash contrib/test.sh
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -15,8 +15,6 @@ mod e2e {
     #[cfg(not(feature = "v2"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn send_receive_payjoin() {
-        env::set_var("RUST_LOG", "debug");
-
         let bitcoind_exe = env::var("BITCOIND_EXE")
             .ok()
             .or_else(|| bitcoind::downloaded_exe_path().ok())
@@ -161,7 +159,6 @@ mod e2e {
         static TESTS_TIMEOUT: Lazy<Duration> = Lazy::new(|| Duration::from_secs(20));
         static WAIT_SERVICE_INTERVAL: Lazy<Duration> = Lazy::new(|| Duration::from_secs(3));
 
-        env::set_var("RUST_LOG", "debug");
         init_tracing();
         let (cert, key) = local_cert_key();
         let ohttp_relay_port = find_free_port();

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -307,7 +307,6 @@ mod integration {
                 OhttpKeys::from_str("AQAg3WpRjS0aqAxQUoLvpas2VYjT2oIg6-3XSiB-QiYI1BAABAABAAM")
                     .expect("Invalid OhttpKeys");
 
-            std::env::set_var("RUST_LOG", "debug");
             let (cert, key) = local_cert_key();
             let port = find_free_port();
             let directory = Url::parse(&format!("https://localhost:{}", port)).unwrap();
@@ -346,7 +345,6 @@ mod integration {
 
         #[tokio::test]
         async fn test_session_expiration() {
-            std::env::set_var("RUST_LOG", "debug");
             init_tracing();
             let (cert, key) = local_cert_key();
             let ohttp_relay_port = find_free_port();
@@ -417,7 +415,6 @@ mod integration {
 
         #[tokio::test]
         async fn v2_to_v2() {
-            std::env::set_var("RUST_LOG", "debug");
             init_tracing();
             let (cert, key) = local_cert_key();
             let ohttp_relay_port = find_free_port();
@@ -531,7 +528,6 @@ mod integration {
 
         #[tokio::test]
         async fn v1_to_v2() {
-            std::env::set_var("RUST_LOG", "debug");
             init_tracing();
             let (cert, key) = local_cert_key();
             let ohttp_relay_port = find_free_port();


### PR DESCRIPTION
The log level is no longer hardcoded in tests. It can be manually overriden with an environment variable when calling `cargo test` or `contrib/test.sh`.

I set RUST_LOG=debug in the github workflow to maintain the same behavior there, but we can remove that if not needed.