### PR TITLE
Modify try_preserving_privacy function signature

### DIFF
--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -7,8 +7,9 @@ use bitcoin::TxIn;
 use bitcoincore_rpc::bitcoin::Amount;
 use bitcoincore_rpc::RpcApi;
 use payjoin::bitcoin::psbt::Psbt;
+use payjoin::receive::InputPair;
 use payjoin::send::Sender;
-use payjoin::{bitcoin, InputPair, PjUri};
+use payjoin::{bitcoin, PjUri};
 
 pub mod config;
 use crate::app::config::AppConfig;

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -7,6 +7,7 @@ use bitcoin::TxIn;
 use bitcoincore_rpc::bitcoin::Amount;
 use bitcoincore_rpc::RpcApi;
 use payjoin::bitcoin::psbt::Psbt;
+use payjoin::psbt::InputPair;
 use payjoin::send::Sender;
 use payjoin::{bitcoin, PjUri};
 
@@ -125,7 +126,7 @@ fn read_local_cert() -> Result<Vec<u8>> {
 
 pub fn input_pair_from_list_unspent(
     utxo: bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry,
-) -> (PsbtInput, TxIn) {
+) -> InputPair {
     let psbtin = PsbtInput {
         // NOTE: non_witness_utxo is not necessary because bitcoin-cli always supplies
         // witness_utxo, even for non-witness inputs
@@ -141,5 +142,5 @@ pub fn input_pair_from_list_unspent(
         previous_output: bitcoin::OutPoint { txid: utxo.txid, vout: utxo.vout },
         ..Default::default()
     };
-    (psbtin, txin)
+    InputPair::new(txin, psbtin).expect("Input pair should be valid")
 }

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -124,7 +124,7 @@ fn read_local_cert() -> Result<Vec<u8>> {
 }
 
 pub fn input_pair_from_list_unspent(
-    utxo: &bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry,
+    utxo: bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry,
 ) -> (PsbtInput, TxIn) {
     let psbtin = PsbtInput {
         // NOTE: non_witness_utxo is not necessary because bitcoin-cli always supplies

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -7,9 +7,8 @@ use bitcoin::TxIn;
 use bitcoincore_rpc::bitcoin::Amount;
 use bitcoincore_rpc::RpcApi;
 use payjoin::bitcoin::psbt::Psbt;
-use payjoin::psbt::InputPair;
 use payjoin::send::Sender;
-use payjoin::{bitcoin, PjUri};
+use payjoin::{bitcoin, InputPair, PjUri};
 
 pub mod config;
 use crate::app::config::AppConfig;

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -375,28 +375,18 @@ fn try_contributing_inputs(
     payjoin: payjoin::receive::WantsInputs,
     bitcoind: &bitcoincore_rpc::Client,
 ) -> Result<payjoin::receive::ProvisionalProposal> {
-    use bitcoin::OutPoint;
-
-    let available_inputs = bitcoind
+    let candidate_inputs = bitcoind
         .list_unspent(None, None, None, None, None)
-        .context("Failed to list unspent from bitcoind")?;
-    let candidate_inputs: HashMap<Amount, OutPoint> = available_inputs
-        .iter()
-        .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
-        .collect();
-
-    let selected_outpoint = payjoin
+        .context("Failed to list unspent from bitcoind")?
+        .into_iter()
+        .map(input_pair_from_list_unspent);
+    let selected_input = payjoin
         .try_preserving_privacy(candidate_inputs)
         .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
-    let selected_utxo = available_inputs
-        .iter()
-        .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
-        .context("This shouldn't happen. Failed to retrieve the privacy preserving utxo from those we provided to the seclector.")?;
-    log::debug!("selected utxo: {:#?}", selected_utxo);
-    let input_pair = input_pair_from_list_unspent(selected_utxo);
+    log::debug!("selected input: {:#?}", selected_input);
 
     Ok(payjoin
-        .contribute_inputs(vec![input_pair])
+        .contribute_inputs(vec![selected_input])
         .expect("This shouldn't happen. Failed to contribute inputs.")
         .commit_inputs())
 }

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::ohttp::OhttpKeys;
 pub mod io;
 
 #[cfg(any(feature = "send", feature = "receive"))]
-pub(crate) mod psbt;
+pub mod psbt;
 #[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
 mod request;
 #[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::ohttp::OhttpKeys;
 pub mod io;
 
 #[cfg(any(feature = "send", feature = "receive"))]
-pub mod psbt;
+pub(crate) mod psbt;
 #[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
 mod request;
 #[cfg(any(feature = "send", all(feature = "receive", feature = "v2")))]
@@ -48,5 +48,6 @@ mod uri;
 
 #[cfg(feature = "base64")]
 pub use bitcoin::base64;
+pub use psbt::InputPair;
 pub use uri::{PjParseError, PjUri, PjUriBuilder, Uri, UriExt};
 pub use url::{ParseError, Url};

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -48,6 +48,5 @@ mod uri;
 
 #[cfg(feature = "base64")]
 pub use bitcoin::base64;
-pub use psbt::InputPair;
 pub use uri::{PjParseError, PjUri, PjUriBuilder, Uri, UriExt};
 pub use url::{ParseError, Url};

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -260,8 +260,6 @@ pub(crate) enum InternalSelectionError {
     TooManyOutputs,
     /// No selection candidates improve privacy
     NotFound,
-    /// Missing previous txout information
-    PrevTxOut(crate::psbt::PrevTxOutError),
 }
 
 impl fmt::Display for SelectionError {
@@ -274,8 +272,6 @@ impl fmt::Display for SelectionError {
             ),
             InternalSelectionError::NotFound =>
                 write!(f, "No selection candidates improve privacy"),
-            InternalSelectionError::PrevTxOut(e) =>
-                write!(f, "Missing previous txout information: {}", e),
         }
     }
 }
@@ -293,8 +289,6 @@ pub struct InputContributionError(InternalInputContributionError);
 
 #[derive(Debug)]
 pub(crate) enum InternalInputContributionError {
-    /// Missing previous txout information
-    PrevTxOut(crate::psbt::PrevTxOutError),
     /// The address type could not be determined
     AddressType(crate::psbt::AddressTypeError),
     /// The original PSBT has no inputs
@@ -308,8 +302,6 @@ pub(crate) enum InternalInputContributionError {
 impl fmt::Display for InputContributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.0 {
-            InternalInputContributionError::PrevTxOut(e) =>
-                write!(f, "Missing previous txout information: {}", e),
             InternalInputContributionError::AddressType(e) =>
                 write!(f, "The address type could not be determined: {}", e),
             InternalInputContributionError::NoSenderInputs =>

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -260,6 +260,8 @@ pub(crate) enum InternalSelectionError {
     TooManyOutputs,
     /// No selection candidates improve privacy
     NotFound,
+    /// Missing previous txout information
+    PrevTxOut(crate::psbt::PrevTxOutError),
 }
 
 impl fmt::Display for SelectionError {
@@ -272,6 +274,8 @@ impl fmt::Display for SelectionError {
             ),
             InternalSelectionError::NotFound =>
                 write!(f, "No selection candidates improve privacy"),
+            InternalSelectionError::PrevTxOut(e) =>
+                write!(f, "Missing previous txout information: {}", e),
         }
     }
 }

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -47,7 +47,8 @@ use error::{
 };
 use optional_parameters::Params;
 
-use crate::psbt::{InternalInputPair, PsbtExt, PsbtInputError};
+pub use crate::psbt::PsbtInputError;
+use crate::psbt::{InternalInputPair, InternalPsbtInputError, PsbtExt};
 
 pub trait Headers {
     fn get_header(&self, key: &str) -> Option<&str>;
@@ -66,9 +67,9 @@ impl InputPair {
         let input_pair = Self { txin, psbtin };
         let raw = InternalInputPair::from(&input_pair);
         raw.validate_utxo(true)?;
-        let address_type = raw.address_type()?;
+        let address_type = raw.address_type().map_err(InternalPsbtInputError::AddressType)?;
         if address_type == AddressType::P2sh && input_pair.psbtin.redeem_script.is_none() {
-            return Err(PsbtInputError::NoRedeemScript);
+            return Err(InternalPsbtInputError::NoRedeemScript.into());
         }
         Ok(input_pair)
     }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 use bitcoin::base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use bitcoin::base64::Engine;
 use bitcoin::psbt::{Input as PsbtInput, Psbt};
-use bitcoin::{Address, Amount, FeeRate, OutPoint, Script, TxIn, TxOut};
+use bitcoin::{Address, FeeRate, OutPoint, Script, TxIn, TxOut};
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -387,8 +387,8 @@ impl WantsInputs {
     /// https://eprint.iacr.org/2022/589.pdf
     pub fn try_preserving_privacy(
         &self,
-        candidate_inputs: impl IntoIterator<Item = (Amount, OutPoint)>,
-    ) -> Result<OutPoint, SelectionError> {
+        candidate_inputs: impl IntoIterator<Item = (PsbtInput, TxIn)>,
+    ) -> Result<(PsbtInput, TxIn), SelectionError> {
         self.inner.try_preserving_privacy(candidate_inputs)
     }
 

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, SystemTime};
 
 use bitcoin::base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use bitcoin::base64::Engine;
-use bitcoin::psbt::{Input as PsbtInput, Psbt};
-use bitcoin::{Address, FeeRate, OutPoint, Script, TxIn, TxOut};
+use bitcoin::psbt::Psbt;
+use bitcoin::{Address, FeeRate, OutPoint, Script, TxOut};
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::hpke::{decrypt_message_a, encrypt_message_b, HpkeKeyPair, HpkePublicKey};
 use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate, OhttpEncapsulationError, OhttpKeys};
-use crate::psbt::PsbtExt;
+use crate::psbt::{InputPair, PsbtExt};
 use crate::receive::optional_parameters::Params;
 use crate::{PjUriBuilder, Request};
 
@@ -387,8 +387,8 @@ impl WantsInputs {
     /// https://eprint.iacr.org/2022/589.pdf
     pub fn try_preserving_privacy(
         &self,
-        candidate_inputs: impl IntoIterator<Item = (PsbtInput, TxIn)>,
-    ) -> Result<(PsbtInput, TxIn), SelectionError> {
+        candidate_inputs: impl IntoIterator<Item = InputPair>,
+    ) -> Result<InputPair, SelectionError> {
         self.inner.try_preserving_privacy(candidate_inputs)
     }
 
@@ -396,7 +396,7 @@ impl WantsInputs {
     /// Any excess input amount is added to the change_vout output indicated previously.
     pub fn contribute_inputs(
         self,
-        inputs: impl IntoIterator<Item = (PsbtInput, TxIn)>,
+        inputs: impl IntoIterator<Item = InputPair>,
     ) -> Result<WantsInputs, InputContributionError> {
         let inner = self.inner.contribute_inputs(inputs)?;
         Ok(WantsInputs { inner, context: self.context })

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -16,8 +16,9 @@ use super::{
 };
 use crate::hpke::{decrypt_message_a, encrypt_message_b, HpkeKeyPair, HpkePublicKey};
 use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate, OhttpEncapsulationError, OhttpKeys};
-use crate::psbt::{InputPair, PsbtExt};
+use crate::psbt::PsbtExt;
 use crate::receive::optional_parameters::Params;
+use crate::receive::InputPair;
 use crate::{PjUriBuilder, Request};
 
 pub(crate) mod error;

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -12,9 +12,8 @@ mod integration {
     use bitcoind::bitcoincore_rpc::{self, RpcApi};
     use log::{log_enabled, Level};
     use once_cell::sync::{Lazy, OnceCell};
-    use payjoin::psbt::InputPair;
     use payjoin::send::SenderBuilder;
-    use payjoin::{PjUri, PjUriBuilder, Request, Uri};
+    use payjoin::{InputPair, PjUri, PjUriBuilder, Request, Uri};
     use tracing_subscriber::{EnvFilter, FmtSubscriber};
     use url::Url;
 

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -12,8 +12,9 @@ mod integration {
     use bitcoind::bitcoincore_rpc::{self, RpcApi};
     use log::{log_enabled, Level};
     use once_cell::sync::{Lazy, OnceCell};
+    use payjoin::receive::InputPair;
     use payjoin::send::SenderBuilder;
-    use payjoin::{InputPair, PjUri, PjUriBuilder, Request, Uri};
+    use payjoin::{PjUri, PjUriBuilder, Request, Uri};
     use tracing_subscriber::{EnvFilter, FmtSubscriber};
     use url::Url;
 


### PR DESCRIPTION
Addresses https://github.com/payjoin/rust-payjoin/issues/32. Instead of having `try_preserving_privacy` modify the PSBT directly as suggested in that issue, we keep the "coin selection" and "input contribution" steps separate but simplify the function interface so that they're easier to chain and reason about.

`try_preserving_privacy` now takes a `(PsbtInput, TxIn)` iterator instead of a bespoke `(Amount, Outpoint)` iterator which is lossy and unwieldy. It also returns a single `(PsbtInput, TxIn)` instead of just an `OutPoint`.

This is the same type that `contribute_inputs` takes as a parameter.