### PR TITLE
Handle v2 error

### DIFF
--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -61,7 +61,7 @@ impl From<crate::ohttp::OhttpEncapsulationError> for Error {
 /// This is currently opaque type because we aren't sure which variants will stay.
 /// You can only display it.
 #[derive(Debug)]
-pub struct RequestError(InternalRequestError);
+pub struct RequestError(pub(crate) InternalRequestError);
 
 #[derive(Debug)]
 pub(crate) enum InternalRequestError {

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -6,7 +6,18 @@ pub enum Error {
     /// To be returned as HTTP 400
     BadRequest(RequestError),
     // To be returned as HTTP 500
-    Server(Box<dyn error::Error>),
+    Server(Box<dyn error::Error + Send + Sync>),
+}
+
+impl Error {
+    pub fn to_json(&self) -> String {
+        match self {
+            Self::BadRequest(e) => e.to_string(),
+            Self::Server(_) =>
+                "{{ \"errorCode\": \"server-error\", \"message\": \"Internal server error\" }}"
+                    .to_string(),
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/payjoin/src/receive/v1.rs
+++ b/payjoin/src/receive/v1.rs
@@ -877,7 +877,7 @@ impl PayjoinProposal {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use std::str::FromStr;
 
     use bitcoin::{Address, Network};
@@ -891,7 +891,6 @@ mod test {
     }
 
     impl MockHeaders {
-        #[cfg(test)]
         fn new(length: u64) -> MockHeaders { MockHeaders { length: length.to_string() } }
     }
 
@@ -905,7 +904,7 @@ mod test {
         }
     }
 
-    fn proposal_from_test_vector() -> Result<UncheckedProposal, RequestError> {
+    pub fn proposal_from_test_vector() -> Result<UncheckedProposal, RequestError> {
         // OriginalPSBT Test Vector from BIP
         // | InputScriptType | Orginal PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|
         // |-----------------|-----------------------|------------------------------|-------------------------|

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -14,6 +14,8 @@ pub(crate) enum InternalSessionError {
     OhttpEncapsulation(OhttpEncapsulationError),
     /// Unexpected response size
     UnexpectedResponseSize(usize),
+    /// Unexpected status code
+    UnexpectedStatusCode(http::StatusCode),
 }
 
 impl fmt::Display for SessionError {
@@ -28,6 +30,8 @@ impl fmt::Display for SessionError {
                 size,
                 crate::ohttp::ENCAPSULATED_MESSAGE_BYTES
             ),
+            InternalSessionError::UnexpectedStatusCode(status) =>
+                write!(f, "Unexpected status code: {}", status),
         }
     }
 }
@@ -38,6 +42,7 @@ impl error::Error for SessionError {
             InternalSessionError::Expired(_) => None,
             InternalSessionError::OhttpEncapsulation(e) => Some(e),
             InternalSessionError::UnexpectedResponseSize(_) => None,
+            InternalSessionError::UnexpectedStatusCode(_) => None,
         }
     }
 }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -613,7 +613,6 @@ mod test {
     });
 
     #[test]
-    #[cfg(feature = "v2")]
     fn receiver_ser_de_roundtrip() {
         let session = Receiver { context: SHARED_CONTEXT.clone() };
         let serialized = serde_json::to_string(&session).unwrap();


### PR DESCRIPTION
Fix #468 with a simple approach: Just add the methods to UncheckedProposal which can be cloned at the beginning of the receive process.

This seems to be is the least invasive way to make this change that I didn't even think of in my enumerated approaches in #468.

Alternatively, we could have some way to extract an ErrorContext from which an Error (request,context) could be extracted from an `ErrorContext::extract_req(e: Error) -> (Request, ohttp_ctx)`

But I think this gets us the progress we want and we can follow up if we decide that's a good idea with the rest of the receiver module error split.

