### PR TITLE
fix: the attribute `version` is obsolete

### DIFF
--- a/payjoin-directory/docker-compose.yml
+++ b/payjoin-directory/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   nginx:
     image: nginx:latest


### PR DESCRIPTION
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion