### PR TITLE
Pad ohttp req/res messages to consistent 8192 bytes

### DIFF
--- a/payjoin/src/ohttp.rs
+++ b/payjoin/src/ohttp.rs
@@ -4,6 +4,8 @@ use std::{error, fmt};
 use bitcoin::base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use bitcoin::base64::Engine;
 
+pub const PADDED_MESSAGE_BYTES: usize = 8192;
+
 pub fn ohttp_encapsulate(
     ohttp_keys: &mut ohttp::KeyConfig,
     method: &str,
@@ -33,6 +35,7 @@ pub fn ohttp_encapsulate(
     }
     let mut bhttp_req = Vec::new();
     let _ = bhttp_message.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_req);
+    bhttp_req.resize(PADDED_MESSAGE_BYTES, 0);
     let encapsulated = ctx.encapsulate(&bhttp_req)?;
     Ok(encapsulated)
 }

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -12,6 +12,8 @@ pub(crate) enum InternalSessionError {
     Expired(std::time::SystemTime),
     /// OHTTP Encapsulation failed
     OhttpEncapsulation(OhttpEncapsulationError),
+    /// Unexpected response size
+    UnexpectedResponseSize(usize),
 }
 
 impl fmt::Display for SessionError {
@@ -20,6 +22,12 @@ impl fmt::Display for SessionError {
             InternalSessionError::Expired(expiry) => write!(f, "Session expired at {:?}", expiry),
             InternalSessionError::OhttpEncapsulation(e) =>
                 write!(f, "OHTTP Encapsulation Error: {}", e),
+            InternalSessionError::UnexpectedResponseSize(size) => write!(
+                f,
+                "Unexpected response size {}, expected {} bytes",
+                size,
+                crate::ohttp::ENCAPSULATED_MESSAGE_BYTES
+            ),
         }
     }
 }
@@ -29,6 +37,7 @@ impl error::Error for SessionError {
         match &self.0 {
             InternalSessionError::Expired(_) => None,
             InternalSessionError::OhttpEncapsulation(e) => Some(e),
+            InternalSessionError::UnexpectedResponseSize(_) => None,
         }
     }
 }

--- a/payjoin/src/request.rs
+++ b/payjoin/src/request.rs
@@ -32,7 +32,7 @@ impl Request {
     }
 
     #[cfg(feature = "v2")]
-    pub fn new_v2(url: Url, body: Vec<u8>) -> Self {
-        Self { url, content_type: V2_REQ_CONTENT_TYPE, body }
+    pub fn new_v2(url: Url, body: [u8; crate::ohttp::ENCAPSULATED_MESSAGE_BYTES]) -> Self {
+        Self { url, content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 }

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -66,6 +66,8 @@ pub(crate) enum InternalValidationError {
     OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
     #[cfg(feature = "v2")]
     UnexpectedStatusCode,
+    #[cfg(feature = "v2")]
+    UnexpectedResponseSize(usize),
 }
 
 impl From<InternalValidationError> for ValidationError {
@@ -119,6 +121,8 @@ impl fmt::Display for ValidationError {
             OhttpEncapsulation(e) => write!(f, "Ohttp encapsulation error: {}", e),
             #[cfg(feature = "v2")]
             UnexpectedStatusCode => write!(f, "unexpected status code"),
+            #[cfg(feature = "v2")]
+            UnexpectedResponseSize(size) => write!(f, "unexpected response size {}, expected {} bytes", size, crate::ohttp::ENCAPSULATED_MESSAGE_BYTES),
         }
     }
 }
@@ -164,6 +168,8 @@ impl std::error::Error for ValidationError {
             OhttpEncapsulation(error) => Some(error),
             #[cfg(feature = "v2")]
             UnexpectedStatusCode => None,
+            #[cfg(feature = "v2")]
+            UnexpectedResponseSize(_) => None,
         }
     }
 }


### PR DESCRIPTION
Padded messages (POST, GET, Response 202, Response 200) are no longer distinguishable

Rationale: 7kb x 2x/min / 1h = ~1MB/hr which is not too much overhead.

- [x] ~~We must also specify a 30s timeout in BIP 77 for long polling and say that clients MUST poll as soon as they receive a response so as not to fingerprint clients based on request timing.~~ TODO left in BIP comments
- [x] allocate fixed length arrays instead of `resize`ing vectors.