### PR TITLE
Enable hyper-util/tokio for TokioIo

### DIFF
--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.17"
 http-body-util = "0.1.2"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.26", optional = true }
-hyper-util = "0.1"
+hyper-util = { version = "0.1", features = ["tokio"] }
 ohttp = "0.5.1"
 redis = { version = "0.23.3", features = ["aio", "tokio-comp"] }
 rustls = { version = "0.22.4", optional = true }


### PR DESCRIPTION
In trying to ship a release for payjoin-directory I realized that this feature has to be enabled in order to build

This seems to have been enabled already in `payjoin-cli` with `cargo build --features v1` for use [here](https://github.com/payjoin/rust-payjoin/blob/2027ee7b8a328311b2e2eb5a38935a8b49a62a12/payjoin-cli/src/app/v1.rs#L161) because `reqwest` depends on `hyper/client` which depends on `hyper-util/client-legacy` which depends on `hyper-util/tokio`. Discovered via `cargo tree -e features`