### PR TITLE
Move v1 response handling to V1Context

### DIFF
--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -57,21 +57,6 @@ macro_rules! ensure {
 }
 
 impl PsbtContext {
-    /// Decodes and validates the response.
-    ///
-    /// Call this method with response from receiver to continue BIP78 flow. If the response is
-    /// valid you will get appropriate PSBT that you should sign and broadcast.
-    #[inline]
-    pub fn process_response(
-        self,
-        response: &mut impl std::io::Read,
-    ) -> Result<Psbt, ResponseError> {
-        let mut res_str = String::new();
-        response.read_to_string(&mut res_str).map_err(InternalValidationError::Io)?;
-        let proposal = Psbt::from_str(&res_str).map_err(|_| ResponseError::parse(&res_str))?;
-        self.process_proposal(proposal).map_err(Into::into)
-    }
-
     fn process_proposal(self, mut proposal: Psbt) -> InternalResult<Psbt> {
         self.basic_checks(&proposal)?;
         self.check_inputs(&proposal)?;
@@ -444,12 +429,11 @@ pub(crate) mod test {
     use bitcoin::FeeRate;
 
     use crate::psbt::PsbtExt;
-    use crate::send::error::{ResponseError, WellKnownError};
 
     pub(crate) const ORIGINAL_PSBT: &str = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
     const PAYJOIN_PROPOSAL: &str = "cHNidP8BAJwCAAAAAo8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////jye60aAl3JgZdaIERvjkeh72VYZuTGH/ps2I4l0IO4MBAAAAAP7///8CJpW4BQAAAAAXqRQd6EnwadJ0FQ46/q6NcutaawlEMIcACT0AAAAAABepFHdAltvPSGdDwi9DR+m0af6+i2d6h9MAAAAAAQEgqBvXBQAAAAAXqRTeTh6QYcpZE1sDWtXm1HmQRUNU0IcBBBYAFMeKRXJTVYKNVlgHTdUmDV/LaYUwIgYDFZrAGqDVh1TEtNi300ntHt/PCzYrT2tVEGcjooWPhRYYSFzWUDEAAIABAACAAAAAgAEAAAAAAAAAAAEBIICEHgAAAAAAF6kUyPLL+cphRyyI5GTUazV0hF2R2NWHAQcXFgAUX4BmVeWSTJIEwtUb5TlPS/ntohABCGsCRzBEAiBnu3tA3yWlT0WBClsXXS9j69Bt+waCs9JcjWtNjtv7VgIge2VYAaBeLPDB6HGFlpqOENXMldsJezF9Gs5amvDQRDQBIQJl1jz1tBt8hNx2owTm+4Du4isx0pmdKNMNIjjaMHFfrQABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUIgICygvBWB5prpfx61y1HDAwo37kYP3YRJBvAjtunBAur3wYSFzWUDEAAIABAACAAAAAgAEAAAABAAAAAAA=";
 
-    fn create_v1_context() -> super::PsbtContext {
+    pub(crate) fn create_psbt_context() -> super::PsbtContext {
         let original_psbt = Psbt::from_str(ORIGINAL_PSBT).unwrap();
         eprintln!("original: {:#?}", original_psbt);
         let payee = original_psbt.unsigned_tx.output[1].script_pubkey.clone();
@@ -467,7 +451,7 @@ pub(crate) mod test {
     fn official_vectors() {
         let original_psbt = Psbt::from_str(ORIGINAL_PSBT).unwrap();
         eprintln!("original: {:#?}", original_psbt);
-        let ctx = create_v1_context();
+        let ctx = create_psbt_context();
         let mut proposal = Psbt::from_str(PAYJOIN_PROPOSAL).unwrap();
         eprintln!("proposal: {:#?}", proposal);
         for output in proposal.outputs_mut() {
@@ -485,7 +469,7 @@ pub(crate) mod test {
     fn test_receiver_steals_sender_change() {
         let original_psbt = Psbt::from_str(ORIGINAL_PSBT).unwrap();
         eprintln!("original: {:#?}", original_psbt);
-        let ctx = create_v1_context();
+        let ctx = create_psbt_context();
         let mut proposal = Psbt::from_str(PAYJOIN_PROPOSAL).unwrap();
         eprintln!("proposal: {:#?}", proposal);
         for output in proposal.outputs_mut() {
@@ -499,30 +483,5 @@ pub(crate) mod test {
         proposal.unsigned_tx.output[0].value -= bitcoin::Amount::from_btc(0.5).unwrap();
         proposal.unsigned_tx.output[1].value += bitcoin::Amount::from_btc(0.5).unwrap();
         ctx.process_proposal(proposal).unwrap();
-    }
-
-    #[test]
-    fn handle_json_errors() {
-        let ctx = create_v1_context();
-        let known_json_error = serde_json::json!({
-            "errorCode": "version-unsupported",
-            "message": "This version of payjoin is not supported."
-        })
-        .to_string();
-        match ctx.process_response(&mut known_json_error.as_bytes()) {
-            Err(ResponseError::WellKnown(WellKnownError::VersionUnsupported { .. })) => (),
-            _ => panic!("Expected WellKnownError"),
-        }
-
-        let ctx = create_v1_context();
-        let invalid_json_error = serde_json::json!({
-            "err": "random",
-            "message": "This version of payjoin is not supported."
-        })
-        .to_string();
-        match ctx.process_response(&mut invalid_json_error.as_bytes()) {
-            Err(ResponseError::Validation(_)) => (),
-            _ => panic!("Expected unrecognized JSON error"),
-        }
     }
 }


### PR DESCRIPTION
The V1-specific error handling was being done in PsbtContext even though the PsbtContext should not know about V1-related json errors.