### PR TITLE
Send v1 to v1 receivers if v2 unsupported

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -65,7 +65,7 @@ impl AppTrait for App {
         println!("Sending fallback request to {}", &req.url);
         let response = http
             .post(req.url)
-            .header("Content-Type", payjoin::V1_REQ_CONTENT_TYPE)
+            .header("Content-Type", req.content_type)
             .body(body.clone())
             .send()
             .await

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -329,11 +329,6 @@ impl App {
             },
             Some(bitcoin::FeeRate::MIN),
         )?;
-        let payjoin_proposal_psbt = payjoin_proposal.psbt();
-        println!(
-            "Responded with Payjoin proposal {}",
-            payjoin_proposal_psbt.clone().extract_tx_unchecked_fee_rate().compute_txid()
-        );
         Ok(payjoin_proposal)
     }
 }

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -92,7 +92,7 @@ impl AppTrait for App {
         let http = http_agent()?;
         let ohttp_response = http
             .post(req.url)
-            .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+            .header("Content-Type", req.content_type)
             .body(req.body)
             .send()
             .await
@@ -156,7 +156,7 @@ impl App {
         let http = http_agent()?;
         let res = http
             .post(req.url)
-            .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+            .header("Content-Type", req.content_type)
             .body(req.body)
             .send()
             .await
@@ -219,7 +219,7 @@ impl App {
             let http = http_agent()?;
             let response = http
                 .post(req.url)
-                .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+                .header("Content-Type", req.content_type)
                 .body(req.body)
                 .send()
                 .await
@@ -251,7 +251,7 @@ impl App {
             let http = http_agent()?;
             let ohttp_response = http
                 .post(req.url)
-                .header("Content-Type", payjoin::V2_REQ_CONTENT_TYPE)
+                .header("Content-Type", req.content_type)
                 .body(req.body)
                 .send()
                 .await

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -91,7 +91,7 @@ impl SessionInitializer {
             self.context.directory.as_str(),
             Some(subdirectory.as_bytes()),
         )?;
-        let req = Request { url, body };
+        let req = Request::new_v2(url, body);
         Ok((req, ctx))
     }
 
@@ -130,7 +130,7 @@ impl ActiveSession {
         let (body, ohttp_ctx) =
             self.fallback_req_body().map_err(InternalSessionError::OhttpEncapsulationError)?;
         let url = self.context.ohttp_relay.clone();
-        let req = Request { url, body };
+        let req = Request::new_v2(url, body);
         Ok((req, ohttp_ctx))
     }
 
@@ -479,7 +479,7 @@ impl PayjoinProposal {
             Some(&body),
         )?;
         let url = self.context.ohttp_relay.clone();
-        let req = Request { url, body };
+        let req = Request::new_v2(url, body);
         Ok((req, ctx))
     }
 

--- a/payjoin/src/request.rs
+++ b/payjoin/src/request.rs
@@ -6,6 +6,7 @@ pub const V1_REQ_CONTENT_TYPE: &str = "text/plain";
 pub const V2_REQ_CONTENT_TYPE: &str = "message/ohttp-req";
 
 /// Represents data that needs to be transmitted to the receiver or payjoin directory.
+/// Ensure the `Content-Length` is set to the length of `body`. (most libraries do this automatically)
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct Request {
@@ -14,10 +15,24 @@ pub struct Request {
     /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
     pub url: Url,
 
+    /// The `Content-Type` header to use for the request.
+    ///
+    /// `text/plain` for v1 requests and `message/ohttp-req` for v2 requests.
+    pub content_type: &'static str,
+
     /// Bytes to be sent to the receiver.
     ///
-    /// This is properly encoded PSBT, already in base64. You only need to make sure `Content-Type`
-    /// is appropriate (`text/plain` for v1 requests and 'message/ohttp-req' for v2)
-    /// and `Content-Length` is `body.len()` (most libraries do the latter automatically).
+    /// This is properly encoded PSBT payload either in base64 in v1 or an OHTTP encapsulated payload in v2.
     pub body: Vec<u8>,
+}
+
+impl Request {
+    pub fn new_v1(url: Url, body: Vec<u8>) -> Self {
+        Self { url, content_type: V1_REQ_CONTENT_TYPE, body }
+    }
+
+    #[cfg(feature = "v2")]
+    pub fn new_v2(url: Url, body: Vec<u8>) -> Self {
+        Self { url, content_type: V2_REQ_CONTENT_TYPE, body }
+    }
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -290,7 +290,7 @@ impl RequestContext {
         .map_err(InternalCreateRequestError::Url)?;
         let body = self.psbt.to_string().as_bytes().to_vec();
         Ok((
-            Request { url, body },
+            Request::new_v1(url, body),
             ContextV1 {
                 original_psbt: self.psbt,
                 disable_output_substitution: self.disable_output_substitution,
@@ -338,7 +338,7 @@ impl RequestContext {
                 .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
         log::debug!("ohttp_relay_url: {:?}", ohttp_relay);
         Ok((
-            Request { url: ohttp_relay, body },
+            Request { url: ohttp_relay, body, content_type: crate::request::V2_REQ_CONTENT_TYPE },
             // this method may be called more than once to re-construct the ohttp, therefore we must clone (or TODO memoize)
             ContextV2 {
                 context_v1: ContextV1 {

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -279,9 +279,9 @@ impl Eq for RequestContext {}
 
 impl RequestContext {
     /// Extract serialized V1 Request and Context froma Payjoin Proposal
-    pub fn extract_v1(self) -> Result<(Request, ContextV1), CreateRequestError> {
+    pub fn extract_v1(&self) -> Result<(Request, ContextV1), CreateRequestError> {
         let url = serialize_url(
-            self.endpoint,
+            self.endpoint.clone(),
             self.disable_output_substitution,
             self.fee_contribution,
             self.min_fee_rate,
@@ -292,10 +292,10 @@ impl RequestContext {
         Ok((
             Request::new_v1(url, body),
             ContextV1 {
-                original_psbt: self.psbt,
+                original_psbt: self.psbt.clone(),
                 disable_output_substitution: self.disable_output_substitution,
                 fee_contribution: self.fee_contribution,
-                payee: self.payee,
+                payee: self.payee.clone(),
                 input_type: self.input_type,
                 sequence: self.sequence,
                 min_fee_rate: self.min_fee_rate,
@@ -303,7 +303,7 @@ impl RequestContext {
         ))
     }
 
-    /// Extract serialized Request and Context from a Payjoin Proposal.
+    /// Extract serialized Request and Context from a Payjoin Proposal. Automatically selects the correct version.
     ///
     /// In order to support polling, this may need to be called many times to be encrypted with
     /// new unique nonces to make independent OHTTP requests.
@@ -321,7 +321,28 @@ impl RequestContext {
                 return Err(InternalCreateRequestError::Expired(expiry).into());
             }
         }
-        let rs = self.extract_rs_pubkey()?;
+
+        match self.extract_rs_pubkey() {
+            Ok(rs) => self.extract_v2_strict(ohttp_relay, rs),
+            Err(e) => {
+                log::warn!("Failed to extract `rs` pubkey, falling back to v1: {}", e);
+                let (req, context_v1) = self.extract_v1()?;
+                Ok((req, ContextV2 { context_v1, e: None, ohttp_res: None }))
+            }
+        }
+    }
+
+    /// Extract serialized Request and Context from a Payjoin Proposal.
+    ///
+    /// This method requires the `rs` pubkey to be extracted from the endpoint
+    /// and has no fallback to v1.
+    #[cfg(feature = "v2")]
+    fn extract_v2_strict(
+        &mut self,
+        ohttp_relay: Url,
+        rs: PublicKey,
+    ) -> Result<(Request, ContextV2), CreateRequestError> {
+        use crate::uri::UrlExt;
         let url = self.endpoint.clone();
         let body = serialize_v2_body(
             &self.psbt,
@@ -338,8 +359,7 @@ impl RequestContext {
                 .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
         log::debug!("ohttp_relay_url: {:?}", ohttp_relay);
         Ok((
-            Request { url: ohttp_relay, body, content_type: crate::request::V2_REQ_CONTENT_TYPE },
-            // this method may be called more than once to re-construct the ohttp, therefore we must clone (or TODO memoize)
+            Request::new_v2(ohttp_relay, body),
             ContextV2 {
                 context_v1: ContextV1 {
                     original_psbt: self.psbt.clone(),
@@ -350,8 +370,8 @@ impl RequestContext {
                     sequence: self.sequence,
                     min_fee_rate: self.min_fee_rate,
                 },
-                e: self.e,
-                ohttp_res,
+                e: Some(self.e),
+                ohttp_res: Some(ohttp_res),
             },
         ))
     }
@@ -515,8 +535,8 @@ pub struct ContextV1 {
 #[cfg(feature = "v2")]
 pub struct ContextV2 {
     context_v1: ContextV1,
-    e: bitcoin::secp256k1::SecretKey,
-    ohttp_res: ohttp::ClientResponse,
+    e: Option<bitcoin::secp256k1::SecretKey>,
+    ohttp_res: Option<ohttp::ClientResponse>,
 }
 
 macro_rules! check_eq {
@@ -550,21 +570,26 @@ impl ContextV2 {
         self,
         response: &mut impl std::io::Read,
     ) -> Result<Option<Psbt>, ResponseError> {
-        let mut res_buf = Vec::new();
-        response.read_to_end(&mut res_buf).map_err(InternalValidationError::Io)?;
-        let response = crate::v2::ohttp_decapsulate(self.ohttp_res, &res_buf)
-            .map_err(InternalValidationError::OhttpEncapsulation)?;
-        let mut body = match response.status() {
-            http::StatusCode::OK => response.body().to_vec(),
-            http::StatusCode::ACCEPTED => return Ok(None),
-            _ => return Err(InternalValidationError::UnexpectedStatusCode)?,
-        };
-        let psbt = crate::v2::decrypt_message_b(&mut body, self.e)
-            .map_err(InternalValidationError::HpkeError)?;
+        match (self.ohttp_res, self.e) {
+            (Some(ohttp_res), Some(e)) => {
+                let mut res_buf = Vec::new();
+                response.read_to_end(&mut res_buf).map_err(InternalValidationError::Io)?;
+                let response = crate::v2::ohttp_decapsulate(ohttp_res, &res_buf)
+                    .map_err(InternalValidationError::OhttpEncapsulation)?;
+                let mut body = match response.status() {
+                    http::StatusCode::OK => response.body().to_vec(),
+                    http::StatusCode::ACCEPTED => return Ok(None),
+                    _ => return Err(InternalValidationError::UnexpectedStatusCode)?,
+                };
+                let psbt = crate::v2::decrypt_message_b(&mut body, e)
+                    .map_err(InternalValidationError::HpkeError)?;
 
-        let proposal = Psbt::deserialize(&psbt).map_err(InternalValidationError::Psbt)?;
-        let processed_proposal = self.context_v1.process_proposal(proposal)?;
-        Ok(Some(processed_proposal))
+                let proposal = Psbt::deserialize(&psbt).map_err(InternalValidationError::Psbt)?;
+                let processed_proposal = self.context_v1.process_proposal(proposal)?;
+                Ok(Some(processed_proposal))
+            }
+            _ => self.context_v1.process_response(response).map(Some),
+        }
     }
 }
 


### PR DESCRIPTION
Fix #144

This lets v2 feature enabled senders attempt a v1 send if v2 request session public keys are not available.

It does this entirely within the send state machine and requires minimal changes upstream (just setting the `content-type` header from `Request` instead of manually.

- Patch 1 changes a pure function to a method since it's only ever used as a method
- Patch 2 includes the content-type header in the Request struct, since the extract_v2 method will switch depending on what it returns, and it makes it more obvious what header to set for all requests
- Patch 3 actually fixes the bug and has `extract_v2` return the fallback if no v2 pubkey is available
- Patch 4 removes a [duplicate](https://github.com/payjoin/rust-payjoin/blob/ff350d5c48dcebbc0dc09d4588dff2397246fdd1/payjoin-cli/src/app/v1.rs#L243-L250) print statement

It uncovered some of the issues with the feature gated error variants in the send module, which probably could be separated. It also uncovered that the integration tests do not use an actual HTTP server for V1 test cases, which I think is OK but I want to raise as a consideration.

- [x] write an integration test