### PR TITLE
Bump payjoin-cli 0.1.0

### DIFF
--- a/payjoin-cli/CHANGELOG.md
+++ b/payjoin-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # payjoin-cli Changelog
 
+## 0.1.0
+
+- Bump payjoin to v0.22.0 with stable wire protocol
+  - Allow mixed input scripts in v2 (#367)
+
+- Fix bug to propagate missing `ohttp_keys` config parameter or argument error (#441)
+- Don't pause between long polling requests (#463)
+- Hide danger-local-https feature with _ prefix (#423)
+
+
 ## 0.0.9-alpha
 
 - Make backwards-compatible v2 to v1 sends possible

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin-cli"
-version = "0.0.9-alpha"
+version = "0.1.0"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "A command-line Payjoin client for Bitcoin Core"
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
Summary:

Take the payjoin-cli out of alpha now that the wire protocol is presumed to be stable.

Changelog:

- Bump payjoin to v0.22.0 with stable wire protocol
  - Allow mixed input scripts in v2 (#367)

- Fix bug to propagate missing  config parameter or argument error (#441)
- Don't pause between long polling requests (#463)
- Hide danger-local-https feature with _ prefix (#423)

---

Because we've already made changes to the payjoin crate, this'll have to be released on a branch which I've pushed to https://github.com/payjoin/rust-payjoin/tree/payjoin-cli-0.1.0. But we still need this bump to Cargo.toml and Changelog. Note that this is going to have a different Cargo.lock by necessity on master than it will in the tagged branch.