### PR TITLE
Join subdir to base pj URL to preserve path

### DIFF
--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -411,12 +411,12 @@ impl V2GetContext {
         ohttp_relay: Url,
     ) -> Result<(Request, ohttp::ClientResponse), CreateRequestError> {
         use crate::uri::UrlExt;
-        let mut url = self.endpoint.clone();
+        let base_url = self.endpoint.clone();
 
         // TODO unify with receiver's fn subdir_path_from_pubkey
         let hash = sha256::Hash::hash(&self.hpke_ctx.reply_pair.public_key().to_compressed_bytes());
         let subdir: ShortId = hash.into();
-        url.set_path(&subdir.to_string());
+        let url = base_url.join(&subdir.to_string()).map_err(InternalCreateRequestError::Url)?;
         let body = encrypt_message_a(
             Vec::new(),
             &self.hpke_ctx.reply_pair.public_key().clone(),


### PR DESCRIPTION
Fix #416

Without this change a base URL subpath e.g. https://payjo.in/dir-path/ would be overwritten when V2GetContext.extract_req was called and incorrectly produce a request to https://payjo.in/subdir instead of https://payjo.in/dir-path/subdir.

-- 

This was smoke test by setting `let base_url let base_url = self.endpoint.clone().join("gg/")` and ensuring the`let url = base_url.join(&subdir.to_string())
            .map_err(InternalCreateRequestError::Url)?;` preserved the path and resulted in "https://example.com/gg/<subdir>"