### PR TITLE
Use More Semantic HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,12 +132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
 dependencies = [
  "jobserver",
  "libc",
@@ -785,12 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,25 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
-name = "h2"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,12 +1000,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -1215,7 +1178,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1315,16 +1277,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
-dependencies = [
- "equivalent",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1628,7 +1580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2487,18 +2439,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2507,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -34,7 +34,7 @@ clap = { version = "~4.0.32", features = ["derive"] }
 config = "0.13.3"
 env_logger = "0.9.0"
 http-body-util = { version = "0.1", optional = true }
-hyper = { version = "1", features = ["full"], optional = true }
+hyper = { version = "1", features = ["http1", "server"], optional = true }
 hyper-rustls = { version = "0.26", optional = true }
 hyper-util = { version = "0.1", optional = true }
 log = "0.4.7"

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -457,7 +457,14 @@ mod e2e {
             let db = docker.run(Redis::default());
             let db_host = format!("127.0.0.1:{}", db.get_host_port_ipv4(6379));
             println!("Database running on {}", db.get_host_port_ipv4(6379));
-            payjoin_directory::listen_tcp_with_tls(port, db_host, timeout, local_cert_key).await
+            payjoin_directory::listen_tcp_with_tls(
+                format!("http://localhost:{}", port),
+                port,
+                db_host,
+                timeout,
+                local_cert_key,
+            )
+            .await
         }
 
         // generates or gets a DER encoded localhost cert and key.

--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -22,7 +22,7 @@ bitcoin = { version = "0.32.2", features = ["base64"] }
 bhttp = { version = "=0.5.1", features = ["http"] }
 futures = "0.3.17"
 http-body-util = "0.1.2"
-hyper = { version = "1" }
+hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.26", optional = true }
 hyper-util = "0.1"
 ohttp = "0.5.1"

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -224,7 +224,7 @@ async fn handle_v2(
         (Method::POST, &["", ""]) => post_session(body).await,
         (Method::POST, &["", id]) => post_fallback_v2(id, body, pool).await,
         (Method::GET, &["", id]) => get_fallback(id, pool).await,
-        (Method::POST, &["", id, "payjoin"]) => post_payjoin(id, body, pool).await,
+        (Method::PUT, &["", id]) => post_payjoin(id, body, pool).await,
         _ => Ok(not_found()),
     }
 }

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -8,7 +8,7 @@ use bitcoin::base64::Engine;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::body::{Body, Bytes, Incoming};
-use hyper::header::{HeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_TYPE};
+use hyper::header::{HeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_TYPE, LOCATION};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode, Uri};
@@ -20,6 +20,7 @@ use tracing::{debug, error, info, trace};
 pub const DEFAULT_DIR_PORT: u16 = 8080;
 pub const DEFAULT_DB_HOST: &str = "localhost:6379";
 pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+pub const DEFAULT_BASE_URL: &str = "https://localhost";
 
 const MAX_BUFFER_SIZE: usize = 65536;
 
@@ -31,6 +32,7 @@ mod db;
 use crate::db::DbPool;
 
 pub async fn listen_tcp(
+    base_url: String,
     port: u16,
     db_host: String,
     timeout: Duration,
@@ -42,13 +44,14 @@ pub async fn listen_tcp(
     while let Ok((stream, _)) = listener.accept().await {
         let pool = pool.clone();
         let ohttp = ohttp.clone();
+        let base_url = base_url.clone();
         let io = TokioIo::new(stream);
         tokio::spawn(async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(
                     io,
                     service_fn(move |req| {
-                        serve_payjoin_directory(req, pool.clone(), ohttp.clone())
+                        serve_payjoin_directory(req, pool.clone(), ohttp.clone(), base_url.clone())
                     }),
                 )
                 .with_upgrades()
@@ -64,6 +67,7 @@ pub async fn listen_tcp(
 
 #[cfg(feature = "danger-local-https")]
 pub async fn listen_tcp_with_tls(
+    base_url: String,
     port: u16,
     db_host: String,
     timeout: Duration,
@@ -77,6 +81,7 @@ pub async fn listen_tcp_with_tls(
     while let Ok((stream, _)) = listener.accept().await {
         let pool = pool.clone();
         let ohttp = ohttp.clone();
+        let base_url = base_url.clone();
         let tls_acceptor = tls_acceptor.clone();
         tokio::spawn(async move {
             let tls_stream = match tls_acceptor.accept(stream).await {
@@ -90,7 +95,7 @@ pub async fn listen_tcp_with_tls(
                 .serve_connection(
                     TokioIo::new(tls_stream),
                     service_fn(move |req| {
-                        serve_payjoin_directory(req, pool.clone(), ohttp.clone())
+                        serve_payjoin_directory(req, pool.clone(), ohttp.clone(), base_url.clone())
                     }),
                 )
                 .with_upgrades()
@@ -143,6 +148,7 @@ async fn serve_payjoin_directory(
     req: Request<Incoming>,
     pool: DbPool,
     ohttp: Arc<Mutex<ohttp::Server>>,
+    base_url: String,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>> {
     let path = req.uri().path().to_string();
     let query = req.uri().query().unwrap_or_default().to_string();
@@ -151,7 +157,7 @@ async fn serve_payjoin_directory(
     let path_segments: Vec<&str> = path.split('/').collect();
     debug!("serve_payjoin_directory: {:?}", &path_segments);
     let mut response = match (parts.method, path_segments.as_slice()) {
-        (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp).await,
+        (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp, base_url).await,
         (Method::GET, ["", "ohttp-keys"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", id]) => post_fallback_v1(id, query, body, pool).await,
         (Method::GET, ["", "health"]) => health_check().await,
@@ -169,6 +175,7 @@ async fn handle_ohttp_gateway(
     body: Incoming,
     pool: DbPool,
     ohttp: Arc<Mutex<ohttp::Server>>,
+    base_url: String,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError> {
     // decapsulate
     let ohttp_body =
@@ -194,10 +201,13 @@ async fn handle_ohttp_gateway(
     }
     let request = http_req.body(full(body))?;
 
-    let response = handle_v2(pool, request).await?;
+    let response = handle_v2(pool, base_url, request).await?;
 
     let (parts, body) = response.into_parts();
     let mut bhttp_res = bhttp::Message::response(parts.status.as_u16());
+    for (name, value) in parts.headers.iter() {
+        bhttp_res.put_header(name.as_str(), value.to_str().unwrap_or_default());
+    }
     let full_body =
         body.collect().await.map_err(|e| HandlerError::InternalServerError(e.into()))?.to_bytes();
     bhttp_res.write_content(&full_body);
@@ -213,6 +223,7 @@ async fn handle_ohttp_gateway(
 
 async fn handle_v2(
     pool: DbPool,
+    base_url: String,
     req: Request<BoxBody<Bytes, hyper::Error>>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError> {
     let path = req.uri().path().to_string();
@@ -221,7 +232,7 @@ async fn handle_v2(
     let path_segments: Vec<&str> = path.split('/').collect();
     debug!("handle_v2: {:?}", &path_segments);
     match (parts.method, path_segments.as_slice()) {
-        (Method::POST, &["", ""]) => post_session(body).await,
+        (Method::POST, &["", ""]) => post_session(base_url, body).await,
         (Method::POST, &["", id]) => post_fallback_v2(id, body, pool).await,
         (Method::GET, &["", id]) => get_fallback(id, pool).await,
         (Method::PUT, &["", id]) => post_payjoin(id, body, pool).await,
@@ -233,6 +244,7 @@ async fn health_check() -> Result<Response<BoxBody<Bytes, hyper::Error>>, Handle
     Ok(Response::new(empty()))
 }
 
+#[derive(Debug)]
 enum HandlerError {
     PayloadTooLarge,
     InternalServerError(anyhow::Error),
@@ -273,6 +285,7 @@ impl From<hyper::http::Error> for HandlerError {
 }
 
 async fn post_session(
+    base_url: String,
     body: BoxBody<Bytes, hyper::Error>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError> {
     let bytes = body.collect().await.map_err(|e| HandlerError::BadRequest(e.into()))?.to_bytes();
@@ -283,9 +296,10 @@ async fn post_session(
     let pubkey = bitcoin::secp256k1::PublicKey::from_slice(&pubkey_bytes)
         .map_err(|e| HandlerError::BadRequest(e.into()))?;
     tracing::info!("Initialized session with pubkey: {:?}", pubkey);
-    let mut res = Response::new(empty());
-    *res.status_mut() = StatusCode::NO_CONTENT;
-    Ok(res)
+    Ok(Response::builder()
+        .header(LOCATION, format!("{}/{}", base_url, pubkey))
+        .status(StatusCode::CREATED)
+        .body(empty())?)
 }
 
 async fn post_fallback_v1(
@@ -412,4 +426,33 @@ fn empty() -> BoxBody<Bytes, hyper::Error> {
 
 fn full<T: Into<Bytes>>(chunk: T) -> BoxBody<Bytes, hyper::Error> {
     Full::new(chunk.into()).map_err(|never| match never {}).boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::Request;
+
+    use super::*;
+
+    /// Ensure that the POST / endpoint returns a 201 Created with a Location header
+    /// as is semantically correct when creating a resource.
+    ///
+    /// https://datatracker.ietf.org/doc/html/rfc9110#name-post
+    #[tokio::test]
+    async fn test_post_session() -> Result<(), Box<dyn std::error::Error>> {
+        let base_url = "https://localhost".to_string();
+        let body = full("some_base64_encoded_pubkey");
+
+        let request = Request::builder().method(Method::POST).uri("/").body(body)?;
+
+        let response = post_session(base_url.clone(), request.into_body())
+            .await
+            .map_err(|e| format!("{:?}", e))?;
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert!(response.headers().contains_key(LOCATION));
+        let location_header = response.headers().get(LOCATION).ok_or("Missing LOCATION header")?;
+        assert!(location_header.to_str()?.starts_with(&base_url));
+        Ok(())
+    }
 }

--- a/payjoin-directory/src/main.rs
+++ b/payjoin-directory/src/main.rs
@@ -17,7 +17,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let db_host = env::var("PJ_DB_HOST").unwrap_or_else(|_| DEFAULT_DB_HOST.to_string());
 
-    payjoin_directory::listen_tcp(dir_port, db_host, timeout).await
+    let base_url = env::var("PJ_DIR_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+
+    payjoin_directory::listen_tcp(base_url, dir_port, db_host, timeout).await
 }
 
 fn init_logging() {

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -29,6 +29,7 @@ static TWENTY_FOUR_HOURS_DEFAULT_EXPIRY: Duration = Duration::from_secs(60 * 60 
 struct SessionContext {
     address: Address,
     directory: url::Url,
+    subdirectory: Option<url::Url>,
     ohttp_keys: OhttpKeys,
     expiry: SystemTime,
     ohttp_relay: url::Url,
@@ -72,6 +73,7 @@ impl SessionInitializer {
             context: SessionContext {
                 address,
                 directory,
+                subdirectory: None,
                 ohttp_keys,
                 ohttp_relay,
                 expiry: SystemTime::now()
@@ -96,7 +98,7 @@ impl SessionInitializer {
     }
 
     pub fn process_res(
-        self,
+        mut self,
         mut res: impl std::io::Read,
         ctx: ohttp::ClientResponse,
     ) -> Result<ActiveSession, Error> {
@@ -106,6 +108,15 @@ impl SessionInitializer {
         if !response.status().is_success() {
             return Err(Error::Server("Enrollment failed, expected success status".into()));
         }
+        log::debug!("Received response headers: {:?}", response.headers());
+        let location = response
+            .headers()
+            .get("location")
+            .ok_or(Error::Server("Missing location header".into()))?
+            .to_str()
+            .map_err(|e| Error::Server(format!("Invalid location header: {}", e).into()))?;
+        self.context.subdirectory =
+            Some(url::Url::parse(location).map_err(|e| Error::Server(e.into()))?);
 
         Ok(ActiveSession { context: self.context.clone() })
     }
@@ -509,6 +520,7 @@ impl Serialize for SessionContext {
         let mut state = serializer.serialize_struct("SessionContext", 4)?;
         state.serialize_field("address", &self.address)?;
         state.serialize_field("directory", &self.directory)?;
+        state.serialize_field("subdirectory", &self.subdirectory)?;
         state.serialize_field("ohttp_keys", &self.ohttp_keys)?;
         state.serialize_field("ohttp_relay", &self.ohttp_relay)?;
         state.serialize_field("expiry", &self.expiry)?;
@@ -529,6 +541,7 @@ impl<'de> Deserialize<'de> for SessionContext {
         enum Field {
             Address,
             Directory,
+            Subdirectory,
             OhttpKeys,
             OhttpRelay,
             Expiry,
@@ -551,6 +564,7 @@ impl<'de> Deserialize<'de> for SessionContext {
             {
                 let mut address: Option<Address<NetworkUnchecked>> = None;
                 let mut directory = None;
+                let mut subdirectory = None;
                 let mut ohttp_keys = None;
                 let mut ohttp_relay = None;
                 let mut expiry = None;
@@ -569,6 +583,12 @@ impl<'de> Deserialize<'de> for SessionContext {
                                 return Err(de::Error::duplicate_field("directory"));
                             }
                             directory = Some(map.next_value()?);
+                        }
+                        Field::Subdirectory => {
+                            if subdirectory.is_some() {
+                                return Err(de::Error::duplicate_field("subdirectory"));
+                            }
+                            subdirectory = Some(map.next_value()?);
                         }
                         Field::OhttpKeys => {
                             if ohttp_keys.is_some() {
@@ -606,6 +626,8 @@ impl<'de> Deserialize<'de> for SessionContext {
                     .ok_or_else(|| de::Error::missing_field("address"))
                     .map(|a| a.assume_checked())?;
                 let directory = directory.ok_or_else(|| de::Error::missing_field("directory"))?;
+                let subdirectory =
+                    subdirectory.ok_or_else(|| de::Error::missing_field("subdirectory"))?;
                 let ohttp_keys =
                     ohttp_keys.ok_or_else(|| de::Error::missing_field("ohttp_keys"))?;
                 let ohttp_relay =
@@ -613,7 +635,16 @@ impl<'de> Deserialize<'de> for SessionContext {
                 let expiry = expiry.ok_or_else(|| de::Error::missing_field("expiry"))?;
                 let s = s.ok_or_else(|| de::Error::missing_field("s"))?;
                 let e = e.ok_or_else(|| de::Error::missing_field("e"))?;
-                Ok(SessionContext { address, directory, ohttp_keys, ohttp_relay, expiry, s, e })
+                Ok(SessionContext {
+                    address,
+                    directory,
+                    subdirectory,
+                    ohttp_keys,
+                    ohttp_relay,
+                    expiry,
+                    s,
+                    e,
+                })
             }
         }
 
@@ -642,6 +673,7 @@ mod test {
                     .unwrap()
                     .assume_checked(),
                 directory: url::Url::parse("https://directory.com").unwrap(),
+                subdirectory: None,
                 ohttp_keys: OhttpKeys(
                     ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap(),
                 ),

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -462,16 +462,14 @@ impl PayjoinProposal {
             }
             None => Ok(self.extract_v1_req().as_bytes().to_vec()),
         }?;
-        let post_payjoin_target = format!(
-            "{}{}/payjoin",
-            self.context.directory.as_str(),
-            subdir_path_from_pubkey(&self.context.s.public_key())
-        );
+        let subdir_path = subdir_path_from_pubkey(&self.context.s.public_key());
+        let post_payjoin_target =
+            self.context.directory.join(&subdir_path).map_err(|e| Error::Server(e.into()))?;
         log::debug!("Payjoin post target: {}", post_payjoin_target.as_str());
         let (body, ctx) = crate::v2::ohttp_encapsulate(
             &mut self.context.ohttp_keys,
-            "POST",
-            &post_payjoin_target,
+            "PUT",
+            post_payjoin_target.as_str(),
             Some(&body),
         )?;
         let url = self.context.ohttp_relay.clone();

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -571,7 +571,14 @@ mod integration {
             let db = docker.run(Redis::default());
             let db_host = format!("127.0.0.1:{}", db.get_host_port_ipv4(6379));
             println!("Database running on {}", db.get_host_port_ipv4(6379));
-            payjoin_directory::listen_tcp_with_tls(port, db_host, timeout, local_cert_key).await
+            payjoin_directory::listen_tcp_with_tls(
+                format!("http://localhost:{}", port),
+                port,
+                db_host,
+                timeout,
+                local_cert_key,
+            )
+            .await
         }
 
         // generates or gets a DER encoded localhost cert and key.


### PR DESCRIPTION
Close #345

These are both backwards-incompatible protocol changes (old v2 vs new v2)

The first patch changes 2 POST requests for sender/receiver to a POST on a session id that establishes the fallback_psbt and a PUT on the session id that updates it to a payjoin_psbt

The second patch has a session ID establishment POST return the new resource URL (session subdirectory) in the "location" header. I'm less sure of this change than the former since it complicates the code for the sake of following "semantic" HTTP [POST](https://datatracker.ietf.org/doc/html/rfc9110#name-post), but it also prevents a payjoin-directory from creating a resource in another subdirectory on a domain that a client can't easily derive.

@spacebear21 I'm hoping you can weigh in.