### PR TITLE
Make `try_preserving_privacy` param generic

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -388,7 +388,9 @@ fn try_contributing_inputs(
         .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
         .collect();
 
-    let selected_outpoint = payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
+    let selected_outpoint = payjoin
+        .try_preserving_privacy(candidate_inputs)
+        .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
     let selected_utxo = available_inputs
         .iter()
         .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -367,7 +367,9 @@ fn try_contributing_inputs(
         .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
         .collect();
 
-    let selected_outpoint = payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
+    let selected_outpoint = payjoin
+        .try_preserving_privacy(candidate_inputs)
+        .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
     let selected_utxo = available_inputs
         .iter()
         .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
@@ -460,7 +459,7 @@ impl WantsInputs {
     /// https://eprint.iacr.org/2022/589.pdf
     pub fn try_preserving_privacy(
         &self,
-        candidate_inputs: HashMap<Amount, OutPoint>,
+        candidate_inputs: impl IntoIterator<Item = (Amount, OutPoint)>,
     ) -> Result<OutPoint, SelectionError> {
         self.inner.try_preserving_privacy(candidate_inputs)
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -632,7 +632,9 @@ mod integration {
                 .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
                 .collect();
 
-            let selected_outpoint = payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
+            let selected_outpoint = payjoin
+                .try_preserving_privacy(candidate_inputs)
+                .expect("Failed to make privacy preserving selection");
             let selected_utxo = available_inputs
                 .iter()
                 .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
@@ -1091,8 +1093,9 @@ mod integration {
                     .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
                     .collect();
 
-                let selected_outpoint =
-                    payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
+                let selected_outpoint = payjoin
+                    .try_preserving_privacy(candidate_inputs)
+                    .expect("Failed to make privacy preserving selection");
                 let selected_utxo = available_inputs
                     .iter()
                     .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)


### PR DESCRIPTION
Fix #70 

IntoIter is generic and allows a Database or BTreeMap to be used as a try_preserving_privacy parameter
instead of the concrete HashMap type