### PR TITLE
Qr optimizations

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "base64 0.21.7",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "base64 0.21.7",

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -19,12 +19,12 @@ exclude = ["tests"]
 send = []
 receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
-v2 = ["bitcoin/rand", "bitcoin/serde", "hpke", "dep:http", "bhttp", "ohttp", "serde", "url/serde"]
+v2 = ["bitcoin/rand", "bitcoin/serde", "hpke", "dep:http", "bhttp", "ohttp", "serde", "url/serde" ]
 io = ["reqwest/rustls-tls"]
 danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
 [dependencies]
-bitcoin = { version = "0.32.4", features = ["base64"] }
+bitcoin = { version = "0.32.5", features = ["base64"] }
 bip21 = "0.5.0"
 hpke = { package = "bitcoin-hpke", version = "0.13.0", optional = true }
 log = { version = "0.4.14"}

--- a/payjoin/src/bech32.rs
+++ b/payjoin/src/bech32.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+
+use bitcoin::bech32::primitives::decode::{CheckedHrpstring, CheckedHrpstringError};
+use bitcoin::bech32::{self, EncodeError, Hrp, NoChecksum};
+
+pub mod nochecksum {
+    use super::*;
+
+    pub fn decode(encoded: &str) -> Result<(Hrp, Vec<u8>), CheckedHrpstringError> {
+        let hrp_string = CheckedHrpstring::new::<NoChecksum>(encoded)?;
+        Ok((hrp_string.hrp(), hrp_string.byte_iter().collect::<Vec<u8>>()))
+    }
+
+    pub fn encode(hrp: Hrp, data: &[u8]) -> Result<String, EncodeError> {
+        bech32::encode_upper::<NoChecksum>(hrp, data)
+    }
+
+    pub fn encode_to_fmt(f: &mut fmt::Formatter, hrp: Hrp, data: &[u8]) -> Result<(), EncodeError> {
+        bech32::encode_upper_to_fmt::<NoChecksum, fmt::Formatter>(f, hrp, data)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn bech32_for_qr() {
+        let bytes = vec![0u8, 1, 2, 3, 31, 32, 33, 95, 0, 96, 127, 128, 129, 254, 255, 0];
+        let hrp = Hrp::parse("STUFF").unwrap();
+        let encoded = nochecksum::encode(hrp, &bytes).unwrap();
+        let decoded = nochecksum::decode(&encoded).unwrap();
+        assert_eq!(decoded, (hrp, bytes.to_vec()));
+
+        // no checksum
+        assert_eq!(
+            encoded.len() as f32,
+            (hrp.as_str().len() + 1) as f32 + (bytes.len() as f32 * 8.0 / 5.0).ceil()
+        );
+
+        // TODO assert uppercase
+
+        // should not error
+        let corrupted = encoded + "QQPP";
+        let decoded = nochecksum::decode(&corrupted).unwrap();
+        assert_eq!(decoded.0, hrp);
+        assert_ne!(decoded, (hrp, bytes.to_vec()));
+    }
+}

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -35,6 +35,8 @@ pub use crate::hpke::{HpkeKeyPair, HpkePublicKey};
 pub(crate) mod ohttp;
 #[cfg(feature = "v2")]
 pub use crate::ohttp::OhttpKeys;
+#[cfg(feature = "v2")]
+pub(crate) mod bech32;
 
 #[cfg(feature = "io")]
 pub mod io;

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -24,8 +24,6 @@
 use std::str::FromStr;
 
 #[cfg(feature = "v2")]
-use bitcoin::base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
-#[cfg(feature = "v2")]
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::psbt::Psbt;
 use bitcoin::{Amount, FeeRate, Script, ScriptBuf, TxOut, Weight};
@@ -41,6 +39,8 @@ use crate::hpke::{decrypt_message_b, encrypt_message_a, HpkeKeyPair, HpkePublicK
 use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate};
 use crate::psbt::PsbtExt;
 use crate::request::Request;
+#[cfg(feature = "v2")]
+use crate::uri::ShortId;
 use crate::PjUri;
 
 // See usize casts
@@ -405,8 +405,8 @@ impl V2GetContext {
 
         // TODO unify with receiver's fn subdir_path_from_pubkey
         let hash = sha256::Hash::hash(&self.hpke_ctx.reply_pair.public_key().to_compressed_bytes());
-        let subdir = BASE64_URL_SAFE_NO_PAD.encode(&hash.as_byte_array()[..8]);
-        url.set_path(&subdir);
+        let subdir: ShortId = hash.into();
+        url.set_path(&subdir.to_string());
         let body = encrypt_message_a(
             Vec::new(),
             &self.hpke_ctx.reply_pair.public_key().clone(),

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -15,7 +15,8 @@ pub(crate) enum InternalPjParseError {
 #[derive(Debug)]
 pub(crate) enum ParseReceiverPubkeyError {
     MissingPubkey,
-    PubkeyNotBase64(bitcoin::base64::DecodeError),
+    InvalidHrp(bitcoin::bech32::Hrp),
+    DecodeBech32(bitcoin::bech32::primitives::decode::CheckedHrpstringError),
     InvalidPubkey(crate::hpke::HpkeError),
 }
 
@@ -26,7 +27,8 @@ impl std::fmt::Display for ParseReceiverPubkeyError {
 
         match &self {
             MissingPubkey => write!(f, "receiver public key is missing"),
-            PubkeyNotBase64(e) => write!(f, "receiver public is not valid base64: {}", e),
+            InvalidHrp(h) => write!(f, "incorrect hrp for receiver key: {}", h),
+            DecodeBech32(e) => write!(f, "receiver public is not valid base64: {}", e),
             InvalidPubkey(e) =>
                 write!(f, "receiver public key does not represent a valid pubkey: {}", e),
         }
@@ -40,7 +42,8 @@ impl std::error::Error for ParseReceiverPubkeyError {
 
         match &self {
             MissingPubkey => None,
-            PubkeyNotBase64(error) => Some(error),
+            InvalidHrp(_) => None,
+            DecodeBech32(error) => Some(error),
             InvalidPubkey(error) => Some(error),
         }
     }

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -17,6 +17,64 @@ pub mod error;
 #[cfg(feature = "v2")]
 pub(crate) mod url_ext;
 
+#[cfg(feature = "v2")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShortId(pub [u8; 8]);
+
+#[cfg(feature = "v2")]
+impl ShortId {
+    pub fn as_bytes(&self) -> &[u8] { &self.0 }
+    pub fn as_slice(&self) -> &[u8] { &self.0 }
+}
+
+#[cfg(feature = "v2")]
+impl std::fmt::Display for ShortId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let id_hrp = bitcoin::bech32::Hrp::parse("ID").unwrap();
+        f.write_str(
+            crate::bech32::nochecksum::encode(id_hrp, &self.0)
+                .expect("bech32 encoding of short ID must succeed")
+                .strip_prefix("ID1")
+                .expect("human readable part must be ID1"),
+        )
+    }
+}
+
+#[cfg(feature = "v2")]
+#[derive(Debug)]
+pub enum ShortIdError {
+    DecodeBech32(bitcoin::bech32::primitives::decode::CheckedHrpstringError),
+    IncorrectLength(std::array::TryFromSliceError),
+}
+
+#[cfg(feature = "v2")]
+impl std::convert::From<bitcoin::hashes::sha256::Hash> for ShortId {
+    fn from(h: bitcoin::hashes::sha256::Hash) -> Self {
+        bitcoin::hashes::Hash::as_byte_array(&h)[..8]
+            .try_into()
+            .expect("truncating SHA256 to 8 bytes should always succeed")
+    }
+}
+
+#[cfg(feature = "v2")]
+impl std::convert::TryFrom<&[u8]> for ShortId {
+    type Error = ShortIdError;
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 8] = bytes.try_into().map_err(ShortIdError::IncorrectLength)?;
+        Ok(Self(bytes))
+    }
+}
+
+#[cfg(feature = "v2")]
+impl std::str::FromStr for ShortId {
+    type Err = ShortIdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (_, bytes) = crate::bech32::nochecksum::decode(&("ID1".to_string() + s))
+            .map_err(ShortIdError::DecodeBech32)?;
+        (&bytes[..]).try_into()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum MaybePayjoinExtras {
     Supported(PayjoinExtras),

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -263,9 +263,19 @@ impl bip21::SerializeParams for &PayjoinExtras {
     type Iterator = std::vec::IntoIter<(Self::Key, Self::Value)>;
 
     fn serialize_params(self) -> Self::Iterator {
+        // normalizing to uppercase enables QR alphanumeric mode encoding
+        // unfortunately Url normalizes these to be lowercase
+        let scheme = self.endpoint.scheme();
+        let host = self.endpoint.host_str().expect("host must be set");
+        let endpoint_str = self
+            .endpoint
+            .as_str()
+            .replacen(scheme, &scheme.to_uppercase(), 1)
+            .replacen(host, &host.to_uppercase(), 1);
+
         vec![
-            ("pj", self.endpoint.as_str().to_string()),
             ("pjos", if self.disable_output_substitution { "1" } else { "0" }.to_string()),
+            ("pj", endpoint_str),
         ]
         .into_iter()
     }

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -181,11 +181,17 @@ impl PjUriBuilder {
         #[allow(unused_mut)]
         let mut pj = origin;
         #[cfg(feature = "v2")]
-        pj.set_receiver_pubkey(receiver_pubkey);
+        if let Some(receiver_pubkey) = receiver_pubkey {
+            pj.set_receiver_pubkey(receiver_pubkey);
+        }
         #[cfg(feature = "v2")]
-        pj.set_ohttp(ohttp_keys);
+        if let Some(ohttp_keys) = ohttp_keys {
+            pj.set_ohttp(ohttp_keys);
+        }
         #[cfg(feature = "v2")]
-        pj.set_exp(expiry);
+        if let Some(expiry) = expiry {
+            pj.set_exp(expiry);
+        }
         Self { address, amount: None, message: None, label: None, pj, pjos: false }
     }
     /// Set the amount you want to receive.

--- a/payjoin/src/uri/url_ext.rs
+++ b/payjoin/src/uri/url_ext.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
-use bitcoin::base64::prelude::BASE64_URL_SAFE_NO_PAD;
-use bitcoin::base64::Engine;
+use bitcoin::bech32::Hrp;
+use bitcoin::consensus::encode::Decodable;
+use bitcoin::consensus::Encodable;
 use url::Url;
 
 use super::error::ParseReceiverPubkeyError;
@@ -21,55 +22,80 @@ pub(crate) trait UrlExt {
 impl UrlExt for Url {
     /// Retrieve the receiver's public key from the URL fragment
     fn receiver_pubkey(&self) -> Result<HpkePublicKey, ParseReceiverPubkeyError> {
-        let value = get_param(self, "rk=", |v| Some(v.to_owned()))
+        let value = get_param(self, "RK1", |v| Some(v.to_owned()))
             .ok_or(ParseReceiverPubkeyError::MissingPubkey)?;
 
-        let decoded = BASE64_URL_SAFE_NO_PAD
-            .decode(&value)
-            .map_err(ParseReceiverPubkeyError::PubkeyNotBase64)?;
+        let (hrp, bytes) = crate::bech32::nochecksum::decode(&value)
+            .map_err(ParseReceiverPubkeyError::DecodeBech32)?;
 
-        HpkePublicKey::from_compressed_bytes(&decoded)
+        let rk_hrp: Hrp = Hrp::parse("RK").unwrap();
+        if hrp != rk_hrp {
+            return Err(ParseReceiverPubkeyError::InvalidHrp(hrp));
+        }
+
+        HpkePublicKey::from_compressed_bytes(&bytes[..])
             .map_err(ParseReceiverPubkeyError::InvalidPubkey)
     }
 
     /// Set the receiver's public key in the URL fragment
     fn set_receiver_pubkey(&mut self, pubkey: Option<HpkePublicKey>) {
+        let rk_hrp: Hrp = Hrp::parse("RK").unwrap();
+
         set_param(
             self,
-            "rk=",
-            pubkey.map(|k| BASE64_URL_SAFE_NO_PAD.encode(k.to_compressed_bytes())),
+            "RK1",
+            pubkey.map(|k| {
+                crate::bech32::nochecksum::encode(rk_hrp, &k.to_compressed_bytes())
+                    .expect("encoding compressed pubkey bytes should never fail")
+            }),
         )
     }
 
     /// Retrieve the ohttp parameter from the URL fragment
     fn ohttp(&self) -> Option<OhttpKeys> {
-        get_param(self, "ohttp=", |value| OhttpKeys::from_str(value).ok())
+        get_param(self, "OH1", |value| OhttpKeys::from_str(value).ok())
     }
 
     /// Set the ohttp parameter in the URL fragment
     fn set_ohttp(&mut self, ohttp: Option<OhttpKeys>) {
-        set_param(self, "ohttp=", ohttp.map(|o| o.to_string()))
+        set_param(self, "OH1", ohttp.map(|o| o.to_string()))
     }
 
     /// Retrieve the exp parameter from the URL fragment
     fn exp(&self) -> Option<std::time::SystemTime> {
-        get_param(self, "exp=", |value| {
-            value
-                .parse::<u64>()
+        get_param(self, "EX1", |value| {
+            let (hrp, bytes) = crate::bech32::nochecksum::decode(value).ok()?;
+
+            let ex_hrp: Hrp = Hrp::parse("EX").unwrap();
+            if hrp != ex_hrp {
+                return None;
+            }
+
+            let mut cursor = &bytes[..];
+            u32::consensus_decode(&mut cursor)
+                .map(|timestamp| {
+                    std::time::UNIX_EPOCH + std::time::Duration::from_secs(timestamp as u64)
+                })
                 .ok()
-                .map(|timestamp| std::time::UNIX_EPOCH + std::time::Duration::from_secs(timestamp))
         })
     }
 
     /// Set the exp parameter in the URL fragment
     fn set_exp(&mut self, exp: Option<std::time::SystemTime>) {
         let exp_str = exp.map(|e| {
-            match e.duration_since(std::time::UNIX_EPOCH) {
-                Ok(duration) => duration.as_secs().to_string(),
-                Err(_) => "0".to_string(), // Handle times before Unix epoch by setting to "0"
-            }
+            let t = match e.duration_since(std::time::UNIX_EPOCH) {
+                Ok(duration) => duration.as_secs().try_into().unwrap(), // TODO Result type instead of Option & unwrap
+                Err(_) => 0u32,
+            };
+
+            let mut buf = [0u8; 4];
+            t.consensus_encode(&mut &mut buf[..]).unwrap(); // TODO no unwrap
+
+            let ex_hrp: Hrp = Hrp::parse("EX").unwrap();
+            crate::bech32::nochecksum::encode(ex_hrp, &buf)
+                .expect("encoding u32 timestamp should never fail")
         });
-        set_param(self, "exp=", exp_str)
+        set_param(self, "EX1", exp_str)
     }
 }
 
@@ -78,32 +104,31 @@ where
     F: Fn(&str) -> Option<T>,
 {
     if let Some(fragment) = url.fragment() {
-        for param in fragment.split('&') {
-            if let Some(value) = param.strip_prefix(prefix) {
-                return parse(value);
+        for param in fragment.split('+') {
+            if param.starts_with(prefix) {
+                return parse(param);
             }
         }
     }
     None
 }
 
-fn set_param(url: &mut Url, prefix: &str, value: Option<String>) {
+fn set_param(url: &mut Url, prefix: &str, param: Option<String>) {
     let fragment = url.fragment().unwrap_or("");
     let mut fragment = fragment.to_string();
     if let Some(start) = fragment.find(prefix) {
-        let end = fragment[start..].find('&').map_or(fragment.len(), |i| start + i);
+        let end = fragment[start..].find('+').map_or(fragment.len(), |i| start + i);
         fragment.replace_range(start..end, "");
-        if fragment.ends_with('&') {
+        if fragment.ends_with('+') {
             fragment.pop();
         }
     }
 
-    if let Some(value) = value {
-        let new_param = format!("{}{}", prefix, value);
+    if let Some(param) = param {
         if !fragment.is_empty() {
-            fragment.push('&');
+            fragment.push('+');
         }
-        fragment.push_str(&new_param);
+        fragment.push_str(&param);
     }
 
     url.set_fragment(if fragment.is_empty() { None } else { Some(&fragment) });
@@ -118,11 +143,11 @@ mod tests {
     fn test_ohttp_get_set() {
         let mut url = Url::parse("https://example.com").unwrap();
 
-        let ohttp_keys =
-            OhttpKeys::from_str("AQO6SMScPUqSo60A7MY6Ak2hDO0CGAxz7BLYp60syRu0gw").unwrap();
+        let serialized = "OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let ohttp_keys = OhttpKeys::from_str(serialized).unwrap();
         url.set_ohttp(Some(ohttp_keys.clone()));
-        assert_eq!(url.fragment(), Some("ohttp=AQO6SMScPUqSo60A7MY6Ak2hDO0CGAxz7BLYp60syRu0gw"));
 
+        assert_eq!(url.fragment(), Some(serialized));
         assert_eq!(url.ohttp(), Some(ohttp_keys));
 
         url.set_ohttp(None);
@@ -136,7 +161,7 @@ mod tests {
         let exp_time =
             std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1720547781);
         url.set_exp(Some(exp_time));
-        assert_eq!(url.fragment(), Some("exp=1720547781"));
+        assert_eq!(url.fragment(), Some("EX1C4UC6ES"));
 
         assert_eq!(url.exp(), Some(exp_time));
 
@@ -145,20 +170,10 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_v2_url_fragment_on_bip21() {
-        // fragment is not percent encoded so `&ohttp=` is parsed as a query parameter, not a fragment parameter
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
-                   &pj=https://example.com\
-                   #exp=1720547781&ohttp=AQO6SMScPUqSo60A7MY6Ak2hDO0CGAxz7BLYp60syRu0gw";
-        let uri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
-        assert!(uri.extras.endpoint().ohttp().is_none());
-    }
-
-    #[test]
     fn test_valid_v2_url_fragment_on_bip21() {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
                    &pj=https://example.com\
-                   #ohttp%3DAQO6SMScPUqSo60A7MY6Ak2hDO0CGAxz7BLYp60syRu0gw";
+                   #OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
         let uri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
         assert!(uri.extras.endpoint().ohttp().is_some());
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -193,7 +193,7 @@ mod integration {
         #[tokio::test]
         async fn test_bad_ohttp_keys() {
             let bad_ohttp_keys =
-                OhttpKeys::from_str("AQO6SMScPUqSo60A7MY6Ak2hDO0CGAxz7BLYp60syRu0gw")
+                OhttpKeys::from_str("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC")
                     .expect("Invalid OhttpKeys");
 
             let (cert, key) = local_cert_key();


### PR DESCRIPTION
These commits:

1. encode fragment paramters as bech32 strings (with no checksum), with 2 character param names in the human readable part, and `+` as a delimiter
    - expiry time parameter encoded as a little endian u32, in line with bitcoin header timestamp and unix time nLocktime encoding. `EX` hrp
    - ohttp has `OH` hrp, same byte representation as previously encoded in base64
    - receiver key has `RK` hrp, same byte representation as previously encoded in base64
2. use bech32 with no human readable part for the subdirectory IDs
3. uppercase the scheme and host of the URI
4. move the pj so it follows the pjos parameter

Once the `#` %-escaping bug is fixed (see #373), and as long as no path elements between the host and the subdirectory ID, the entire `pj` parameter of the bip21 URI can be encoded in a QR using the alphanumeric mode. Closes #389.

I'm not sure about the last commit, although it seems sufficiently motivated since there is no purpose to clearing these values it doesn't actually simplify the code that much.

Manually verified, with manual % escaping of `#`, using the `qrencode` CLI encoder alphanumeric mode is indeed used for everything following `pj=`.