### PR TITLE
Handle v2 error generic

### DIFF
--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -1,5 +1,5 @@
 use bitcoincore_rpc::jsonrpc::serde_json;
-use payjoin::receive::v2::Receiver;
+use payjoin::receive::v2::{InitialState, Receiver};
 use payjoin::send::v2::Sender;
 use sled::{IVec, Tree};
 use url::Url;
@@ -7,7 +7,7 @@ use url::Url;
 use super::*;
 
 impl Database {
-    pub(crate) fn insert_recv_session(&self, session: Receiver) -> Result<()> {
+    pub(crate) fn insert_recv_session(&self, session: Receiver<InitialState>) -> Result<()> {
         let recv_tree = self.0.open_tree("recv_sessions")?;
         let key = &session.id();
         let value = serde_json::to_string(&session).map_err(Error::Serialize)?;
@@ -16,12 +16,13 @@ impl Database {
         Ok(())
     }
 
-    pub(crate) fn get_recv_sessions(&self) -> Result<Vec<Receiver>> {
+    pub(crate) fn get_recv_sessions(&self) -> Result<Vec<Receiver<InitialState>>> {
         let recv_tree = self.0.open_tree("recv_sessions")?;
         let mut sessions = Vec::new();
         for item in recv_tree.iter() {
             let (_, value) = item?;
-            let session: Receiver = serde_json::from_slice(&value).map_err(Error::Deserialize)?;
+            let session: Receiver<InitialState> =
+                serde_json::from_slice(&value).map_err(Error::Deserialize)?;
             sessions.push(session);
         }
         Ok(sessions)

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -6,7 +6,7 @@ pub enum Error {
     /// To be returned as HTTP 400
     BadRequest(RequestError),
     // To be returned as HTTP 500
-    Server(Box<dyn error::Error>),
+    Server(Box<dyn error::Error + Send + Sync>),
 }
 
 impl Error {

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -9,6 +9,17 @@ pub enum Error {
     Server(Box<dyn error::Error>),
 }
 
+impl Error {
+    pub fn to_json(&self) -> String {
+        match self {
+            Self::BadRequest(e) => e.to_string(),
+            Self::Server(_) =>
+                "{{ \"errorCode\": \"server-error\", \"message\": \"Internal server error\" }}"
+                    .to_string(),
+        }
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -14,6 +14,8 @@ pub(crate) enum InternalSessionError {
     OhttpEncapsulation(OhttpEncapsulationError),
     /// Unexpected response size
     UnexpectedResponseSize(usize),
+    /// Unexpected status code
+    UnexpectedStatusCode(http::StatusCode),
 }
 
 impl fmt::Display for SessionError {
@@ -28,6 +30,8 @@ impl fmt::Display for SessionError {
                 size,
                 crate::ohttp::ENCAPSULATED_MESSAGE_BYTES
             ),
+            InternalSessionError::UnexpectedStatusCode(status) =>
+                write!(f, "Unexpected status code: {}", status),
         }
     }
 }
@@ -38,6 +42,7 @@ impl error::Error for SessionError {
             InternalSessionError::Expired(_) => None,
             InternalSessionError::OhttpEncapsulation(e) => Some(e),
             InternalSessionError::UnexpectedResponseSize(_) => None,
+            InternalSessionError::UnexpectedStatusCode(_) => None,
         }
     }
 }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -176,7 +176,7 @@ mod integration {
 
         use bitcoin::Address;
         use http::StatusCode;
-        use payjoin::receive::v2::{PayjoinProposal, Receiver, UncheckedProposal};
+        use payjoin::receive::v2::{InitialState, PayjoinProposal, Receiver, UncheckedProposal};
         use payjoin::send::v2::SenderBuilder;
         use payjoin::{OhttpKeys, PjUri, UriExt};
         use reqwest::{Client, ClientBuilder, Error, Response};
@@ -841,7 +841,7 @@ mod integration {
             directory: Url,
             ohttp_keys: OhttpKeys,
             custom_expire_after: Option<Duration>,
-        ) -> Receiver {
+        ) -> Receiver<InitialState> {
             let mock_ohttp_relay = directory.clone(); // pass through to directory
             Receiver::new(
                 address,
@@ -854,9 +854,9 @@ mod integration {
 
         fn handle_directory_proposal(
             receiver: &bitcoincore_rpc::Client,
-            proposal: UncheckedProposal,
+            proposal: Receiver<UncheckedProposal>,
             custom_inputs: Option<Vec<InputPair>>,
-        ) -> PayjoinProposal {
+        ) -> Receiver<PayjoinProposal> {
             // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
             let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 


### PR DESCRIPTION
Make the Receiver state machine generic so that it the error handling function can always provide context to an error

Extract JSON OHTTP request to be returned to the directory

This is a Draft because I'm not sure which design is going to make the most sense yet. Sharing my exploration of way to close #468 