### PR TITLE
Propagate ParseError when retrieving ohttp parameter

### DIFF
--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -5,7 +5,7 @@ use bitcoin::transaction::Version;
 use bitcoin::{AddressType, Sequence};
 
 #[cfg(feature = "v2")]
-use crate::uri::error::ParseReceiverPubkeyError;
+use crate::uri::error::ParseReceiverPubkeyParamError;
 
 /// Error that may occur when the response from receiver is malformed.
 ///
@@ -203,7 +203,7 @@ pub(crate) enum InternalCreateRequestError {
     #[cfg(feature = "v2")]
     OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
     #[cfg(feature = "v2")]
-    ParseReceiverPubkey(ParseReceiverPubkeyError),
+    ParseReceiverPubkey(ParseReceiverPubkeyParamError),
     #[cfg(feature = "v2")]
     MissingOhttpConfig,
     #[cfg(feature = "v2")]
@@ -287,8 +287,8 @@ impl From<crate::psbt::AddressTypeError> for CreateRequestError {
 }
 
 #[cfg(feature = "v2")]
-impl From<ParseReceiverPubkeyError> for CreateRequestError {
-    fn from(value: ParseReceiverPubkeyError) -> Self {
+impl From<ParseReceiverPubkeyParamError> for CreateRequestError {
+    fn from(value: ParseReceiverPubkeyParamError) -> Self {
         CreateRequestError(InternalCreateRequestError::ParseReceiverPubkey(value))
     }
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -306,7 +306,7 @@ impl Sender {
         )
         .map_err(InternalCreateRequestError::Hpke)?;
         let mut ohttp =
-            self.endpoint.ohttp().ok_or(InternalCreateRequestError::MissingOhttpConfig)?;
+            self.endpoint.ohttp().map_err(|_| InternalCreateRequestError::MissingOhttpConfig)?;
         let (body, ohttp_ctx) = ohttp_encapsulate(&mut ohttp, "POST", url.as_str(), Some(&body))
             .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
         log::debug!("ohttp_relay_url: {:?}", ohttp_relay);
@@ -418,7 +418,7 @@ impl V2GetContext {
         )
         .map_err(InternalCreateRequestError::Hpke)?;
         let mut ohttp =
-            self.endpoint.ohttp().ok_or(InternalCreateRequestError::MissingOhttpConfig)?;
+            self.endpoint.ohttp().map_err(|_| InternalCreateRequestError::MissingOhttpConfig)?;
         let (body, ohttp_ctx) = ohttp_encapsulate(&mut ohttp, "GET", url.as_str(), Some(&body))
             .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
 

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -331,7 +331,7 @@ impl Sender {
     #[cfg(feature = "v2")]
     fn extract_rs_pubkey(
         &self,
-    ) -> Result<HpkePublicKey, crate::uri::error::ParseReceiverPubkeyError> {
+    ) -> Result<HpkePublicKey, crate::uri::error::ParseReceiverPubkeyParamError> {
         use crate::uri::UrlExt;
         self.endpoint.receiver_pubkey()
     }

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -32,7 +32,7 @@ impl std::fmt::Display for ParseOhttpKeysParamError {
 
 #[cfg(feature = "v2")]
 #[derive(Debug)]
-pub(crate) enum ParseReceiverPubkeyError {
+pub(crate) enum ParseReceiverPubkeyParamError {
     MissingPubkey,
     InvalidHrp(bitcoin::bech32::Hrp),
     DecodeBech32(bitcoin::bech32::primitives::decode::CheckedHrpstringError),
@@ -40,9 +40,9 @@ pub(crate) enum ParseReceiverPubkeyError {
 }
 
 #[cfg(feature = "v2")]
-impl std::fmt::Display for ParseReceiverPubkeyError {
+impl std::fmt::Display for ParseReceiverPubkeyParamError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use ParseReceiverPubkeyError::*;
+        use ParseReceiverPubkeyParamError::*;
 
         match &self {
             MissingPubkey => write!(f, "receiver public key is missing"),
@@ -55,9 +55,9 @@ impl std::fmt::Display for ParseReceiverPubkeyError {
 }
 
 #[cfg(feature = "v2")]
-impl std::error::Error for ParseReceiverPubkeyError {
+impl std::error::Error for ParseReceiverPubkeyParamError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use ParseReceiverPubkeyError::*;
+        use ParseReceiverPubkeyParamError::*;
 
         match &self {
             MissingPubkey => None,

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -13,6 +13,25 @@ pub(crate) enum InternalPjParseError {
 
 #[cfg(feature = "v2")]
 #[derive(Debug)]
+pub(crate) enum ParseOhttpKeysParamError {
+    MissingOhttpKeys,
+    InvalidOhttpKeys(crate::ohttp::ParseOhttpKeysError),
+}
+
+#[cfg(feature = "v2")]
+impl std::fmt::Display for ParseOhttpKeysParamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use ParseOhttpKeysParamError::*;
+
+        match &self {
+            MissingOhttpKeys => write!(f, "ohttp keys are missing"),
+            InvalidOhttpKeys(o) => write!(f, "invalid ohttp keys: {}", o),
+        }
+    }
+}
+
+#[cfg(feature = "v2")]
+#[derive(Debug)]
 pub(crate) enum ParseReceiverPubkeyError {
     MissingPubkey,
     InvalidHrp(bitcoin::bech32::Hrp),


### PR DESCRIPTION
Not sure if you guys are accepting contributions, but I recently came across payjoins and thought it was a cool idea and wanted to see if i could contribute. 

This PR will update the `ohttp()` getter to propagate the parse errors as part of #399. If this looks good, i can submit another patch to do the same for `exp()`