### PR TITLE
Expose test fixtures and fns at payjoin-test-utils

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1590,6 +1590,7 @@ dependencies = [
  "ohttp-relay",
  "once_cell",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1624,6 +1625,7 @@ dependencies = [
  "once_cell",
  "payjoin",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1657,6 +1659,21 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "payjoin-test-utils"
+version = "0.1.0"
+dependencies = [
+ "bitcoincore-rpc",
+ "bitcoind",
+ "http",
+ "log",
+ "ohttp-relay",
+ "payjoin-directory",
+ "rcgen",
+ "testcontainers",
+ "testcontainers-modules",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1590,6 +1590,7 @@ dependencies = [
  "ohttp-relay",
  "once_cell",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1624,6 +1625,7 @@ dependencies = [
  "once_cell",
  "payjoin",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1657,6 +1659,21 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "payjoin-test-utils"
+version = "0.1.0"
+dependencies = [
+ "bitcoincore-rpc",
+ "bitcoind",
+ "http",
+ "log",
+ "ohttp-relay",
+ "payjoin-directory",
+ "rcgen",
+ "testcontainers",
+ "testcontainers-modules",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["payjoin", "payjoin-cli", "payjoin-directory"]
+members = ["payjoin", "payjoin-cli", "payjoin-directory", "payjoin-test-utils"]
 resolver = "2"
 
 [patch.crates-io.payjoin]

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -53,6 +53,7 @@ http = "1"
 ohttp-relay = "0.0.8"
 once_cell = "1"
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
+payjoin-test-utils = { path = "../payjoin-test-utils" }
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["redis"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "payjoin-test-utils"
+version = "0.1.0"
+edition = "2021"
+authors = ["Dan Gould <d@ngould.dev>"]
+rust-version = "1.63"
+license = "MIT"
+
+[dependencies]
+bitcoincore-rpc = "0.19.0"
+bitcoind = { version = "0.36.0", features = ["0_21_2"] }
+http = "1"
+log = "0.4.7"
+ohttp-relay = "0.0.8"
+payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
+rcgen = "0.11"
+testcontainers = "0.15.0"
+testcontainers-modules = { version = "0.1.3", features = ["redis"] }

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -1,0 +1,77 @@
+use std::time::Duration;
+
+use bitcoincore_rpc::bitcoin::Amount;
+use bitcoincore_rpc::json::AddressType;
+use bitcoincore_rpc::RpcApi;
+use testcontainers::clients::Cli;
+use testcontainers_modules::redis::Redis;
+
+type Error = Box<dyn std::error::Error + 'static>;
+
+pub fn init_bitcoind() -> Result<bitcoind::BitcoinD, Error> {
+    let bitcoind_exe = std::env::var("BITCOIND_EXE")
+        .ok()
+        .or_else(|| bitcoind::downloaded_exe_path().ok())
+        .unwrap();
+    let mut conf = bitcoind::Conf::default();
+    conf.view_stdout = log::log_enabled!(log::Level::Debug);
+    let bitcoind = bitcoind::BitcoinD::with_conf(bitcoind_exe, &conf)?;
+    Ok(bitcoind)
+}
+
+pub fn init_bitcoind_sender_receiver(
+    sender_address_type: Option<AddressType>,
+    receiver_address_type: Option<AddressType>,
+) -> Result<(bitcoind::BitcoinD, bitcoincore_rpc::Client, bitcoincore_rpc::Client), Error> {
+    let bitcoind = init_bitcoind()?;
+    let receiver = bitcoind.create_wallet("receiver")?;
+    let receiver_address = receiver.get_new_address(None, receiver_address_type)?.assume_checked();
+    let sender = bitcoind.create_wallet("sender")?;
+    let sender_address = sender.get_new_address(None, sender_address_type)?.assume_checked();
+    bitcoind.client.generate_to_address(1, &receiver_address)?;
+    bitcoind.client.generate_to_address(101, &sender_address)?;
+
+    assert_eq!(
+        Amount::from_btc(50.0)?,
+        receiver.get_balances()?.mine.trusted,
+        "receiver doesn't own bitcoin"
+    );
+
+    assert_eq!(
+        Amount::from_btc(50.0)?,
+        sender.get_balances()?.mine.trusted,
+        "sender doesn't own bitcoin"
+    );
+    Ok((bitcoind, sender, receiver))
+}
+
+pub async fn init_directory(port: u16, local_cert_key: (Vec<u8>, Vec<u8>)) -> Result<(), Error> {
+    let docker: Cli = Cli::default();
+    let timeout = Duration::from_secs(2);
+    let db = docker.run(Redis);
+    let db_host = format!("127.0.0.1:{}", db.get_host_port_ipv4(6379));
+    println!("Database running on {}", db.get_host_port_ipv4(6379));
+    payjoin_directory::listen_tcp_with_tls(port, db_host, timeout, local_cert_key).await
+}
+
+pub async fn init_ohttp_relay(
+    port: u16,
+    gateway_origin: http::Uri,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ohttp_relay::listen_tcp(port, gateway_origin).await
+}
+
+// generates or gets a DER encoded localhost cert and key.
+pub fn local_cert_key() -> (Vec<u8>, Vec<u8>) {
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["0.0.0.0".to_string(), "localhost".to_string()])
+            .expect("Failed to generate cert");
+    let cert_der = cert.serialize_der().expect("Failed to serialize cert");
+    let key_der = cert.serialize_private_key_der();
+    (cert_der, key_der)
+}
+
+pub fn find_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1.0.108"
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
+payjoin-test-utils = { path = "../payjoin-test-utils" }
 ohttp-relay = "0.0.8"
 once_cell = "1"
 rcgen = { version = "0.11" }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -60,16 +60,16 @@ mod integration {
             do_v1_to_v1(sender, receiver, false)
         }
 
-        // TODO: Not supported by bitcoind 0_21_2. Later versions fail for unknown reasons
-        //#[test]
-        //fn v1_to_v1_taproot() -> Result<(), BoxError> {
-        //    init_tracing();
-        //    let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(
-        //        Some(AddressType::Bech32m),
-        //        Some(AddressType::Bech32m),
-        //    )?;
-        //    do_v1_to_v1(sender, receiver, false)
-        //}
+        #[ignore] // TODO: Not supported by bitcoind 0_21_2. Later versions fail for unknown reasons
+        #[test]
+        fn v1_to_v1_taproot() -> Result<(), BoxError> {
+            init_tracing();
+            let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(
+                Some(AddressType::Bech32m),
+                Some(AddressType::Bech32m),
+            )?;
+            do_v1_to_v1(sender, receiver, false)
+        }
 
         fn do_v1_to_v1(
             sender: bitcoincore_rpc::Client,


### PR DESCRIPTION
This new crate also provides an opportunity to create downstream test fixtures in payjoin-ffi and language bindings downstream of it.