### PR TITLE
Export InputContributionError

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -38,10 +38,12 @@ pub mod v2;
 
 use bitcoin::secp256k1::rand::seq::SliceRandom;
 use bitcoin::secp256k1::rand::{self, Rng};
-pub use error::{Error, OutputSubstitutionError, RequestError, SelectionError};
+pub use error::{
+    Error, InputContributionError, OutputSubstitutionError, RequestError, SelectionError,
+};
 use error::{
-    InputContributionError, InternalInputContributionError, InternalOutputSubstitutionError,
-    InternalRequestError, InternalSelectionError,
+    InternalInputContributionError, InternalOutputSubstitutionError, InternalRequestError,
+    InternalSelectionError,
 };
 use optional_parameters::Params;
 


### PR DESCRIPTION
Since it's a public error downstream implementations may need to switch on it or define types over it

I need this specifically for bindings