### PR TITLE
Fix unresumable Sender

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1577,7 +1577,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1577,7 +1577,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -37,7 +37,7 @@ hyper = { version = "1", features = ["http1", "server"], optional = true }
 hyper-rustls = { version = "0.26", optional = true }
 hyper-util = { version = "0.1", optional = true }
 log = "0.4.7"
-payjoin = { version = "0.21.0", features = ["send", "receive", "base64"] }
+payjoin = { version = "0.22.0", features = ["send", "receive", "base64"] }
 rcgen = { version = "0.11.1", optional = true }
 reqwest = { version = "0.12", default-features = false }
 rustls = { version = "0.22.4", optional = true }

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -293,7 +293,7 @@ mod e2e {
                 .stderr(Stdio::inherit())
                 .spawn()
                 .expect("Failed to execute payjoin-cli");
-            let _ = send_until_request_timeout(cli_send_initiator).await;
+            send_until_request_timeout(cli_send_initiator).await?;
 
             let cli_receive_resumer = Command::new(payjoin_cli)
                 .arg("--rpchost")
@@ -309,7 +309,7 @@ mod e2e {
                 .stderr(Stdio::inherit())
                 .spawn()
                 .expect("Failed to execute payjoin-cli");
-            let _ = respond_with_payjoin(cli_receive_resumer).await;
+            respond_with_payjoin(cli_receive_resumer).await?;
 
             let cli_send_resumer = Command::new(payjoin_cli)
                 .arg("--rpchost")
@@ -328,7 +328,7 @@ mod e2e {
                 .stderr(Stdio::inherit())
                 .spawn()
                 .expect("Failed to execute payjoin-cli");
-            let _ = check_payjoin_sent(cli_send_resumer).await;
+            check_payjoin_sent(cli_send_resumer).await?;
             Ok(())
         }
 

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Payjoin Changelog
 
+## 0.22.0
+
+- Propagate Uri Fragment parameter errors to the caller
+- Have `Sender` to persist reply key so resumption listens where a previous sender left off
+
 ## 0.21.0
 
 - Upgrade rustls v0.22.4

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library for the BIP78 Pay to Endpoint protocol."
 repository = "https://github.com/payjoin/rust-payjoin"

--- a/payjoin/src/hpke.rs
+++ b/payjoin/src/hpke.rs
@@ -31,6 +31,11 @@ impl From<HpkeKeyPair> for (HpkeSecretKey, HpkePublicKey) {
 }
 
 impl HpkeKeyPair {
+    pub fn from_secret_key(secret_key: &HpkeSecretKey) -> Self {
+        let public_key = <SecpK256HkdfSha256 as hpke::Kem>::sk_to_pk(&secret_key.0);
+        Self(secret_key.clone(), HpkePublicKey(public_key))
+    }
+
     pub fn gen_keypair() -> Self {
         let (sk, pk) = <SecpK256HkdfSha256 as hpke::Kem>::gen_keypair(&mut OsRng);
         Self(HpkeSecretKey(sk), HpkePublicKey(pk))


### PR DESCRIPTION
The Sender was generating new hpke keys on resume since keygen was being done in `extract_v2`. This caused a problem where when the Sender was persisted, stopped, and resumed, the receiver would have already pushed a response to a different ShortId than the one the Sender would look for it in the resumed state.

By generating a key on Sender creation and persisting that the Sender can produce a consistent HpkeContext every single run.

I am NOT sure why the e2e test did not catch this. I believed its behavior was starting a receiver, stopping it, starting a sender, stopping it, resuiming a receiver, stopping it, and resuming a sender, and stopping it which is where this bug propagated. It didn't fail before this change and I'm not sure why, it should have.