### PR TITLE
Hide danger-local-https feature with _ prefix

### DIFF
--- a/contrib/coverage.sh
+++ b/contrib/coverage.sh
@@ -4,5 +4,5 @@ set -e
 # https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#merge-coverages-generated-under-different-test-conditions
 cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage results
 cargo llvm-cov --no-report --features=send,receive
-cargo llvm-cov --no-report --features=v2,danger-local-https,io
+cargo llvm-cov --no-report --features=v2,_danger-local-https,io
 cargo llvm-cov report --lcov --output-path lcov.info # generate report without tests

--- a/contrib/lint.sh
+++ b/contrib/lint.sh
@@ -2,4 +2,4 @@
 set -e
 
 cargo clippy --all-targets --keep-going --features=send,receive -- -D warnings
-cargo clippy --all-targets --keep-going --features=v2,danger-local-https,io -- -D warnings
+cargo clippy --all-targets --keep-going --features=v2,_danger-local-https,io -- -D warnings

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [features]
 default = ["v1"]
 native-certs = ["reqwest/rustls-tls-native-roots"]
-danger-local-https = ["rcgen", "reqwest/rustls-tls", "rustls", "hyper-rustls", "payjoin/danger-local-https", "tokio-rustls"]
+_danger-local-https = ["rcgen", "reqwest/rustls-tls", "rustls", "hyper-rustls", "payjoin/_danger-local-https", "tokio-rustls"]
 v1 = ["hyper", "hyper-util", "http-body-util"]
 v2 = ["payjoin/v2", "payjoin/io"]
 
@@ -53,7 +53,7 @@ bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
 ohttp-relay = "0.0.8"
 once_cell = "1"
-payjoin-directory = { path = "../payjoin-directory", features = ["danger-local-https"] }
+payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["redis"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -79,11 +79,11 @@ rpcport = 18443
 From the directory you'll run payjoin-cli, assuming "boom" is the name of the receiving wallet, 18443 is the rpc port, and you wish to request 10,000 sats run:
 
 ```console
-RUST_LOG=debug cargo run --features=danger-local-https -- -r "http://localhost:18443/wallet/boom" receive 10000
+RUST_LOG=debug cargo run --features=_danger-local-https -- -r "http://localhost:18443/wallet/boom" receive 10000
 ```
 
 The default configuration listens for payjoin requests at `http://localhost:3000` and expects you to relay https requests there.
-Payjoin requires a secure endpoint, either https and .onion are valid. In order to receive payjoin in a local testing environment one may enable the  `danger-local-https` feature which will provision a self-signed certificate and host the `https://localhost:3000` endpoint. Emphasis on HTTP**S**.
+Payjoin requires a secure endpoint, either https and .onion are valid. In order to receive payjoin in a local testing environment one may enable the  `_danger-local-https` feature which will provision a self-signed certificate and host the `https://localhost:3000` endpoint. Emphasis on HTTP**S**.
 
 This will generate a payjoin capable bip21 URI with which to accept payjoin:
 
@@ -103,7 +103,7 @@ Using the previously generated bip21 URI, run the following command
 from the sender directory:
 
 ```console
- RUST_LOG=debug cargo run --features=danger-local-https -- send <BIP21> --fee-rate <FEE_SAT_PER_VB>
+ RUST_LOG=debug cargo run --features=_danger-local-https -- send <BIP21> --fee-rate <FEE_SAT_PER_VB>
 ```
 
 You should see the payjoin transaction occur and be able to verify the Partially Signed Bitcoin Transaction (PSBT), inputs, and Unspent Transaction Outputs (UTXOs).

--- a/payjoin-cli/contrib/test.sh
+++ b/payjoin-cli/contrib/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-cargo test --locked --package payjoin-cli --verbose --no-default-features --features=danger-local-https,v2 --test e2e
-cargo test --locked --package payjoin-cli --verbose --features=danger-local-https
+cargo test --locked --package payjoin-cli --verbose --no-default-features --features=_danger-local-https,v2 --test e2e
+cargo test --locked --package payjoin-cli --verbose --features=_danger-local-https

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod v1;
 #[cfg(feature = "v2")]
 pub(crate) mod v2;
 
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 #[async_trait::async_trait]
@@ -97,13 +97,13 @@ pub trait App {
     }
 }
 
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 fn http_agent() -> Result<reqwest::Client> { Ok(http_agent_builder()?.build()?) }
 
-#[cfg(not(feature = "danger-local-https"))]
+#[cfg(not(feature = "_danger-local-https"))]
 fn http_agent() -> Result<reqwest::Client> { Ok(reqwest::Client::new()) }
 
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 fn http_agent_builder() -> Result<reqwest::ClientBuilder> {
     use rustls::pki_types::CertificateDer;
     use rustls::RootCertStore;
@@ -117,7 +117,7 @@ fn http_agent_builder() -> Result<reqwest::ClientBuilder> {
         .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice())?))
 }
 
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 fn read_local_cert() -> Result<Vec<u8>> {
     let mut local_cert_path = std::env::temp_dir();
     local_cert_path.push(LOCAL_CERT_FILE);

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -23,7 +23,7 @@ use super::config::AppConfig;
 use super::App as AppTrait;
 use crate::app::{http_agent, input_pair_from_list_unspent};
 use crate::db::Database;
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 struct Headers<'a>(&'a hyper::HeaderMap);
@@ -140,14 +140,14 @@ impl App {
         let listener = TcpListener::bind(addr).await?;
         let app = self.clone();
 
-        #[cfg(feature = "danger-local-https")]
+        #[cfg(feature = "_danger-local-https")]
         let tls_acceptor = Self::init_tls_acceptor()?;
         while let Ok((stream, _)) = listener.accept().await {
             let app = app.clone();
-            #[cfg(feature = "danger-local-https")]
+            #[cfg(feature = "_danger-local-https")]
             let tls_acceptor = tls_acceptor.clone();
             tokio::spawn(async move {
-                #[cfg(feature = "danger-local-https")]
+                #[cfg(feature = "_danger-local-https")]
                 let stream = match tls_acceptor.accept(stream).await {
                     Ok(tls_stream) => tls_stream,
                     Err(e) => {
@@ -167,7 +167,7 @@ impl App {
         Ok(())
     }
 
-    #[cfg(feature = "danger-local-https")]
+    #[cfg(feature = "_danger-local-https")]
     fn init_tls_acceptor() -> Result<tokio_rustls::TlsAcceptor> {
         use std::io::Write;
 

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -366,12 +366,12 @@ async fn unwrap_ohttp_keys_or_else_fetch(config: &AppConfig) -> Result<payjoin::
         println!("Bootstrapping private network transport over Oblivious HTTP");
         let ohttp_relay = config.ohttp_relay.clone();
         let payjoin_directory = config.pj_directory.clone();
-        #[cfg(feature = "danger-local-https")]
+        #[cfg(feature = "_danger-local-https")]
         let cert_der = crate::app::read_local_cert()?;
         Ok(payjoin::io::fetch_ohttp_keys(
             ohttp_relay,
             payjoin_directory,
-            #[cfg(feature = "danger-local-https")]
+            #[cfg(feature = "_danger-local-https")]
             cert_der,
         )
         .await?)

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 mod e2e {
     use std::env;
     use std::process::Stdio;

--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-danger-local-https = ["hyper-rustls", "rustls", "tokio-rustls"]
+_danger-local-https = ["hyper-rustls", "rustls", "tokio-rustls"]
 
 [dependencies]
 anyhow = "1.0.71"

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -64,7 +64,7 @@ pub async fn listen_tcp(
     Ok(())
 }
 
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 pub async fn listen_tcp_with_tls(
     port: u16,
     db_host: String,
@@ -106,7 +106,7 @@ pub async fn listen_tcp_with_tls(
     Ok(())
 }
 
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 fn init_tls_acceptor(cert_key: (Vec<u8>, Vec<u8>)) -> Result<tokio_rustls::TlsAcceptor> {
     use rustls::pki_types::{CertificateDer, PrivateKeyDer};
     use rustls::ServerConfig;

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -21,7 +21,7 @@ receive = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
 v2 = ["bitcoin/rand", "bitcoin/serde", "hpke", "dep:http", "bhttp", "ohttp", "serde", "url/serde"]
 io = ["reqwest/rustls-tls"]
-danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
+_danger-local-https = ["io", "reqwest/rustls-tls", "rustls"]
 
 [dependencies]
 bitcoin = { version = "0.32.4", features = ["base64"] }
@@ -40,7 +40,7 @@ serde_json = "1.0.108"
 [dev-dependencies]
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
-payjoin-directory = { path = "../payjoin-directory", features = ["danger-local-https"] }
+payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
 ohttp-relay = "0.0.8"
 once_cell = "1"
 rcgen = { version = "0.11" }

--- a/payjoin/contrib/test.sh
+++ b/payjoin/contrib/test.sh
@@ -3,4 +3,4 @@ set -e
 
 cargo test --locked --package payjoin --verbose --all-features --lib
 cargo test --locked --package payjoin --verbose --features=send,receive --test integration
-cargo test --locked --package payjoin --verbose --no-default-features --features=send,receive,danger-local-https,v2 --test integration
+cargo test --locked --package payjoin --verbose --no-default-features --features=send,receive,_danger-local-https,v2 --test integration

--- a/payjoin/src/io.rs
+++ b/payjoin/src/io.rs
@@ -11,20 +11,20 @@ use crate::{OhttpKeys, Url};
 ///   directory stores and forwards payjoin client payloads.
 ///
 /// * `cert_der` (optional): The DER-encoded certificate to use for local HTTPS connections.  This
-///   parameter is only available when the "danger-local-https" feature is enabled.
+///   parameter is only available when the "_danger-local-https" feature is enabled.
 #[cfg(feature = "v2")]
 pub async fn fetch_ohttp_keys(
     ohttp_relay: Url,
     payjoin_directory: Url,
-    #[cfg(feature = "danger-local-https")] cert_der: Vec<u8>,
+    #[cfg(feature = "_danger-local-https")] cert_der: Vec<u8>,
 ) -> Result<OhttpKeys, Error> {
     use reqwest::{Client, Proxy};
 
     let ohttp_keys_url = payjoin_directory.join("/ohttp-keys")?;
     let proxy = Proxy::all(ohttp_relay.as_str())?;
-    #[cfg(not(feature = "danger-local-https"))]
+    #[cfg(not(feature = "_danger-local-https"))]
     let client = Client::builder().proxy(proxy).build()?;
-    #[cfg(feature = "danger-local-https")]
+    #[cfg(feature = "_danger-local-https")]
     let client = Client::builder()
         .danger_accept_invalid_certs(true)
         .use_rustls_tls()
@@ -44,7 +44,7 @@ enum InternalError {
     ParseUrl(crate::ParseError),
     Reqwest(reqwest::Error),
     Io(std::io::Error),
-    #[cfg(feature = "danger-local-https")]
+    #[cfg(feature = "_danger-local-https")]
     Rustls(rustls::Error),
     #[cfg(feature = "v2")]
     InvalidOhttpKeys(String),
@@ -61,7 +61,7 @@ macro_rules! impl_from_error {
 impl_from_error!(reqwest::Error, Reqwest);
 impl_from_error!(crate::ParseError, ParseUrl);
 impl_from_error!(std::io::Error, Io);
-#[cfg(feature = "danger-local-https")]
+#[cfg(feature = "_danger-local-https")]
 impl_from_error!(rustls::Error, Rustls);
 
 impl std::fmt::Display for Error {
@@ -76,7 +76,7 @@ impl std::fmt::Display for Error {
             InvalidOhttpKeys(e) => {
                 write!(f, "Invalid ohttp keys returned from payjoin directory: {}", e)
             }
-            #[cfg(feature = "danger-local-https")]
+            #[cfg(feature = "_danger-local-https")]
             Rustls(e) => e.fmt(f),
         }
     }
@@ -92,7 +92,7 @@ impl std::error::Error for Error {
             Io(e) => Some(e),
             #[cfg(feature = "v2")]
             InvalidOhttpKeys(_) => None,
-            #[cfg(feature = "danger-local-https")]
+            #[cfg(feature = "_danger-local-https")]
             Rustls(e) => Some(e),
         }
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -171,7 +171,7 @@ mod integration {
         }
     }
 
-    #[cfg(feature = "danger-local-https")]
+    #[cfg(feature = "_danger-local-https")]
     #[cfg(feature = "v2")]
     mod v2 {
         use std::sync::Arc;


### PR DESCRIPTION
This prevents it from showing up in docs.rs documentation