### PR TITLE
Multiparty Senders: NS1R

### DIFF
--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -124,10 +124,7 @@ pub fn local_cert_key() -> (Vec<u8>, Vec<u8>) {
     (cert_der, key_der)
 }
 
-pub fn init_bitcoind_sender_receiver(
-    sender_address_type: Option<AddressType>,
-    receiver_address_type: Option<AddressType>,
-) -> Result<(bitcoind::BitcoinD, bitcoincore_rpc::Client, bitcoincore_rpc::Client), BoxError> {
+pub fn init_bitcoind() -> Result<bitcoind::BitcoinD, BoxError> {
     let bitcoind_exe = env::var("BITCOIND_EXE")
         .ok()
         .or_else(|| bitcoind::downloaded_exe_path().ok())
@@ -135,29 +132,78 @@ pub fn init_bitcoind_sender_receiver(
     let mut conf = bitcoind::Conf::default();
     conf.view_stdout = log_enabled!(Level::Debug);
     let bitcoind = bitcoind::BitcoinD::with_conf(bitcoind_exe, &conf)?;
-    let receiver = bitcoind.create_wallet("receiver")?;
-    let receiver_address = receiver.get_new_address(None, receiver_address_type)?.assume_checked();
-    let sender = bitcoind.create_wallet("sender")?;
-    let sender_address = sender.get_new_address(None, sender_address_type)?.assume_checked();
-    bitcoind.client.generate_to_address(1, &receiver_address)?;
-    bitcoind.client.generate_to_address(101, &sender_address)?;
+    Ok(bitcoind)
+}
 
-    assert_eq!(
-        Amount::from_btc(50.0)?,
-        receiver.get_balances()?.mine.trusted,
-        "receiver doesn't own bitcoin"
-    );
+pub fn init_bitcoind_sender_receiver(
+    sender_address_type: Option<AddressType>,
+    receiver_address_type: Option<AddressType>,
+) -> Result<(bitcoind::BitcoinD, bitcoincore_rpc::Client, bitcoincore_rpc::Client), BoxError> {
+    let bitcoind = init_bitcoind()?;
+    let mut wallets = create_and_fund_wallets(
+        &bitcoind,
+        vec![("receiver", receiver_address_type), ("sender", sender_address_type)],
+    )?;
+    let receiver = wallets.pop().expect("receiver to exist");
+    let sender = wallets.pop().expect("sender to exist");
 
-    assert_eq!(
-        Amount::from_btc(50.0)?,
-        sender.get_balances()?.mine.trusted,
-        "sender doesn't own bitcoin"
-    );
-    Ok((bitcoind, sender, receiver))
+    Ok((bitcoind, receiver, sender))
+}
+
+fn create_and_fund_wallets<W: AsRef<str>>(
+    bitcoind: &bitcoind::BitcoinD,
+    wallets: Vec<(W, Option<AddressType>)>,
+) -> Result<Vec<bitcoincore_rpc::Client>, BoxError> {
+    let mut funded_wallets = vec![];
+    let funding_wallet = bitcoind.create_wallet("funding_wallet")?;
+    let funding_address = funding_wallet.get_new_address(None, None)?.assume_checked();
+    // 100 blocks would work here, we add a extra block to cover fees between transfers
+    bitcoind.client.generate_to_address(101 + wallets.len() as u64, &funding_address)?;
+    for (wallet_name, address_type) in wallets {
+        let wallet = bitcoind.create_wallet(wallet_name)?;
+        let address = wallet.get_new_address(None, address_type)?.assume_checked();
+        funding_wallet.send_to_address(
+            &address,
+            Amount::from_btc(50.0)?,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+        funded_wallets.push(wallet);
+    }
+    // Mine the block which funds the different wallets
+    bitcoind.client.generate_to_address(1, &funding_address)?;
+
+    for wallet in funded_wallets.iter() {
+        let balances = wallet.get_balances()?;
+        assert_eq!(
+            balances.mine.trusted,
+            Amount::from_btc(50.0)?,
+            "wallet doesn't have expected amount of bitcoin"
+        );
+    }
+
+    Ok(funded_wallets)
 }
 
 pub fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxSendSyncError> {
     Ok(http_agent_builder(cert_der).build()?)
+}
+
+pub fn init_bitcoind_multi_sender_single_reciever(
+    number_of_senders: usize,
+) -> Result<(bitcoind::BitcoinD, Vec<bitcoincore_rpc::Client>, bitcoincore_rpc::Client), BoxError> {
+    let bitcoind = init_bitcoind()?;
+    let wallets_to_create =
+        (0..number_of_senders + 1).map(|i| (format!("sender_{}", i), None)).collect::<Vec<_>>();
+    let mut wallets = create_and_fund_wallets(&bitcoind, wallets_to_create)?;
+    let receiver = wallets.pop().expect("reciever to exist");
+    let senders = wallets;
+
+    Ok((bitcoind, senders, receiver))
 }
 
 fn http_agent_builder(cert_der: Vec<u8>) -> ClientBuilder {

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -20,12 +20,12 @@ default = ["v2"]
 #[doc = "Core features for payjoin state machines"]
 _core = ["bitcoin/rand", "serde_json", "url", "bitcoin_uri"]
 directory = []
-psbt-merge = []
 v1 = ["_core"]
 v2 = ["_core", "bitcoin/serde", "hpke", "dep:http", "bhttp", "ohttp", "serde", "url/serde", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
 _danger-local-https = ["reqwest/rustls-tls", "rustls"]
+_multiparty = ["v2"]
 
 [dependencies]
 bitcoin = { version = "0.32.5", features = ["base64"] }

--- a/payjoin/src/psbt/mod.rs
+++ b/payjoin/src/psbt/mod.rs
@@ -1,6 +1,6 @@
 //! Utilities to make work with PSBTs easier
 
-#[cfg(feature = "psbt-merge")]
+#[cfg(feature = "_multiparty")]
 pub(crate) mod merge;
 
 use std::collections::BTreeMap;

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -25,6 +25,8 @@ use crate::psbt::{InternalInputPair, InternalPsbtInputError, PsbtExt};
 mod error;
 pub(crate) mod optional_parameters;
 
+#[cfg(feature = "_multiparty")]
+pub mod multiparty;
 #[cfg(feature = "v1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "v1")))]
 pub mod v1;

--- a/payjoin/src/receive/multiparty/error.rs
+++ b/payjoin/src/receive/multiparty/error.rs
@@ -1,0 +1,56 @@
+use core::fmt;
+use std::error;
+
+#[derive(Debug)]
+pub struct MultipartyError(InternalMultipartyError);
+
+#[derive(Debug)]
+pub(crate) enum InternalMultipartyError {
+    /// Not enough proposals
+    NotEnoughProposals,
+    /// Proposal version not supported
+    ProposalVersionNotSupported(usize),
+    /// Optimistic merge not supported
+    OptimisticMergeNotSupported,
+    /// Bitcoin Internal Error
+    BitcoinExtractTxError(Box<bitcoin::psbt::ExtractTxError>),
+    /// Input in Finalized Proposal is missing witness or script_sig
+    InputMissingWitnessOrScriptSig,
+    /// Failed to combine psbts
+    FailedToCombinePsbts(bitcoin::psbt::Error),
+}
+
+impl From<InternalMultipartyError> for MultipartyError {
+    fn from(e: InternalMultipartyError) -> Self { MultipartyError(e) }
+}
+
+impl fmt::Display for MultipartyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            InternalMultipartyError::NotEnoughProposals => write!(f, "Not enough proposals"),
+            InternalMultipartyError::ProposalVersionNotSupported(v) =>
+                write!(f, "Proposal version not supported: {}", v),
+            InternalMultipartyError::OptimisticMergeNotSupported =>
+                write!(f, "Optimistic merge not supported"),
+            InternalMultipartyError::BitcoinExtractTxError(e) =>
+                write!(f, "Bitcoin extract tx error: {:?}", e),
+            InternalMultipartyError::InputMissingWitnessOrScriptSig =>
+                write!(f, "Input in Finalized Proposal is missing witness or script_sig"),
+            InternalMultipartyError::FailedToCombinePsbts(e) =>
+                write!(f, "Failed to combine psbts: {:?}", e),
+        }
+    }
+}
+
+impl error::Error for MultipartyError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.0 {
+            InternalMultipartyError::NotEnoughProposals => None,
+            InternalMultipartyError::ProposalVersionNotSupported(_) => None,
+            InternalMultipartyError::OptimisticMergeNotSupported => None,
+            InternalMultipartyError::BitcoinExtractTxError(e) => Some(e),
+            InternalMultipartyError::InputMissingWitnessOrScriptSig => None,
+            InternalMultipartyError::FailedToCombinePsbts(e) => Some(e),
+        }
+    }
+}

--- a/payjoin/src/receive/multiparty/mod.rs
+++ b/payjoin/src/receive/multiparty/mod.rs
@@ -1,0 +1,250 @@
+use bitcoin::{FeeRate, Psbt};
+
+use super::error::InputContributionError;
+use super::{v1, v2, Error, ImplementationError, InputPair};
+use crate::psbt::merge::merge_unsigned_tx;
+use crate::receive::multiparty::error::{InternalMultipartyError, MultipartyError};
+use crate::receive::v2::SessionContext;
+
+pub(crate) mod error;
+
+const SUPPORTED_VERSIONS: &[usize] = &[2];
+
+#[derive(Default)]
+pub struct UncheckedProposalBuilder {
+    proposals: Vec<v2::UncheckedProposal>,
+}
+
+impl UncheckedProposalBuilder {
+    pub fn new() -> Self { Self { proposals: vec![] } }
+
+    pub fn add(&mut self, proposal: v2::UncheckedProposal) -> Result<Self, MultipartyError> {
+        self.check_proposal_suitability(&proposal)?;
+        self.proposals.push(proposal);
+        Ok(Self { proposals: self.proposals.clone() })
+    }
+
+    fn check_proposal_suitability(
+        &self,
+        proposal: &v2::UncheckedProposal,
+    ) -> Result<(), MultipartyError> {
+        let params = proposal.v1.params.clone();
+        if !SUPPORTED_VERSIONS.contains(&params.v) {
+            return Err(InternalMultipartyError::ProposalVersionNotSupported(params.v).into());
+        }
+
+        if !params.optimistic_merge {
+            return Err(InternalMultipartyError::OptimisticMergeNotSupported.into());
+        }
+        Ok(())
+    }
+
+    pub fn build(&self) -> Result<UncheckedProposal, MultipartyError> {
+        if self.proposals.len() < 2 {
+            return Err(InternalMultipartyError::NotEnoughProposals.into());
+        }
+        let agg_psbt = self
+            .proposals
+            .iter()
+            .map(|p| p.v1.psbt.clone())
+            .reduce(merge_unsigned_tx)
+            .ok_or(InternalMultipartyError::NotEnoughProposals)?;
+        let unchecked_proposal = v1::UncheckedProposal {
+            psbt: agg_psbt,
+            params: self.proposals.first().expect("checked above").v1.params.clone(),
+        };
+        let contexts = self.proposals.iter().map(|p| p.context.clone()).collect();
+        Ok(UncheckedProposal { v1: unchecked_proposal, contexts })
+    }
+}
+
+/// A multiparty proposal that has been merged by the receiver
+pub struct UncheckedProposal {
+    v1: v1::UncheckedProposal,
+    contexts: Vec<SessionContext>,
+}
+
+impl UncheckedProposal {
+    pub fn check_broadcast_suitability(
+        self,
+        min_fee_rate: Option<FeeRate>,
+        can_broadcast: impl Fn(&bitcoin::Transaction) -> Result<bool, ImplementationError>,
+    ) -> Result<MaybeInputsOwned, Error> {
+        let inner = self.v1.check_broadcast_suitability(min_fee_rate, can_broadcast)?;
+        Ok(MaybeInputsOwned { v1: inner, contexts: self.contexts })
+    }
+}
+
+pub struct MaybeInputsOwned {
+    v1: v1::MaybeInputsOwned,
+    contexts: Vec<SessionContext>,
+}
+
+impl MaybeInputsOwned {
+    pub fn check_inputs_not_owned(
+        self,
+        is_owned: impl Fn(&bitcoin::Script) -> Result<bool, ImplementationError>,
+    ) -> Result<MaybeInputsSeen, Error> {
+        let inner = self.v1.check_inputs_not_owned(is_owned)?;
+        Ok(MaybeInputsSeen { v1: inner, contexts: self.contexts })
+    }
+}
+
+pub struct MaybeInputsSeen {
+    v1: v1::MaybeInputsSeen,
+    contexts: Vec<SessionContext>,
+}
+
+impl MaybeInputsSeen {
+    pub fn check_no_inputs_seen_before(
+        self,
+        is_seen: impl Fn(&bitcoin::OutPoint) -> Result<bool, ImplementationError>,
+    ) -> Result<OutputsUnknown, Error> {
+        let inner = self.v1.check_no_inputs_seen_before(is_seen)?;
+        Ok(OutputsUnknown { v1: inner, contexts: self.contexts })
+    }
+}
+
+pub struct OutputsUnknown {
+    v1: v1::OutputsUnknown,
+    contexts: Vec<SessionContext>,
+}
+
+impl OutputsUnknown {
+    pub fn identify_receiver_outputs(
+        self,
+        is_receiver_output: impl Fn(&bitcoin::Script) -> Result<bool, ImplementationError>,
+    ) -> Result<WantsOutputs, Error> {
+        let inner = self.v1.identify_receiver_outputs(is_receiver_output)?;
+        Ok(WantsOutputs { v1: inner, contexts: self.contexts })
+    }
+}
+
+pub struct WantsOutputs {
+    v1: v1::WantsOutputs,
+    contexts: Vec<SessionContext>,
+}
+
+impl WantsOutputs {
+    pub fn commit_outputs(self) -> WantsInputs {
+        let inner = self.v1.commit_outputs();
+        WantsInputs { v1: inner, contexts: self.contexts }
+    }
+}
+
+pub struct WantsInputs {
+    v1: v1::WantsInputs,
+    contexts: Vec<SessionContext>,
+}
+
+impl WantsInputs {
+    /// Add the provided list of inputs to the transaction.
+    /// Any excess input amount is added to the change_vout output indicated previously.
+    pub fn contribute_inputs(
+        self,
+        inputs: impl IntoIterator<Item = InputPair>,
+    ) -> Result<WantsInputs, InputContributionError> {
+        let inner = self.v1.contribute_inputs(inputs)?;
+        Ok(WantsInputs { v1: inner, contexts: self.contexts })
+    }
+
+    /// Proceed to the proposal finalization step.
+    /// Inputs cannot be modified after this function is called.
+    pub fn commit_inputs(self) -> ProvisionalProposal {
+        let inner = self.v1.commit_inputs();
+        ProvisionalProposal { v1: inner, contexts: self.contexts }
+    }
+}
+
+pub struct ProvisionalProposal {
+    v1: v1::ProvisionalProposal,
+    contexts: Vec<SessionContext>,
+}
+
+impl ProvisionalProposal {
+    pub fn finalize_proposal(
+        self,
+        wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, ImplementationError>,
+        min_feerate_sat_per_vb: Option<FeeRate>,
+        max_feerate_sat_per_vb: FeeRate,
+    ) -> Result<PayjoinProposal, Error> {
+        let inner = self.v1.finalize_proposal(
+            wallet_process_psbt,
+            min_feerate_sat_per_vb,
+            Some(max_feerate_sat_per_vb),
+        )?;
+        Ok(PayjoinProposal { v1: inner, contexts: self.contexts })
+    }
+}
+
+pub struct PayjoinProposal {
+    v1: v1::PayjoinProposal,
+    contexts: Vec<SessionContext>,
+}
+
+impl PayjoinProposal {
+    pub fn sender_iter(&self) -> impl Iterator<Item = v2::PayjoinProposal> {
+        self.contexts
+            .iter()
+            .map(|ctx| v2::PayjoinProposal::new(self.v1.clone(), ctx.clone()))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    pub fn proposal(&self) -> &v1::PayjoinProposal { &self.v1 }
+}
+
+/// A multiparty proposal that is ready to be combined into a single psbt
+#[derive(Default)]
+pub struct FinalizedProposal {
+    v2_proposals: Vec<v2::UncheckedProposal>,
+}
+
+impl FinalizedProposal {
+    pub fn new() -> Self { Self { v2_proposals: vec![] } }
+
+    pub fn add(&mut self, proposal: v2::UncheckedProposal) -> Result<(), MultipartyError> {
+        self.check_proposal_suitability(&proposal)?;
+        self.v2_proposals.push(proposal);
+        Ok(())
+    }
+
+    fn check_proposal_suitability(
+        &self,
+        proposal: &v2::UncheckedProposal,
+    ) -> Result<(), MultipartyError> {
+        if !SUPPORTED_VERSIONS.contains(&proposal.v1.params.v) {
+            return Err(
+                InternalMultipartyError::ProposalVersionNotSupported(proposal.v1.params.v).into()
+            );
+        }
+        Ok(())
+    }
+
+    pub fn combine(self) -> Result<Psbt, MultipartyError> {
+        if self.v2_proposals.len() < 2 {
+            return Err(InternalMultipartyError::NotEnoughProposals.into());
+        }
+
+        let mut agg_psbt = self.v2_proposals.first().expect("checked above").v1.psbt.clone();
+        for proposal in self.v2_proposals.iter().skip(1) {
+            agg_psbt
+                .combine(proposal.v1.psbt.clone())
+                .map_err(InternalMultipartyError::FailedToCombinePsbts)?;
+        }
+
+        // We explicitly call extract_tx to do some fee sanity checks
+        // Otherwise you can just read the inputs from the unsigned_tx of the psbt
+        let tx = agg_psbt
+            .clone()
+            .extract_tx()
+            .map_err(|e| InternalMultipartyError::BitcoinExtractTxError(Box::new(e)))?;
+        if tx.input.iter().any(|input| input.witness.is_empty() && input.script_sig.is_empty()) {
+            return Err(InternalMultipartyError::InputMissingWitnessOrScriptSig.into());
+        }
+
+        Ok(agg_psbt)
+    }
+
+    pub fn v2(&self) -> &[v2::UncheckedProposal] { &self.v2_proposals }
+}

--- a/payjoin/src/receive/optional_parameters.rs
+++ b/payjoin/src/receive/optional_parameters.rs
@@ -14,6 +14,9 @@ pub(crate) struct Params {
     pub additional_fee_contribution: Option<(bitcoin::Amount, usize)>,
     // minfeerate
     pub min_fee_rate: FeeRate,
+    #[cfg(feature = "_multiparty")]
+    /// Opt in to optimistic psbt merge
+    pub optimistic_merge: bool,
 }
 
 impl Default for Params {
@@ -23,6 +26,8 @@ impl Default for Params {
             disable_output_substitution: false,
             additional_fee_contribution: None,
             min_fee_rate: FeeRate::BROADCAST_MIN,
+            #[cfg(feature = "_multiparty")]
+            optimistic_merge: false,
         }
     }
 }
@@ -84,6 +89,8 @@ impl Params {
                     },
                 ("disableoutputsubstitution", v) =>
                     params.disable_output_substitution = v == "true",
+                #[cfg(feature = "_multiparty")]
+                ("optimisticmerge", v) => params.optimistic_merge = v == "true",
                 _ => (),
             }
         }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -35,6 +35,9 @@ pub(crate) mod v1;
 #[cfg_attr(docsrs, doc(cfg(feature = "v2")))]
 pub mod v2;
 
+#[cfg(feature = "_multiparty")]
+pub mod multiparty;
+
 type InternalResult<T> = Result<T, InternalProposalError>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/payjoin/src/send/multiparty/error.rs
+++ b/payjoin/src/send/multiparty/error.rs
@@ -1,0 +1,118 @@
+use std::fmt::{self, Display};
+
+use bitcoin::psbt::Error as PsbtError;
+
+use crate::hpke::HpkeError;
+use crate::ohttp::OhttpEncapsulationError;
+use crate::receive::ImplementationError;
+use crate::send::InternalProposalError;
+use crate::uri::url_ext::{ParseOhttpKeysParamError, ParseReceiverPubkeyParamError};
+
+#[derive(Debug)]
+pub struct CreateRequestError(InternalCreateRequestError);
+
+#[derive(Debug)]
+pub(crate) enum InternalCreateRequestError {
+    #[allow(dead_code)]
+    Expired(std::time::SystemTime),
+    MissingOhttpConfig,
+    OhttpEncapsulation(OhttpEncapsulationError),
+    Hpke(HpkeError),
+    ParseReceiverPubkeyParam(ParseReceiverPubkeyParamError),
+    Url(url::ParseError),
+}
+
+impl From<InternalCreateRequestError> for CreateRequestError {
+    fn from(value: InternalCreateRequestError) -> Self { CreateRequestError(value) }
+}
+
+impl Display for CreateRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
+}
+
+impl std::error::Error for CreateRequestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.0 {
+            InternalCreateRequestError::Expired(_) => None,
+            InternalCreateRequestError::MissingOhttpConfig => None,
+            InternalCreateRequestError::OhttpEncapsulation(e) => Some(e),
+            InternalCreateRequestError::Hpke(e) => Some(e),
+            InternalCreateRequestError::ParseReceiverPubkeyParam(e) => Some(e),
+            InternalCreateRequestError::Url(e) => Some(e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FinalizedError(InternalFinalizedError);
+
+#[derive(Debug)]
+pub(crate) enum InternalFinalizedError {
+    CreateRequest(CreateRequestError),
+    Encapsulation(OhttpEncapsulationError),
+    Hpke(HpkeError),
+    ParseOhttp(ParseOhttpKeysParamError),
+    InvalidSize,
+    #[allow(dead_code)]
+    FinalizePsbt(ImplementationError),
+    MissingResponse,
+    Psbt(PsbtError),
+    #[allow(dead_code)]
+    UnexpectedStatusCode(http::StatusCode),
+    Proposal(InternalProposalError),
+}
+
+impl From<InternalFinalizedError> for FinalizedError {
+    fn from(value: InternalFinalizedError) -> Self { FinalizedError(value) }
+}
+
+impl Display for FinalizedError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
+}
+
+impl std::error::Error for FinalizedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.0 {
+            InternalFinalizedError::CreateRequest(e) => Some(e),
+            InternalFinalizedError::Encapsulation(e) => Some(e),
+            InternalFinalizedError::Hpke(e) => Some(e),
+            InternalFinalizedError::ParseOhttp(_e) => None,
+            InternalFinalizedError::InvalidSize => None,
+            InternalFinalizedError::FinalizePsbt(_) => None,
+            InternalFinalizedError::MissingResponse => None,
+            InternalFinalizedError::Psbt(e) => Some(e),
+            InternalFinalizedError::UnexpectedStatusCode(_) => None,
+            InternalFinalizedError::Proposal(e) => Some(e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FinalizeResponseError(InternalFinalizeResponseError);
+
+#[derive(Debug)]
+pub(crate) enum InternalFinalizeResponseError {
+    #[allow(dead_code)]
+    InvalidSize(usize),
+    Ohttp(OhttpEncapsulationError),
+    #[allow(dead_code)]
+    UnexpectedStatusCode(http::StatusCode),
+}
+
+impl From<InternalFinalizeResponseError> for FinalizeResponseError {
+    fn from(value: InternalFinalizeResponseError) -> Self { FinalizeResponseError(value) }
+}
+
+impl Display for FinalizeResponseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
+}
+
+impl std::error::Error for FinalizeResponseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.0 {
+            InternalFinalizeResponseError::InvalidSize(_) => None,
+            InternalFinalizeResponseError::Ohttp(e) => Some(e),
+            InternalFinalizeResponseError::UnexpectedStatusCode(_) => None,
+        }
+    }
+}

--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -1,0 +1,280 @@
+use bitcoin::{FeeRate, Psbt};
+use error::{
+    CreateRequestError, FinalizeResponseError, FinalizedError, InternalCreateRequestError,
+    InternalFinalizeResponseError, InternalFinalizedError,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::v2::{self, EncapsulationError, HpkeContext};
+use super::{serialize_url, AdditionalFeeContribution, BuildSenderError, InternalResult};
+use crate::hpke::decrypt_message_b;
+use crate::ohttp::ohttp_decapsulate;
+use crate::receive::ImplementationError;
+use crate::send::v2::V2PostContext;
+use crate::{PjUri, Request};
+
+mod error;
+
+#[derive(Clone)]
+pub struct SenderBuilder<'a>(v2::SenderBuilder<'a>);
+
+impl<'a> SenderBuilder<'a> {
+    pub fn new(psbt: Psbt, uri: PjUri<'a>) -> Self { Self(v2::SenderBuilder::new(psbt, uri)) }
+    pub fn build_recommended(self, min_fee_rate: FeeRate) -> Result<Sender, BuildSenderError> {
+        let v2 = v2::SenderBuilder::new(self.0 .0.psbt, self.0 .0.uri)
+            .build_recommended(min_fee_rate)?;
+        Ok(Sender(v2))
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Sender(v2::Sender);
+
+impl Sender {
+    pub fn extract_v2(
+        &self,
+        ohttp_relay: Url,
+    ) -> Result<(Request, PostContext), CreateRequestError> {
+        use crate::hpke::encrypt_message_a;
+        use crate::ohttp::ohttp_encapsulate;
+        use crate::send::PsbtContext;
+        use crate::uri::UrlExt;
+        let url = self.0.endpoint().clone();
+        if let Ok(expiry) = url.exp() {
+            if std::time::SystemTime::now() > expiry {
+                return Err(InternalCreateRequestError::Expired(expiry).into());
+            }
+        }
+        let rs = self
+            .0
+            .extract_rs_pubkey()
+            .map_err(InternalCreateRequestError::ParseReceiverPubkeyParam)?;
+        let body = serialize_v2_body(
+            &self.0.v1.psbt,
+            self.0.v1.disable_output_substitution,
+            self.0.v1.fee_contribution,
+            self.0.v1.min_fee_rate,
+        )?;
+        let hpke_ctx = HpkeContext::new(rs, &self.0.reply_key);
+        let body = encrypt_message_a(
+            body,
+            &hpke_ctx.reply_pair.public_key().clone(),
+            &hpke_ctx.receiver.clone(),
+        )
+        .map_err(InternalCreateRequestError::Hpke)?;
+        let mut ohttp = self
+            .0
+            .v1
+            .endpoint
+            .ohttp()
+            .map_err(|_| InternalCreateRequestError::MissingOhttpConfig)?;
+        let (body, ohttp_ctx) = ohttp_encapsulate(&mut ohttp, "POST", url.as_str(), Some(&body))
+            .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
+
+        let v2_post_ctx = V2PostContext {
+            endpoint: self.0.endpoint().clone(),
+            psbt_ctx: PsbtContext {
+                original_psbt: self.0.v1.psbt.clone(),
+                disable_output_substitution: self.0.v1.disable_output_substitution,
+                fee_contribution: self.0.v1.fee_contribution,
+                payee: self.0.v1.payee.clone(),
+                min_fee_rate: self.0.v1.min_fee_rate,
+            },
+            hpke_ctx,
+            ohttp_ctx,
+        };
+        Ok((Request::new_v2(&ohttp_relay, &body), PostContext(v2_post_ctx)))
+    }
+}
+
+fn serialize_v2_body(
+    psbt: &Psbt,
+    disable_output_substitution: bool,
+    fee_contribution: Option<AdditionalFeeContribution>,
+    min_fee_rate: FeeRate,
+) -> Result<Vec<u8>, CreateRequestError> {
+    let mut url = serialize_url(
+        Url::parse("http://localhost").unwrap(),
+        disable_output_substitution,
+        fee_contribution,
+        min_fee_rate,
+        "2",
+    )
+    .map_err(InternalCreateRequestError::Url)?;
+    append_optimisitic_merge_query_param(&mut url);
+    let base64 = psbt.to_string();
+    Ok(format!("{}\n{}", base64, url.query().unwrap_or_default()).into_bytes())
+}
+
+/// Post context is used to process the response from the directory and generate
+/// the GET context which can be used to extract a request for the receiver
+pub struct PostContext(v2::V2PostContext);
+
+impl PostContext {
+    pub fn process_response(self, response: &[u8]) -> Result<GetContext, EncapsulationError> {
+        let v2_get_ctx = self.0.process_response(response)?;
+        Ok(GetContext(v2_get_ctx))
+    }
+}
+
+/// Get context is used to extract a request for the receiver. In the multiparty context this is a
+/// merged PSBT with other senders.
+pub struct GetContext(v2::V2GetContext);
+
+impl GetContext {
+    /// Extract the GET request that will give us the psbt to be finalized
+    pub fn extract_req(
+        &self,
+        ohttp_relay: Url,
+    ) -> Result<(Request, ohttp::ClientResponse), crate::send::v2::CreateRequestError> {
+        self.0.extract_req(ohttp_relay)
+    }
+
+    /// Process the response from the directory. Provide a closure to finalize the inputs
+    /// you own. With the FinalizeContext, you can extract the last POST request and process the response sent back from the directory.
+    pub fn process_response_and_finalize(
+        &self,
+        response: &[u8],
+        ohttp_ctx: ohttp::ClientResponse,
+        finalize_psbt: impl Fn(&Psbt) -> Result<Psbt, ImplementationError>,
+    ) -> Result<FinalizeContext, FinalizedError> {
+        let psbt_ctx = PsbtContext { inner: self.0.psbt_ctx.clone() };
+        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
+            response.try_into().map_err(|_| InternalFinalizedError::InvalidSize)?;
+
+        let response = ohttp_decapsulate(ohttp_ctx, response_array)
+            .map_err(InternalFinalizedError::Encapsulation)?;
+        let body = match response.status() {
+            http::StatusCode::OK => Some(response.body().to_vec()),
+            http::StatusCode::ACCEPTED => None,
+            _ => return Err(InternalFinalizedError::UnexpectedStatusCode(response.status()))?,
+        };
+        if let Some(body) = body {
+            let psbt = decrypt_message_b(
+                &body,
+                self.0.hpke_ctx.receiver.clone(),
+                self.0.hpke_ctx.reply_pair.secret_key().clone(),
+            )
+            .map_err(InternalFinalizedError::Hpke)?;
+
+            let proposal = Psbt::deserialize(&psbt).map_err(InternalFinalizedError::Psbt)?;
+            let psbt =
+                psbt_ctx.process_proposal(proposal).map_err(InternalFinalizedError::Proposal)?;
+            let finalized_psbt =
+                finalize_psbt(&psbt).map_err(InternalFinalizedError::FinalizePsbt)?;
+            Ok(FinalizeContext {
+                hpke_ctx: self.0.hpke_ctx.clone(),
+                directory_url: self.0.endpoint.clone(),
+                psbt: finalized_psbt,
+            })
+        } else {
+            Err(InternalFinalizedError::MissingResponse.into())
+        }
+    }
+}
+
+/// Finalize context is used to extract the last POST request and process the response sent back from the directory.
+pub struct FinalizeContext {
+    hpke_ctx: HpkeContext,
+    directory_url: Url,
+    psbt: Psbt,
+}
+
+impl FinalizeContext {
+    pub fn extract_req(
+        &self,
+        ohttp_relay: Url,
+    ) -> Result<(Request, ohttp::ClientResponse), FinalizedError> {
+        use crate::hpke::encrypt_message_a;
+        use crate::ohttp::ohttp_encapsulate;
+        use crate::uri::UrlExt;
+
+        let hpke_ctx = self.hpke_ctx.clone();
+        let directory_url = self.directory_url.clone();
+        // TODO: check if request is expired off the directory url
+
+        // The query params are not needed for the final request
+        // The reciever will ignore them. PSBT is all that is needed.
+        let body = serialize_v2_body(
+            &self.psbt,
+            false, // disable output substitution
+            None,  // fee contribution
+            FeeRate::BROADCAST_MIN,
+        )
+        .map_err(InternalFinalizedError::CreateRequest)?;
+        let body = encrypt_message_a(
+            body,
+            &hpke_ctx.reply_pair.public_key().clone(),
+            &hpke_ctx.receiver.clone(),
+        )
+        .map_err(InternalFinalizedError::Hpke)?;
+        let mut ohttp = directory_url.ohttp().map_err(InternalFinalizedError::ParseOhttp)?;
+        let (body, ohttp_ctx) =
+            ohttp_encapsulate(&mut ohttp, "POST", directory_url.as_str(), Some(&body))
+                .map_err(InternalFinalizedError::Encapsulation)?;
+        let request = Request::new_v2(&ohttp_relay, &body);
+        Ok((request, ohttp_ctx))
+    }
+
+    pub fn process_response(
+        self,
+        response: &[u8],
+        ohttp_ctx: ohttp::ClientResponse,
+    ) -> Result<(), FinalizeResponseError> {
+        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] = response
+            .try_into()
+            .map_err(|_| InternalFinalizeResponseError::InvalidSize(response.len()))?;
+
+        let response = ohttp_decapsulate(ohttp_ctx, response_array)
+            .map_err(InternalFinalizeResponseError::Ohttp)?;
+        match response.status() {
+            http::StatusCode::OK | http::StatusCode::ACCEPTED => Ok(()),
+            _ => Err(InternalFinalizeResponseError::UnexpectedStatusCode(response.status()))?,
+        }
+    }
+}
+
+pub(crate) struct PsbtContext {
+    inner: crate::send::PsbtContext,
+}
+
+impl PsbtContext {
+    fn process_proposal(self, mut proposal: Psbt) -> InternalResult<Psbt> {
+        // TODO(armins) add multiparty check fees modeled after crate::send::PsbtContext::check_fees
+        // The problem with this is that some of the inputs will be missing witness_utxo or non_witness_utxo field in the psbt so the default psbt.fee() will fail
+        // Similarly we need to implement a check for the inputs. It would be useful to have all the checks as crate::send::PsbtContext::check_inputs
+        // However that method expects the reciver to have provided witness for their inputs. In a ns1r the reciever will not sign any inputs of the optimistic merged psbt
+        self.inner.basic_checks(&proposal)?;
+        self.inner.check_outputs(&proposal)?;
+        self.inner.restore_original_utxos(&mut proposal)?;
+        Ok(proposal)
+    }
+}
+
+fn append_optimisitic_merge_query_param(url: &mut Url) {
+    url.query_pairs_mut().append_pair("optimisticmerge", "true");
+}
+
+#[cfg(test)]
+mod test {
+    use bitcoin::FeeRate;
+    use payjoin_test_utils::BoxError;
+    use url::Url;
+
+    use crate::send::multiparty::append_optimisitic_merge_query_param;
+    use crate::send::serialize_url;
+
+    #[test]
+    fn test_optimistic_merge_query_param() -> Result<(), BoxError> {
+        let mut url =
+            serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2")?;
+        append_optimisitic_merge_query_param(&mut url);
+        assert_eq!(url, Url::parse("http://localhost?v=2&optimisticmerge=true")?);
+
+        let url = serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2")?;
+        assert_eq!(url, Url::parse("http://localhost?v=2")?);
+
+        Ok(())
+    }
+}

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -38,7 +38,7 @@ use crate::{HpkeKeyPair, HpkePublicKey, IntoUrl, PjUri, Request};
 mod error;
 
 #[derive(Clone)]
-pub struct SenderBuilder<'a>(v1::SenderBuilder<'a>);
+pub struct SenderBuilder<'a>(pub(crate) v1::SenderBuilder<'a>);
 
 impl<'a> SenderBuilder<'a> {
     /// Prepare the context from which to make Sender requests
@@ -119,9 +119,9 @@ impl<'a> SenderBuilder<'a> {
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sender {
     /// The v1 Sender.
-    v1: v1::Sender,
+    pub(crate) v1: v1::Sender,
     /// The secret key to decrypt the receiver's reply.
-    reply_key: HpkeSecretKey,
+    pub(crate) reply_key: HpkeSecretKey,
 }
 
 impl Sender {
@@ -184,7 +184,7 @@ impl Sender {
         ))
     }
 
-    fn extract_rs_pubkey(
+    pub(crate) fn extract_rs_pubkey(
         &self,
     ) -> Result<HpkePublicKey, crate::uri::url_ext::ParseReceiverPubkeyParamError> {
         self.v1.endpoint.receiver_pubkey()
@@ -193,7 +193,7 @@ impl Sender {
     pub fn endpoint(&self) -> &Url { self.v1.endpoint() }
 }
 
-fn serialize_v2_body(
+pub(crate) fn serialize_v2_body(
     psbt: &Psbt,
     disable_output_substitution: bool,
     fee_contribution: Option<AdditionalFeeContribution>,
@@ -215,10 +215,10 @@ fn serialize_v2_body(
 
 pub struct V2PostContext {
     /// The payjoin directory subdirectory to send the request to.
-    endpoint: Url,
-    psbt_ctx: PsbtContext,
-    hpke_ctx: HpkeContext,
-    ohttp_ctx: ohttp::ClientResponse,
+    pub(crate) endpoint: Url,
+    pub(crate) psbt_ctx: PsbtContext,
+    pub(crate) hpke_ctx: HpkeContext,
+    pub(crate) ohttp_ctx: ohttp::ClientResponse,
 }
 
 impl V2PostContext {
@@ -245,9 +245,9 @@ impl V2PostContext {
 #[derive(Debug, Clone)]
 pub struct V2GetContext {
     /// The payjoin directory subdirectory to send the request to.
-    endpoint: Url,
-    psbt_ctx: PsbtContext,
-    hpke_ctx: HpkeContext,
+    pub(crate) endpoint: Url,
+    pub(crate) psbt_ctx: PsbtContext,
+    pub(crate) hpke_ctx: HpkeContext,
 }
 
 impl V2GetContext {
@@ -310,9 +310,9 @@ impl V2GetContext {
 
 #[cfg(feature = "v2")]
 #[derive(Debug, Clone)]
-struct HpkeContext {
-    receiver: HpkePublicKey,
-    reply_pair: HpkeKeyPair,
+pub(crate) struct HpkeContext {
+    pub(crate) receiver: HpkePublicKey,
+    pub(crate) reply_pair: HpkeKeyPair,
 }
 
 #[cfg(feature = "v2")]

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -24,6 +24,7 @@
 use bitcoin::hashes::{sha256, Hash};
 pub use error::{CreateRequestError, EncapsulationError};
 use error::{InternalCreateRequestError, InternalEncapsulationError};
+use ohttp::ClientResponse;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -33,7 +34,7 @@ use crate::hpke::{decrypt_message_b, encrypt_message_a, HpkeSecretKey};
 use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate};
 use crate::send::v1;
 use crate::uri::{ShortId, UrlExt};
-use crate::{HpkeKeyPair, HpkePublicKey, IntoUrl, PjUri, Request};
+use crate::{HpkeKeyPair, HpkePublicKey, IntoUrl, OhttpKeys, PjUri, Request};
 
 mod error;
 
@@ -138,37 +139,34 @@ impl Sender {
         &self,
         ohttp_relay: Url,
     ) -> Result<(Request, V2PostContext), CreateRequestError> {
-        use crate::hpke::encrypt_message_a;
-        use crate::ohttp::ohttp_encapsulate;
-        use crate::send::PsbtContext;
-        use crate::uri::UrlExt;
         if let Ok(expiry) = self.v1.endpoint.exp() {
             if std::time::SystemTime::now() > expiry {
                 return Err(InternalCreateRequestError::Expired(expiry).into());
             }
         }
-        let rs = self.extract_rs_pubkey()?;
-        let url = self.v1.endpoint.clone();
+
+        let mut ohttp_keys = self
+            .v1
+            .endpoint()
+            .ohttp()
+            .map_err(|_| InternalCreateRequestError::MissingOhttpConfig)?;
         let body = serialize_v2_body(
             &self.v1.psbt,
             self.v1.disable_output_substitution,
             self.v1.fee_contribution,
             self.v1.min_fee_rate,
         )?;
-        let hpke_ctx = HpkeContext::new(rs, &self.reply_key);
-        let body = encrypt_message_a(
+        let (request, ohttp_ctx) = extract_request(
+            ohttp_relay,
+            self.reply_key.clone(),
             body,
-            &hpke_ctx.reply_pair.public_key().clone(),
-            &hpke_ctx.receiver.clone(),
-        )
-        .map_err(InternalCreateRequestError::Hpke)?;
-        let mut ohttp =
-            self.v1.endpoint.ohttp().map_err(|_| InternalCreateRequestError::MissingOhttpConfig)?;
-        let (body, ohttp_ctx) = ohttp_encapsulate(&mut ohttp, "POST", url.as_str(), Some(&body))
-            .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
-        log::debug!("ohttp_relay_url: {:?}", ohttp_relay);
+            self.v1.endpoint.clone(),
+            self.extract_rs_pubkey()?,
+            &mut ohttp_keys,
+        )?;
+        let rs = self.extract_rs_pubkey()?;
         Ok((
-            Request::new_v2(&ohttp_relay, &body),
+            request,
             V2PostContext {
                 endpoint: self.v1.endpoint.clone(),
                 psbt_ctx: PsbtContext {
@@ -178,7 +176,7 @@ impl Sender {
                     payee: self.v1.payee.clone(),
                     min_fee_rate: self.v1.min_fee_rate,
                 },
-                hpke_ctx,
+                hpke_ctx: HpkeContext::new(rs, &self.reply_key),
                 ohttp_ctx,
             },
         ))
@@ -191,6 +189,31 @@ impl Sender {
     }
 
     pub fn endpoint(&self) -> &Url { self.v1.endpoint() }
+}
+
+pub(crate) fn extract_request(
+    ohttp_relay: Url,
+    reply_key: HpkeSecretKey,
+    body: Vec<u8>,
+    url: Url,
+    receiver_pubkey: HpkePublicKey,
+    ohttp_keys: &mut OhttpKeys,
+) -> Result<(Request, ClientResponse), CreateRequestError> {
+    use crate::hpke::encrypt_message_a;
+    use crate::ohttp::ohttp_encapsulate;
+    let hpke_ctx = HpkeContext::new(receiver_pubkey, &reply_key);
+    let body = encrypt_message_a(
+        body,
+        &hpke_ctx.reply_pair.public_key().clone(),
+        &hpke_ctx.receiver.clone(),
+    )
+    .map_err(InternalCreateRequestError::Hpke)?;
+
+    let (body, ohttp_ctx) = ohttp_encapsulate(ohttp_keys, "POST", url.as_str(), Some(&body))
+        .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
+    log::debug!("ohttp_relay_url: {:?}", ohttp_relay);
+    let request = Request::new_v2(&ohttp_relay, &body);
+    Ok((request, ohttp_ctx))
 }
 
 pub(crate) fn serialize_v2_body(


### PR DESCRIPTION
The following is an expansion of the BIP77 protocol that allows for
    multiple senders to opt in to a optimisitic merge with other potential
    senders at a cost of an additional round of communication. The protocol
    does not introduce new message types instead it re-uses the existing v2
    structs. Everything touching NS1R is feature gated behind the
    `multi_party` flag.

The remaining work is:
Multi party version of `try_preserving_privacy`. Currently when the
       v2 reciever is assembling a payjoin it calls in the v1
    `try_preserving_privacy` method which invalidates for txs with > 2
    outputs. We would either need to relax this constraint or write a
    bespoke version of `try_preserving_privacy` that optimizes for the
    multiparty case. The latter is more favorable in my opnion.

For more context please take a look at: https://github.com/orgs/payjoin/discussions/411

Outside of this PR we should consider expanding BIP77 to describe the protocol upgrades made in this PR