### PR TITLE
Tag payjoin-directory v0.0.1

### DIFF
--- a/payjoin-directory/CHANGELOG.md
+++ b/payjoin-directory/CHANGELOG.md
@@ -1,0 +1,5 @@
+# payjoin-directory Changelog
+
+## 0.0.1
+
+- Release initial payjoin-directory to store and forward payjoin payloads using secp256k1 hpke


### PR DESCRIPTION
If we're running it in production we ought to tag it