### PR TITLE
Derive Debug Clone on send,receive mod types

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -168,7 +168,7 @@ impl UncheckedProposal {
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
 /// Call [`Self::check_inputs_not_owned`] to proceed.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MaybeInputsOwned {
     psbt: Psbt,
     params: Params,
@@ -212,7 +212,7 @@ impl MaybeInputsOwned {
 /// Typestate to validate that the Original PSBT has no inputs that have been seen before.
 ///
 /// Call [`Self::check_no_inputs_seen_before`] to proceed.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MaybeInputsSeen {
     psbt: Psbt,
     params: Params,
@@ -246,7 +246,7 @@ impl MaybeInputsSeen {
 ///
 /// Only accept PSBTs that send us money.
 /// Identify those outputs with [`Self::identify_receiver_outputs`] to proceed.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct OutputsUnknown {
     psbt: Psbt,
     params: Params,
@@ -864,7 +864,7 @@ impl ProvisionalProposal {
 
 /// A finalized payjoin proposal, complete with fees and receiver signatures, that the sender
 /// should find acceptable.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PayjoinProposal {
     payjoin_psbt: Psbt,
     params: Params,

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -260,7 +260,7 @@ impl UncheckedProposal {
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
 /// Call [`check_no_receiver_owned_inputs()`](struct.UncheckedProposal.html#method.check_no_receiver_owned_inputs) to proceed.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MaybeInputsOwned {
     inner: super::MaybeInputsOwned,
     context: SessionContext,
@@ -283,7 +283,7 @@ impl MaybeInputsOwned {
 /// Typestate to validate that the Original PSBT has no inputs that have been seen before.
 ///
 /// Call [`check_no_inputs_seen`](struct.MaybeInputsSeen.html#method.check_no_inputs_seen_before) to proceed.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MaybeInputsSeen {
     inner: super::MaybeInputsSeen,
     context: SessionContext,
@@ -306,7 +306,7 @@ impl MaybeInputsSeen {
 ///
 /// Only accept PSBTs that send us money.
 /// Identify those outputs with `identify_receiver_outputs()` to proceed
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct OutputsUnknown {
     inner: super::OutputsUnknown,
     context: SessionContext,

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -372,6 +372,7 @@ pub enum Context {
     V2(V2PostContext),
 }
 
+#[derive(Debug, Clone)]
 pub struct V1Context {
     psbt_context: PsbtContext,
 }
@@ -418,6 +419,7 @@ impl V2PostContext {
 }
 
 #[cfg(feature = "v2")]
+#[derive(Debug, Clone)]
 pub struct V2GetContext {
     endpoint: Url,
     psbt_ctx: PsbtContext,
@@ -491,6 +493,7 @@ pub struct PsbtContext {
 }
 
 #[cfg(feature = "v2")]
+#[derive(Debug, Clone)]
 struct HpkeContext {
     receiver: HpkePublicKey,
     reply_pair: HpkeKeyPair,


### PR DESCRIPTION
These trait implementations make a hygienic Rust API, and some are needed for downstream bindings (V1Context Clone specifically)