### PR TITLE
Work around '#' escaping bug in bip21 crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -206,16 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip21"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe7a7f5928d264879d5b65eb18a72ea1890c57f22d62ee2eba93f207a6a020b"
-dependencies = [
- "bitcoin",
- "percent-encoding-rfc3986",
-]
-
-[[package]]
 name = "bitcoin"
 version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +300,16 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_uri"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0a228e083d1702f83389b0ac71eb70078dc8d7fcbb6cde864d1cbca145f5cc"
+dependencies = [
+ "bitcoin",
+ "percent-encoding-rfc3986",
 ]
 
 [[package]]
@@ -1580,10 +1580,10 @@ name = "payjoin"
 version = "0.20.0"
 dependencies = [
  "bhttp",
- "bip21",
  "bitcoin",
  "bitcoin-hpke",
  "bitcoin-ohttp",
+ "bitcoin_uri",
  "bitcoind",
  "http",
  "log",
@@ -1609,7 +1609,6 @@ version = "0.0.9-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "bip21",
  "bitcoincore-rpc",
  "bitcoind",
  "clap",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -206,16 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip21"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe7a7f5928d264879d5b65eb18a72ea1890c57f22d62ee2eba93f207a6a020b"
-dependencies = [
- "bitcoin",
- "percent-encoding-rfc3986",
-]
-
-[[package]]
 name = "bitcoin"
 version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +300,16 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_uri"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0a228e083d1702f83389b0ac71eb70078dc8d7fcbb6cde864d1cbca145f5cc"
+dependencies = [
+ "bitcoin",
+ "percent-encoding-rfc3986",
 ]
 
 [[package]]
@@ -1580,10 +1580,10 @@ name = "payjoin"
 version = "0.20.0"
 dependencies = [
  "bhttp",
- "bip21",
  "bitcoin",
  "bitcoin-hpke",
  "bitcoin-ohttp",
+ "bitcoin_uri",
  "bitcoind",
  "http",
  "log",
@@ -1609,7 +1609,6 @@ version = "0.0.9-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "bip21",
  "bitcoincore-rpc",
  "bitcoind",
  "clap",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -28,7 +28,6 @@ v2 = ["payjoin/v2", "payjoin/io"]
 [dependencies]
 anyhow = "1.0.70"
 async-trait = "0.1"
-bip21 = "0.5.0"
 bitcoincore-rpc = "0.19.0"
 clap = { version = "~4.0.32", features = ["derive"] }
 config = "0.13.3"

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -25,7 +25,7 @@ _danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
 [dependencies]
 bitcoin = { version = "0.32.5", features = ["base64"] }
-bip21 = "0.5.0"
+bitcoin_uri = "0.1.0"
 hpke = { package = "bitcoin-hpke", version = "0.13.0", optional = true }
 log = { version = "0.4.14"}
 http = { version = "1", optional = true }

--- a/payjoin/src/uri/url_ext.rs
+++ b/payjoin/src/uri/url_ext.rs
@@ -160,9 +160,19 @@ mod tests {
     #[test]
     fn test_valid_v2_url_fragment_on_bip21() {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
-                   &pj=https://example.com\
-                   #OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
-        let uri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
-        assert!(uri.extras.endpoint().ohttp().is_some());
+                   &pjos=0&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let pjuri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
+        assert!(pjuri.extras.endpoint().ohttp().is_some());
+        assert_eq!(format!("{}", pjuri), uri);
+
+        let reordered = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
+                   &pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC\
+                   &pjos=0";
+        let pjuri =
+            Uri::try_from(reordered).unwrap().assume_checked().check_pj_supported().unwrap();
+        assert!(pjuri.extras.endpoint().ohttp().is_some());
+        assert_eq!(format!("{}", pjuri), uri);
     }
 }


### PR DESCRIPTION
The `pj` parameter of the BIP 21 URL is itself a URL which contains a
fragment.

The # character was not escaped by bip21 during serialization. According
to RFC 3986, this terminates the query string, effectively truncating the `pj`
parameter.

The buggy deserialization likewise ignored #, parsing it as part of the
value, which survived a round trips with the incorrect serialization
behavior.

Upstream fix PR: https://github.com/payjoin/bitcoin_uri/pull/3