### PR TITLE
Abstract send feature error variants into separate feature-specific abstractions

### DIFF
--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -434,10 +434,10 @@ mod tests {
             _ => panic!("Expected WellKnown error"),
         };
         let unrecognized_error = r#"{"errorCode":"random", "message":"random"}"#;
-        assert_eq!(
-            ResponseError::parse(unrecognized_error).to_string(),
-            "The receiver sent an unrecognized error."
-        );
+        assert!(matches!(
+            ResponseError::parse(unrecognized_error),
+            ResponseError::Unrecognized { .. }
+        ));
         let invalid_json_error = json!({
             "err": "random",
             "message": "This version of payjoin is not supported."

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -135,13 +135,7 @@ pub(crate) enum InternalValidationError {
     FeeRateBelowMinimum,
     Psbt(bitcoin::psbt::Error),
     #[cfg(feature = "v2")]
-    Hpke(crate::hpke::HpkeError),
-    #[cfg(feature = "v2")]
-    OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
-    #[cfg(feature = "v2")]
-    UnexpectedStatusCode,
-    #[cfg(feature = "v2")]
-    UnexpectedResponseSize(usize),
+    V2Encapsulation(crate::send::v2::EncapsulationError),
 }
 
 impl From<InternalValidationError> for ValidationError {
@@ -190,13 +184,7 @@ impl fmt::Display for ValidationError {
             FeeRateBelowMinimum =>  write!(f, "the fee rate of proposed transaction is below minimum"),
             Psbt(e) => write!(f, "psbt error: {}", e),
             #[cfg(feature = "v2")]
-            Hpke(e) => write!(f, "v2 error: {}", e),
-            #[cfg(feature = "v2")]
-            OhttpEncapsulation(e) => write!(f, "Ohttp encapsulation error: {}", e),
-            #[cfg(feature = "v2")]
-            UnexpectedStatusCode => write!(f, "unexpected status code"),
-            #[cfg(feature = "v2")]
-            UnexpectedResponseSize(size) => write!(f, "unexpected response size {}, expected {} bytes", size, crate::ohttp::ENCAPSULATED_MESSAGE_BYTES),
+            V2Encapsulation(e) => write!(f, "v2 encapsulation error: {}", e),
         }
     }
 }
@@ -237,13 +225,7 @@ impl std::error::Error for ValidationError {
             FeeRateBelowMinimum => None,
             Psbt(error) => Some(error),
             #[cfg(feature = "v2")]
-            Hpke(error) => Some(error),
-            #[cfg(feature = "v2")]
-            OhttpEncapsulation(error) => Some(error),
-            #[cfg(feature = "v2")]
-            UnexpectedStatusCode => None,
-            #[cfg(feature = "v2")]
-            UnexpectedResponseSize(_) => None,
+            V2Encapsulation(e) => Some(e),
         }
     }
 }

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -264,8 +264,6 @@ pub enum ResponseError {
     WellKnown(WellKnownError),
 
     /// Errors caused by malformed responses.
-    ///
-    /// These errors are only displayed in debug logs.
     Validation(ValidationError),
 
     /// `Unrecognized` Errors are NOT defined in the [`BIP78::ReceiverWellKnownError`] spec.
@@ -348,7 +346,7 @@ impl Display for ResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::WellKnown(e) => e.fmt(f),
-            Self::Validation(_) => write!(f, "The receiver sent an invalid response."),
+            Self::Validation(e) => write!(f, "The receiver sent an invalid response: {}", e),
 
             // Do NOT display unrecognized errors to end users, only debug logs
             Self::Unrecognized { .. } => write!(f, "The receiver sent an unrecognized error."),
@@ -444,9 +442,9 @@ mod tests {
             "err": "random",
             "message": "This version of payjoin is not supported."
         });
-        assert_eq!(
-            ResponseError::from_json(invalid_json_error).to_string(),
-            "The receiver sent an invalid response."
-        );
+        assert!(matches!(
+            ResponseError::from_json(invalid_json_error),
+            ResponseError::Validation(_)
+        ));
     }
 }

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -27,24 +27,6 @@ pub mod v2;
 
 type InternalResult<T> = Result<T, InternalProposalError>;
 
-/// Data required to validate the response.
-///
-/// This type is used to process a BIP78 response.
-/// Then call [`Self::process_response`] on it to continue BIP78 flow.
-#[derive(Debug, Clone)]
-pub struct V1Context {
-    psbt_context: PsbtContext,
-}
-
-impl V1Context {
-    pub fn process_response(
-        self,
-        response: &mut impl std::io::Read,
-    ) -> Result<Psbt, ResponseError> {
-        self.psbt_context.process_response(response)
-    }
-}
-
 /// Data required to validate the response against the original PSBT.
 #[derive(Debug, Clone)]
 pub struct PsbtContext {

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -253,3 +253,21 @@ impl Sender {
 
     pub fn endpoint(&self) -> &Url { &self.endpoint }
 }
+
+/// Data required to validate the response.
+///
+/// This type is used to process a BIP78 response.
+/// Then call [`Self::process_response`] on it to continue BIP78 flow.
+#[derive(Debug, Clone)]
+pub struct V1Context {
+    psbt_context: PsbtContext,
+}
+
+impl V1Context {
+    pub fn process_response(
+        self,
+        response: &mut impl std::io::Read,
+    ) -> Result<Psbt, ResponseError> {
+        self.psbt_context.process_response(response)
+    }
+}

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -63,9 +63,7 @@ impl From<ParseReceiverPubkeyParamError> for CreateRequestError {
 
 /// Error returned for v2-specific payload encapsulation errors.
 #[derive(Debug)]
-pub struct EncapsulationError {
-    internal: InternalEncapsulationError,
-}
+pub struct EncapsulationError(InternalEncapsulationError);
 
 #[derive(Debug)]
 pub(crate) enum InternalEncapsulationError {
@@ -83,7 +81,7 @@ impl fmt::Display for EncapsulationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use InternalEncapsulationError::*;
 
-        match &self.internal {
+        match &self.0 {
             InvalidSize(size) => write!(f, "invalid size: {}", size),
             UnexpectedStatusCode(status) => write!(f, "unexpected status code: {}", status),
             Ohttp(error) => write!(f, "OHTTP encapsulation error: {}", error),
@@ -96,7 +94,7 @@ impl std::error::Error for EncapsulationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use InternalEncapsulationError::*;
 
-        match &self.internal {
+        match &self.0 {
             InvalidSize(_) => None,
             UnexpectedStatusCode(_) => None,
             Ohttp(error) => Some(error),
@@ -106,7 +104,7 @@ impl std::error::Error for EncapsulationError {
 }
 
 impl From<InternalEncapsulationError> for EncapsulationError {
-    fn from(value: InternalEncapsulationError) -> Self { EncapsulationError { internal: value } }
+    fn from(value: InternalEncapsulationError) -> Self { EncapsulationError(value) }
 }
 
 impl From<InternalEncapsulationError> for super::ResponseError {

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -302,7 +302,7 @@ impl V2GetContext {
         )
         .map_err(InternalEncapsulationError::Hpke)?;
 
-        let proposal = Psbt::deserialize(&psbt).map_err(InternalValidationError::Psbt)?;
+        let proposal = Psbt::deserialize(&psbt).map_err(InternalProposalError::Psbt)?;
         let processed_proposal = self.psbt_ctx.clone().process_proposal(proposal)?;
         Ok(Some(processed_proposal))
     }

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -324,7 +324,6 @@ impl HpkeContext {
 
 mod test {
     #[test]
-    #[cfg(feature = "v2")]
     fn req_ctx_ser_de_roundtrip() {
         use super::*;
         use crate::send::test::ORIGINAL_PSBT;

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -126,7 +126,7 @@ pub struct Sender {
 
 impl Sender {
     /// Extract serialized V1 Request and Context from a Payjoin Proposal
-    pub fn extract_v1(&self) -> Result<(Request, V1Context), url::ParseError> {
+    pub fn extract_v1(&self) -> Result<(Request, v1::V1Context), url::ParseError> {
         self.v1.extract_v1()
     }
 


### PR DESCRIPTION
This reduces the feature flag coupling toward #392 and works toward #403.

It makes tiers of errors so that ResponseError has clear differences between its WellKnown (should displayable), Validation (may display), and Unknown (MUST NOT display) variants.

It separates v2-specific error definitions into the v2 module. And it isolates ProposalErrors that should only crop up when validating against Proposal PSBT state machine rules. the goal of this is so that we may stabalize and expose some of these error types in a payjoin-1.0 implementation.

I also edited some tests to match against error variants rather than strings. We ought to be able to do this with numerous error variants as they stabilize.

