### PR TITLE
Remove `contribute_non_witness_input`

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -408,10 +408,6 @@ impl ProvisionalProposal {
         self.inner.contribute_witness_input(txo, outpoint)
     }
 
-    pub fn contribute_non_witness_input(&mut self, tx: bitcoin::Transaction, outpoint: OutPoint) {
-        self.inner.contribute_non_witness_input(tx, outpoint)
-    }
-
     pub fn is_output_substitution_disabled(&self) -> bool {
         self.inner.is_output_substitution_disabled()
     }


### PR DESCRIPTION
Remove a maintenance burden that's unnecessary at this time. Support for non_witness inputs can be added back later if/when we move to using PSBTv2 internally, without having to maintain separate logic.