### PR TITLE
Bump payjoin version to 0.21.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1577,7 +1577,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bhttp",
  "bip21",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1577,7 +1577,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bhttp",
  "bip21",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -38,7 +38,7 @@ hyper = { version = "1", features = ["http1", "server"], optional = true }
 hyper-rustls = { version = "0.26", optional = true }
 hyper-util = { version = "0.1", optional = true }
 log = "0.4.7"
-payjoin = { version = "0.20.0", features = ["send", "receive", "base64"] }
+payjoin = { version = "0.21.0", features = ["send", "receive", "base64"] }
 rcgen = { version = "0.11.1", optional = true }
 reqwest = { version = "0.12", default-features = false }
 rustls = { version = "0.22.4", optional = true }

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Payjoin Changelog
 
+## 0.21.0
+
+- Upgrade rustls v0.22.4
+- Depend on [bitcoin-ohttp](https://docs.rs/bitcoin-ohttp/latest/bitcoin_ohttp/)
+- Allow receiver to contribute multiple inputs and outputs
+- Remove `contribute_witness_inputs` and `contribute_non_witness_inputs` in favor of a single consolidated `contribute_inputs` function
+- Make `InputPair` public to facilitate working with inputs in coin selection and input contributions
+- Enable receiver fee contributions in `apply_fee`, which now requires a max_feerate parameter
+- Fix weight estimations for nested segwit inputs
+- Fix mixed input scripts receiver check in Payjoin V1 to only error if the receiver would *introduce* mixed types
+- Allow mixed input scripts in Payjoin V2
+- Implement client end-to-end encryption using HPKE using [bitcoin-hpke](https://docs.rs/bitcoin-hpke/latest/bitcoin_hpke/)
+- Make session initialization implicit
+- Make payloads uniform by removing sender auth key
+- Shorten subdirectory IDs to 64 pseudorandom bits [#386](https://github.com/payjoin/rust-payjoin/pull/386)
+- Clarify send and receive module documentation [#407](https://github.com/payjoin/rust-payjoin/pull/407)
+- Pad ohttp messages to consistent 8192 bytes [#395](https://github.com/payjoin/rust-payjoin/pull/395)
+- encode subdirectory IDs in bech32 and other QR optimizations [#417](https://github.com/payjoin/rust-payjoin/pull/417)
+- Upgrade to bitcoin v0.32.5
+- Work around '#' escaping bug in bip21 crate [#373](https://github.com/payjoin/rust-payjoin/pull/373)
+- Hide `_danger-local-https` feature behind `_` prefix so it doesn't show up in docs [#423](https://github.com/payjoin/rust-payjoin/pull/423)
+
+
 ## 0.20.0
 
 - remove `contribute_non_witness_input` because it was unused

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library for the BIP78 Pay to Endpoint protocol."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
We should really get #417, #373, ~~and perhaps #413~~ in before release candidate in order to prevent future breaking changes