### PR TITLE
Avoid stringly typed arguments in payjoin-cli App trait

### DIFF
--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -7,6 +7,7 @@ use bitcoin::TxIn;
 use bitcoincore_rpc::bitcoin::Amount;
 use bitcoincore_rpc::RpcApi;
 use payjoin::bitcoin::psbt::Psbt;
+use payjoin::bitcoin::FeeRate;
 use payjoin::receive::InputPair;
 use payjoin::{bitcoin, PjUri};
 
@@ -27,18 +28,15 @@ pub trait App {
     where
         Self: Sized;
     fn bitcoind(&self) -> Result<bitcoincore_rpc::Client>;
-    async fn send_payjoin(&self, bip21: &str, fee_rate: &f32) -> Result<()>;
+    async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()>;
     async fn receive_payjoin(self, amount_arg: &str) -> Result<()>;
 
-    fn create_original_psbt(&self, uri: &PjUri, fee_rate: &f32) -> Result<Psbt> {
+    fn create_original_psbt(&self, uri: &PjUri, fee_rate: FeeRate) -> Result<Psbt> {
         let amount = uri.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;
 
         // wallet_create_funded_psbt requires a HashMap<address: String, Amount>
         let mut outputs = HashMap::with_capacity(1);
         outputs.insert(uri.address.to_string(), amount);
-        let fee_rate_sat_per_kwu = fee_rate * 250.0_f32;
-        let fee_rate: bitcoin::FeeRate =
-            bitcoin::FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64);
         let fee_sat_per_kvb =
             fee_rate.to_sat_per_kwu().checked_mul(4).ok_or(anyhow!("Invalid fee rate"))?;
         let fee_per_kvb = Amount::from_sat(fee_sat_per_kvb);

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -29,7 +29,7 @@ pub trait App {
         Self: Sized;
     fn bitcoind(&self) -> Result<bitcoincore_rpc::Client>;
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()>;
-    async fn receive_payjoin(self, amount_arg: &str) -> Result<()>;
+    async fn receive_payjoin(self, amount: Amount) -> Result<()>;
 
     fn create_original_psbt(&self, uri: &PjUri, fee_rate: FeeRate) -> Result<Psbt> {
         let amount = uri.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -107,8 +107,8 @@ impl AppTrait for App {
         Ok(())
     }
 
-    async fn receive_payjoin(self, amount_arg: &str) -> Result<()> {
-        let pj_uri_string = self.construct_payjoin_uri(amount_arg, None)?;
+    async fn receive_payjoin(self, amount: Amount) -> Result<()> {
+        let pj_uri_string = self.construct_payjoin_uri(amount, None)?;
         println!(
             "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
             self.config.port
@@ -123,11 +123,10 @@ impl AppTrait for App {
 impl App {
     fn construct_payjoin_uri(
         &self,
-        amount_arg: &str,
+        amount: Amount,
         fallback_target: Option<&str>,
     ) -> Result<String> {
         let pj_receiver_address = self.bitcoind()?.get_new_address(None, None)?.assume_checked();
-        let amount = Amount::from_sat(amount_arg.parse()?);
         let pj_part = match fallback_target {
             Some(target) => target,
             None => self.config.pj_endpoint.as_str(),

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -68,14 +68,12 @@ impl AppTrait for App {
         .with_context(|| "Failed to connect to bitcoind")
     }
 
-    async fn send_payjoin(&self, bip21: &str, fee_rate: &f32) -> Result<()> {
+    async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         let uri =
             Uri::try_from(bip21).map_err(|e| anyhow!("Failed to create URI from BIP21: {}", e))?;
         let uri = uri.assume_checked();
         let uri = uri.check_pj_supported().map_err(|_| anyhow!("URI does not support Payjoin"))?;
         let psbt = self.create_original_psbt(&uri, fee_rate)?;
-        let fee_rate_sat_per_kwu = fee_rate * 250.0_f32;
-        let fee_rate = FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64);
         let (req, ctx) = SenderBuilder::new(psbt, uri.clone())
             .build_recommended(fee_rate)
             .with_context(|| "Failed to build payjoin request")?

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -54,7 +54,7 @@ impl AppTrait for App {
         .with_context(|| "Failed to connect to bitcoind")
     }
 
-    async fn send_payjoin(&self, bip21: &str, fee_rate: &f32) -> Result<()> {
+    async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         use payjoin::UriExt;
         let uri =
             Uri::try_from(bip21).map_err(|e| anyhow!("Failed to create URI from BIP21: {}", e))?;
@@ -66,8 +66,6 @@ impl AppTrait for App {
             Some(send_session) => send_session,
             None => {
                 let psbt = self.create_original_psbt(&uri, fee_rate)?;
-                let fee_rate_sat_per_kwu = fee_rate * 250.0_f32;
-                let fee_rate = FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64);
                 let mut req_ctx = SenderBuilder::new(psbt, uri.clone())
                     .build_recommended(fee_rate)
                     .with_context(|| "Failed to build payjoin request")?;

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -76,9 +76,8 @@ impl AppTrait for App {
         self.spawn_payjoin_sender(req_ctx).await
     }
 
-    async fn receive_payjoin(self, amount_arg: &str) -> Result<()> {
+    async fn receive_payjoin(self, amount: Amount) -> Result<()> {
         let address = self.bitcoind()?.get_new_address(None, None)?.assume_checked();
-        let amount = Amount::from_sat(amount_arg.parse()?);
         let ohttp_keys = unwrap_ohttp_keys_or_else_fetch(&self.config).await?;
         let session = Receiver::new(
             address,


### PR DESCRIPTION
Minor standalone changes from ongoing refactoring work. A more comprehensive approach might be to allow explicit units to be parsed from the string form of these arguments (see also rust-bitcoin/rust-bitcoin#1786) but personally I think that's undesirable since it complicates payjoin-cli, and as a reference implementation it should prioritize readability and simplicity over convenience/flexibility of the CLI.