### PR TITLE
Separate receive::{v1,v2} error modules

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -224,7 +224,7 @@ impl App {
                 .handle_payjoin_post(req)
                 .await
                 .map_err(|e| match e {
-                    Error::BadRequest(e) => {
+                    Error::Validation(e) => {
                         log::error!("Error handling request: {}", e);
                         Response::builder().status(400).body(full(e.to_string())).unwrap()
                     }
@@ -248,9 +248,9 @@ impl App {
     ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error> {
         let address = self
             .bitcoind()
-            .map_err(|e| Error::Server(e.into()))?
+            .map_err(|e| Error::Implementation(e.into()))?
             .get_new_address(None, None)
-            .map_err(|e| Error::Server(e.into()))?
+            .map_err(|e| Error::Implementation(e.into()))?
             .assume_checked();
         let uri_string = if let Some(amount) = amount {
             format!(
@@ -263,7 +263,7 @@ impl App {
             format!("{}?pj={}", address.to_qr_uri(), self.config.pj_endpoint)
         };
         let uri = Uri::try_from(uri_string.clone())
-            .map_err(|_| Error::Server(anyhow!("Could not parse payjoin URI string.").into()))?;
+            .map_err(|_| Error::Implementation(anyhow!("Could not parse payjoin URI string.").into()))?;
         let _ = uri.assume_checked(); // we just got it from bitcoind above
 
         Ok(Response::new(full(uri_string)))
@@ -276,7 +276,8 @@ impl App {
         let (parts, body) = req.into_parts();
         let headers = Headers(&parts.headers);
         let query_string = parts.uri.query().unwrap_or("");
-        let body = body.collect().await.map_err(|e| Error::Server(e.into()))?.aggregate().reader();
+        let body =
+            body.collect().await.map_err(|e| Error::Implementation(e.into()))?.aggregate().reader();
         let proposal = UncheckedProposal::from_request(body, query_string, headers)?;
 
         let payjoin_proposal = self.process_v1_proposal(proposal)?;
@@ -290,22 +291,22 @@ impl App {
     }
 
     fn process_v1_proposal(&self, proposal: UncheckedProposal) -> Result<PayjoinProposal, Error> {
-        let bitcoind = self.bitcoind().map_err(|e| Error::Server(e.into()))?;
+        let bitcoind = self.bitcoind().map_err(|e| Error::Implementation(e.into()))?;
 
         // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network = bitcoind.get_blockchain_info().map_err(|e| Error::Server(e.into()))?.chain;
+        let network = bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
 
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
             let mempool_results =
-                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Error::Server(e.into()))?;
+                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Error::Implementation(e.into()))?;
             match mempool_results.first() {
                 Some(result) => Ok(result.allowed),
-                None => Err(Error::Server(
+                None => Err(Error::Implementation(
                     anyhow!("No mempool results returned on broadcast check").into(),
                 )),
             }
@@ -318,7 +319,7 @@ impl App {
                 bitcoind
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Error::Server(e.into()))
+                    .map_err(|e| Error::Implementation(e.into()))
             } else {
                 Ok(false)
             }
@@ -327,7 +328,7 @@ impl App {
 
         // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
         let payjoin = proposal.check_no_inputs_seen_before(|input| {
-            self.db.insert_input_seen_before(*input).map_err(|e| Error::Server(e.into()))
+            self.db.insert_input_seen_before(*input).map_err(|e| Error::Implementation(e.into()))
         })?;
         log::trace!("check3");
 
@@ -336,7 +337,7 @@ impl App {
                 bitcoind
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Error::Server(e.into()))
+                    .map_err(|e| Error::Implementation(e.into()))
             } else {
                 Ok(false)
             }
@@ -346,12 +347,12 @@ impl App {
             .substitute_receiver_script(
                 &bitcoind
                     .get_new_address(None, None)
-                    .map_err(|e| Error::Server(e.into()))?
+                    .map_err(|e| Error::Implementation(e.into()))?
                     .require_network(network)
-                    .map_err(|e| Error::Server(e.into()))?
+                    .map_err(|e| Error::Implementation(e.into()))?
                     .script_pubkey(),
             )
-            .map_err(|e| Error::Server(e.into()))?
+            .map_err(|e| Error::Implementation(e.into()))?
             .commit_outputs();
 
         let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &bitcoind)
@@ -364,12 +365,12 @@ impl App {
             |psbt: &Psbt| {
                 bitcoind
                     .wallet_process_psbt(&psbt.to_string(), None, None, Some(false))
-                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Error::Server(e.into())))
-                    .map_err(|e| Error::Server(e.into()))?
+                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into())))
+                    .map_err(|e| Error::Implementation(e.into()))?
             },
             Some(bitcoin::FeeRate::MIN),
             self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
-                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Server("Invalid fee rate".into()))
+                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Implementation("Invalid fee rate".into()))
             })?,
         )?;
         Ok(payjoin_proposal)

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -16,8 +16,9 @@ use hyper_util::rt::TokioIo;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::{self, FeeRate};
 use payjoin::receive::v1::{PayjoinProposal, UncheckedProposal};
+use payjoin::receive::Error;
 use payjoin::send::v1::SenderBuilder;
-use payjoin::{Error, Uri, UriExt};
+use payjoin::{Uri, UriExt};
 use tokio::net::TcpListener;
 
 use super::config::AppConfig;

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -262,8 +262,9 @@ impl App {
         } else {
             format!("{}?pj={}", address.to_qr_uri(), self.config.pj_endpoint)
         };
-        let uri = Uri::try_from(uri_string.clone())
-            .map_err(|_| Error::Implementation(anyhow!("Could not parse payjoin URI string.").into()))?;
+        let uri = Uri::try_from(uri_string.clone()).map_err(|_| {
+            Error::Implementation(anyhow!("Could not parse payjoin URI string.").into())
+        })?;
         let _ = uri.assume_checked(); // we just got it from bitcoind above
 
         Ok(Response::new(full(uri_string)))
@@ -297,13 +298,15 @@ impl App {
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network = bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
+        let network =
+            bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
 
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
-            let mempool_results =
-                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Error::Implementation(e.into()))?;
+            let mempool_results = bitcoind
+                .test_mempool_accept(&[raw_tx])
+                .map_err(|e| Error::Implementation(e.into()))?;
             match mempool_results.first() {
                 Some(result) => Ok(result.allowed),
                 None => Err(Error::Implementation(
@@ -365,12 +368,15 @@ impl App {
             |psbt: &Psbt| {
                 bitcoind
                     .wallet_process_psbt(&psbt.to_string(), None, None, Some(false))
-                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into())))
+                    .map(|res| {
+                        Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into()))
+                    })
                     .map_err(|e| Error::Implementation(e.into()))?
             },
             Some(bitcoin::FeeRate::MIN),
             self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
-                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Implementation("Invalid fee rate".into()))
+                FeeRate::from_sat_per_vb(fee_rate)
+                    .ok_or(Error::Implementation("Invalid fee rate".into()))
             })?,
         )?;
         Ok(payjoin_proposal)

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -7,8 +7,9 @@ use payjoin::bitcoin::consensus::encode::serialize_hex;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::{Amount, FeeRate};
 use payjoin::receive::v2::{Receiver, UncheckedProposal};
+use payjoin::receive::Error;
 use payjoin::send::v2::{Sender, SenderBuilder};
-use payjoin::{bitcoin, Error, Uri};
+use payjoin::{bitcoin, Uri};
 use tokio::signal;
 use tokio::sync::watch;
 

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -257,12 +257,14 @@ impl App {
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network = bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
+        let network =
+            bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
-            let mempool_results =
-                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Error::Implementation(e.into()))?;
+            let mempool_results = bitcoind
+                .test_mempool_accept(&[raw_tx])
+                .map_err(|e| Error::Implementation(e.into()))?;
             match mempool_results.first() {
                 Some(result) => Ok(result.allowed),
                 None => Err(Error::Implementation(
@@ -314,12 +316,15 @@ impl App {
             |psbt: &Psbt| {
                 bitcoind
                     .wallet_process_psbt(&psbt.to_string(), None, None, Some(false))
-                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into())))
+                    .map(|res| {
+                        Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into()))
+                    })
                     .map_err(|e| Error::Implementation(e.into()))?
             },
             Some(bitcoin::FeeRate::MIN),
             self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
-                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Implementation("Invalid fee rate".into()))
+                FeeRate::from_sat_per_vb(fee_rate)
+                    .ok_or(Error::Implementation("Invalid fee rate".into()))
             })?,
         )?;
         let payjoin_proposal_psbt = payjoin_proposal.psbt();

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -251,21 +251,21 @@ impl App {
         &self,
         proposal: payjoin::receive::v2::UncheckedProposal,
     ) -> Result<payjoin::receive::v2::PayjoinProposal, Error> {
-        let bitcoind = self.bitcoind().map_err(|e| Error::Server(e.into()))?;
+        let bitcoind = self.bitcoind().map_err(|e| Error::Implementation(e.into()))?;
 
         // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network = bitcoind.get_blockchain_info().map_err(|e| Error::Server(e.into()))?.chain;
+        let network = bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
             let mempool_results =
-                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Error::Server(e.into()))?;
+                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Error::Implementation(e.into()))?;
             match mempool_results.first() {
                 Some(result) => Ok(result.allowed),
-                None => Err(Error::Server(
+                None => Err(Error::Implementation(
                     anyhow!("No mempool results returned on broadcast check").into(),
                 )),
             }
@@ -278,7 +278,7 @@ impl App {
                 bitcoind
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Error::Server(e.into()))
+                    .map_err(|e| Error::Implementation(e.into()))
             } else {
                 Ok(false)
             }
@@ -287,7 +287,7 @@ impl App {
 
         // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
         let payjoin = proposal.check_no_inputs_seen_before(|input| {
-            self.db.insert_input_seen_before(*input).map_err(|e| Error::Server(e.into()))
+            self.db.insert_input_seen_before(*input).map_err(|e| Error::Implementation(e.into()))
         })?;
         log::trace!("check3");
 
@@ -297,7 +297,7 @@ impl App {
                     bitcoind
                         .get_address_info(&address)
                         .map(|info| info.is_mine.unwrap_or(false))
-                        .map_err(|e| Error::Server(e.into()))
+                        .map_err(|e| Error::Implementation(e.into()))
                 } else {
                     Ok(false)
                 }
@@ -314,12 +314,12 @@ impl App {
             |psbt: &Psbt| {
                 bitcoind
                     .wallet_process_psbt(&psbt.to_string(), None, None, Some(false))
-                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Error::Server(e.into())))
-                    .map_err(|e| Error::Server(e.into()))?
+                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into())))
+                    .map_err(|e| Error::Implementation(e.into()))?
             },
             Some(bitcoin::FeeRate::MIN),
             self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
-                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Server("Invalid fee rate".into()))
+                FeeRate::from_sat_per_vb(fee_rate).ok_or(Error::Implementation("Invalid fee rate".into()))
             })?,
         )?;
         let payjoin_proposal_psbt = payjoin_proposal.psbt();

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -21,8 +21,6 @@ pub extern crate bitcoin;
 
 #[cfg(feature = "receive")]
 pub mod receive;
-#[cfg(feature = "receive")]
-pub use crate::receive::Error;
 
 #[cfg(feature = "send")]
 pub mod send;

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -75,7 +75,7 @@ pub enum ValidationError {
     V1(v1::RequestError),
     /// Protocol-specific errors for BIP-77 v2 sessions (e.g. session management, OHTTP, HPKE encryption)
     #[cfg(feature = "v2")]
-    V2(v2::RequestError),
+    V2(v2::SessionError),
 }
 
 impl From<InternalPayloadError> for ValidationError {
@@ -87,8 +87,8 @@ impl From<v1::InternalRequestError> for ValidationError {
 }
 
 #[cfg(feature = "v2")]
-impl From<v2::InternalRequestError> for ValidationError {
-    fn from(e: v2::InternalRequestError) -> Self { ValidationError::V2(e.into()) }
+impl From<v2::InternalSessionError> for ValidationError {
+    fn from(e: v2::InternalSessionError) -> Self { ValidationError::V2(e.into()) }
 }
 
 impl fmt::Display for ValidationError {

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -1,5 +1,8 @@
-use std::error;
-use std::fmt::{self, Display};
+use std::{error, fmt};
+
+use crate::receive::v1;
+#[cfg(feature = "v2")]
+use crate::receive::v2;
 
 /// The top-level error type for the payjoin receiver, representing all possible failures that can occur
 /// during the processing of a payjoin request.
@@ -14,7 +17,7 @@ pub enum Error {
     /// Error arising from the payjoin state machine
     ///
     /// e.g. PSBT validation, HTTP request validation, protocol version checks
-    Validation(RequestError),
+    Validation(ValidationError),
     /// Error arising due to the specific receiver implementation
     ///
     /// e.g. database errors, network failures, wallet errors
@@ -26,8 +29,7 @@ impl Error {
         match self {
             Self::Validation(e) => e.to_string(),
             Self::Implementation(_) =>
-                "{{ \"errorCode\": \"unavailable\", \"message\": \"Receiver error\" }}"
-                    .to_string(),
+                "{{ \"errorCode\": \"unavailable\", \"message\": \"Receiver error\" }}".to_string(),
         }
     }
 }
@@ -44,46 +46,82 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &self {
-            Self::Validation(_) => None,
+            Self::Validation(e) => e.source(),
             Self::Implementation(e) => Some(e.as_ref()),
         }
     }
 }
 
-impl From<RequestError> for Error {
-    fn from(e: RequestError) -> Self { Error::Validation(e) }
+impl From<InternalPayloadError> for Error {
+    fn from(e: InternalPayloadError) -> Self {
+        Error::Validation(ValidationError::Payload(e.into()))
+    }
 }
 
-impl From<InternalRequestError> for Error {
-    fn from(e: InternalRequestError) -> Self { Error::Validation(e.into()) }
+impl From<v1::InternalRequestError> for Error {
+    fn from(e: v1::InternalRequestError) -> Self { Error::Validation(e.into()) }
 }
 
-#[cfg(feature = "v2")]
-impl From<crate::hpke::HpkeError> for Error {
-    fn from(e: crate::hpke::HpkeError) -> Self { Error::Implementation(Box::new(e)) }
-}
-
-#[cfg(feature = "v2")]
-impl From<crate::ohttp::OhttpEncapsulationError> for Error {
-    fn from(e: crate::ohttp::OhttpEncapsulationError) -> Self { Error::Implementation(Box::new(e)) }
-}
-
-/// Error that may occur when the request from sender is malformed.
+/// An error that occurs during validation of a payjoin request, encompassing all possible validation
+/// failures across different protocol versions and stages.
 ///
-/// This is currently opaque type because we aren't sure which variants will stay.
-/// You can only display it.
+/// This abstraction serves as the primary error type for the validation phase of request processing,
+/// allowing uniform error handling while maintaining protocol version specifics internally.
 #[derive(Debug)]
-pub struct RequestError(pub(crate) InternalRequestError);
+pub enum ValidationError {
+    /// Error arising from validation of the original PSBT payload
+    Payload(PayloadError),
+    /// Protocol-specific errors for BIP-78 v1 requests (e.g. HTTP request validation, parameter checks)
+    V1(v1::RequestError),
+    /// Protocol-specific errors for BIP-77 v2 sessions (e.g. session management, OHTTP, HPKE encryption)
+    #[cfg(feature = "v2")]
+    V2(v2::RequestError),
+}
+
+impl From<InternalPayloadError> for ValidationError {
+    fn from(e: InternalPayloadError) -> Self { ValidationError::Payload(e.into()) }
+}
+
+impl From<v1::InternalRequestError> for ValidationError {
+    fn from(e: v1::InternalRequestError) -> Self { ValidationError::V1(e.into()) }
+}
+
+#[cfg(feature = "v2")]
+impl From<v2::InternalRequestError> for ValidationError {
+    fn from(e: v2::InternalRequestError) -> Self { ValidationError::V2(e.into()) }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ValidationError::Payload(e) => write!(f, "{}", e),
+            ValidationError::V1(e) => write!(f, "{}", e),
+            #[cfg(feature = "v2")]
+            ValidationError::V2(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ValidationError::Payload(e) => Some(e),
+            ValidationError::V1(e) => Some(e),
+            #[cfg(feature = "v2")]
+            ValidationError::V2(e) => Some(e),
+        }
+    }
+}
 
 #[derive(Debug)]
-pub(crate) enum InternalRequestError {
-    Psbt(bitcoin::psbt::Error),
-    Base64(bitcoin::base64::DecodeError),
-    Io(std::io::Error),
-    MissingHeader(&'static str),
-    InvalidContentType(String),
-    InvalidContentLength(std::num::ParseIntError),
-    ContentLengthTooLarge(u64),
+pub struct PayloadError(pub(crate) InternalPayloadError);
+
+impl From<InternalPayloadError> for PayloadError {
+    fn from(value: InternalPayloadError) -> Self { PayloadError(value) }
+}
+
+#[derive(Debug)]
+pub(crate) enum InternalPayloadError {
     SenderParams(super::optional_parameters::Error),
     /// The raw PSBT fails bip78-specific validation.
     InconsistentPsbt(crate::psbt::InconsistentPsbt),
@@ -102,11 +140,6 @@ pub(crate) enum InternalRequestError {
     /// Original PSBT input has been seen before. Only automatic receivers, aka "interactive" in the spec
     /// look out for these to prevent probing attacks.
     InputSeen(bitcoin::OutPoint),
-    /// Serde deserialization failed
-    #[cfg(feature = "v2")]
-    ParsePsbt(bitcoin::psbt::PsbtParseError),
-    #[cfg(feature = "v2")]
-    Utf8(std::string::FromUtf8Error),
     /// Original PSBT fee rate is below minimum fee rate set by the receiver.
     ///
     /// First argument is the calculated fee rate of the original PSBT.
@@ -117,35 +150,20 @@ pub(crate) enum InternalRequestError {
     FeeTooHigh(bitcoin::FeeRate, bitcoin::FeeRate),
 }
 
-impl From<InternalRequestError> for RequestError {
-    fn from(value: InternalRequestError) -> Self { RequestError(value) }
-}
-
-impl fmt::Display for RequestError {
+impl fmt::Display for PayloadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn write_error(f: &mut fmt::Formatter, code: &str, message: impl Display) -> fmt::Result {
+        use InternalPayloadError::*;
+
+        fn write_error(
+            f: &mut fmt::Formatter,
+            code: &str,
+            message: impl fmt::Display,
+        ) -> fmt::Result {
             write!(f, r#"{{ "errorCode": "{}", "message": "{}" }}"#, code, message)
         }
 
         match &self.0 {
-            InternalRequestError::Psbt(e) => write_error(f, "psbt-error", e),
-            InternalRequestError::Base64(e) => write_error(f, "base64-decode-error", e),
-            InternalRequestError::Io(e) => write_error(f, "io-error", e),
-            InternalRequestError::MissingHeader(header) =>
-                write_error(f, "missing-header", format!("Missing header: {}", header)),
-            InternalRequestError::InvalidContentType(content_type) => write_error(
-                f,
-                "invalid-content-type",
-                format!("Invalid content type: {}", content_type),
-            ),
-            InternalRequestError::InvalidContentLength(e) =>
-                write_error(f, "invalid-content-length", e),
-            InternalRequestError::ContentLengthTooLarge(length) => write_error(
-                f,
-                "content-length-too-large",
-                format!("Content length too large: {}.", length),
-            ),
-            InternalRequestError::SenderParams(e) => match e {
+            SenderParams(e) => match e {
                 super::optional_parameters::Error::UnknownVersion { supported_versions } => {
                     write!(
                         f,
@@ -159,31 +177,22 @@ impl fmt::Display for RequestError {
                 }
                 _ => write_error(f, "sender-params-error", e),
             },
-            InternalRequestError::InconsistentPsbt(e) =>
-                write_error(f, "original-psbt-rejected", e),
-            InternalRequestError::PrevTxOut(e) =>
+            InconsistentPsbt(e) => write_error(f, "original-psbt-rejected", e),
+            PrevTxOut(e) =>
                 write_error(f, "original-psbt-rejected", format!("PrevTxOut Error: {}", e)),
-            InternalRequestError::MissingPayment =>
-                write_error(f, "original-psbt-rejected", "Missing payment."),
-            InternalRequestError::OriginalPsbtNotBroadcastable => write_error(
+            MissingPayment => write_error(f, "original-psbt-rejected", "Missing payment."),
+            OriginalPsbtNotBroadcastable => write_error(
                 f,
                 "original-psbt-rejected",
                 "Can't broadcast. PSBT rejected by mempool.",
             ),
-            InternalRequestError::InputOwned(_) =>
+            InputOwned(_) =>
                 write_error(f, "original-psbt-rejected", "The receiver rejected the original PSBT."),
-            InternalRequestError::InputWeight(e) =>
+            InputWeight(e) =>
                 write_error(f, "original-psbt-rejected", format!("InputWeight Error: {}", e)),
-            InternalRequestError::InputSeen(_) =>
+            InputSeen(_) =>
                 write_error(f, "original-psbt-rejected", "The receiver rejected the original PSBT."),
-            #[cfg(feature = "v2")]
-            InternalRequestError::ParsePsbt(e) => write_error(f, "Error parsing PSBT:", e),
-            #[cfg(feature = "v2")]
-            InternalRequestError::Utf8(e) => write_error(f, "Error parsing PSBT:", e),
-            InternalRequestError::PsbtBelowFeeRate(
-                original_psbt_fee_rate,
-                receiver_min_fee_rate,
-            ) => write_error(
+            PsbtBelowFeeRate(original_psbt_fee_rate, receiver_min_fee_rate) => write_error(
                 f,
                 "original-psbt-rejected",
                 format!(
@@ -191,7 +200,7 @@ impl fmt::Display for RequestError {
                     original_psbt_fee_rate, receiver_min_fee_rate
                 ),
             ),
-            InternalRequestError::FeeTooHigh(proposed_feerate, max_feerate) => write_error(
+            FeeTooHigh(proposed_feerate, max_feerate) => write_error(
                 f,
                 "original-psbt-rejected",
                 format!(
@@ -203,22 +212,16 @@ impl fmt::Display for RequestError {
     }
 }
 
-impl std::error::Error for RequestError {
+impl std::error::Error for PayloadError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use InternalPayloadError::*;
         match &self.0 {
-            InternalRequestError::Psbt(e) => Some(e),
-            InternalRequestError::Base64(e) => Some(e),
-            InternalRequestError::Io(e) => Some(e),
-            InternalRequestError::InvalidContentLength(e) => Some(e),
-            InternalRequestError::SenderParams(e) => Some(e),
-            InternalRequestError::InconsistentPsbt(e) => Some(e),
-            InternalRequestError::PrevTxOut(e) => Some(e),
-            InternalRequestError::InputWeight(e) => Some(e),
-            #[cfg(feature = "v2")]
-            InternalRequestError::ParsePsbt(e) => Some(e),
-            #[cfg(feature = "v2")]
-            InternalRequestError::Utf8(e) => Some(e),
-            InternalRequestError::PsbtBelowFeeRate(_, _) => None,
+            SenderParams(e) => Some(e),
+            InconsistentPsbt(e) => Some(e),
+            PrevTxOut(e) => Some(e),
+            InputWeight(e) => Some(e),
+            PsbtBelowFeeRate(_, _) => None,
+            FeeTooHigh(_, _) => None,
             _ => None,
         }
     }

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -244,7 +244,10 @@ impl std::error::Error for PayloadError {
             InputWeight(e) => Some(e),
             PsbtBelowFeeRate(_, _) => None,
             FeeTooHigh(_, _) => None,
-            _ => None,
+            MissingPayment => None,
+            OriginalPsbtNotBroadcastable => None,
+            InputOwned(_) => None,
+            InputSeen(_) => None,
         }
     }
 }

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -1,13 +1,12 @@
 use bitcoin::{psbt, AddressType, TxIn, TxOut};
-pub use error::{
-    Error, InputContributionError, OutputSubstitutionError, RequestError, SelectionError,
-};
+pub(crate) use error::InternalPayloadError;
+pub use error::{Error, OutputSubstitutionError, PayloadError, SelectionError};
 
 pub use crate::psbt::PsbtInputError;
 use crate::psbt::{InternalInputPair, InternalPsbtInputError};
 
 mod error;
-mod optional_parameters;
+pub(crate) mod optional_parameters;
 pub mod v1;
 #[cfg(feature = "v2")]
 pub mod v2;

--- a/payjoin/src/receive/v1/error.rs
+++ b/payjoin/src/receive/v1/error.rs
@@ -18,8 +18,6 @@ pub struct RequestError(InternalRequestError);
 pub(crate) enum InternalRequestError {
     /// Error parsing or validating the PSBT
     Psbt(bitcoin::psbt::Error),
-    /// Error decoding the base64 encoded PSBT
-    Base64(bitcoin::base64::DecodeError),
     /// I/O error while reading the request body
     Io(std::io::Error),
     /// A required HTTP header is missing from the request
@@ -48,7 +46,6 @@ impl fmt::Display for RequestError {
 
         match &self.0 {
             InternalRequestError::Psbt(e) => write_error(f, "psbt-error", e),
-            InternalRequestError::Base64(e) => write_error(f, "base64-decode-error", e),
             InternalRequestError::Io(e) => write_error(f, "io-error", e),
             InternalRequestError::MissingHeader(header) =>
                 write_error(f, "missing-header", format!("Missing header: {}", header)),
@@ -72,7 +69,6 @@ impl error::Error for RequestError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &self.0 {
             InternalRequestError::Psbt(e) => Some(e),
-            InternalRequestError::Base64(e) => Some(e),
             InternalRequestError::Io(e) => Some(e),
             InternalRequestError::InvalidContentLength(e) => Some(e),
             _ => None,

--- a/payjoin/src/receive/v1/error.rs
+++ b/payjoin/src/receive/v1/error.rs
@@ -1,0 +1,81 @@
+use core::fmt;
+use std::error;
+
+/// Error that occurs during validation of an incoming v1 payjoin request.
+///
+/// This type provides a stable public API for v1 request validation errors while keeping internal
+/// error variants private. It handles validation of:
+/// - PSBT parsing and validation
+/// - I/O operations during request processing
+/// - HTTP headers (Content-Type, Content-Length)
+///
+/// The error messages are formatted as JSON strings according to the BIP-78 spec with appropriate
+/// error codes and human-readable messages.
+#[derive(Debug)]
+pub struct RequestError(InternalRequestError);
+
+#[derive(Debug)]
+pub(crate) enum InternalRequestError {
+    /// Error parsing or validating the PSBT
+    Psbt(bitcoin::psbt::Error),
+    /// Error decoding the base64 encoded PSBT
+    Base64(bitcoin::base64::DecodeError),
+    /// I/O error while reading the request body
+    Io(std::io::Error),
+    /// A required HTTP header is missing from the request
+    MissingHeader(&'static str),
+    /// The Content-Type header has an invalid value
+    InvalidContentType(String),
+    /// The Content-Length header could not be parsed as a number
+    InvalidContentLength(std::num::ParseIntError),
+    /// The Content-Length value exceeds the maximum allowed size
+    ContentLengthTooLarge(u64),
+}
+
+impl From<InternalRequestError> for RequestError {
+    fn from(value: InternalRequestError) -> Self { RequestError(value) }
+}
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn write_error(
+            f: &mut fmt::Formatter,
+            code: &str,
+            message: impl fmt::Display,
+        ) -> fmt::Result {
+            write!(f, r#"{{ "errorCode": "{}", "message": "{}" }}"#, code, message)
+        }
+
+        match &self.0 {
+            InternalRequestError::Psbt(e) => write_error(f, "psbt-error", e),
+            InternalRequestError::Base64(e) => write_error(f, "base64-decode-error", e),
+            InternalRequestError::Io(e) => write_error(f, "io-error", e),
+            InternalRequestError::MissingHeader(header) =>
+                write_error(f, "missing-header", format!("Missing header: {}", header)),
+            InternalRequestError::InvalidContentType(content_type) => write_error(
+                f,
+                "invalid-content-type",
+                format!("Invalid content type: {}", content_type),
+            ),
+            InternalRequestError::InvalidContentLength(e) =>
+                write_error(f, "invalid-content-length", e),
+            InternalRequestError::ContentLengthTooLarge(length) => write_error(
+                f,
+                "content-length-too-large",
+                format!("Content length too large: {}.", length),
+            ),
+        }
+    }
+}
+
+impl error::Error for RequestError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.0 {
+            InternalRequestError::Psbt(e) => Some(e),
+            InternalRequestError::Base64(e) => Some(e),
+            InternalRequestError::Io(e) => Some(e),
+            InternalRequestError::InvalidContentLength(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/payjoin/src/receive/v1/error.rs
+++ b/payjoin/src/receive/v1/error.rs
@@ -71,7 +71,9 @@ impl error::Error for RequestError {
             InternalRequestError::Psbt(e) => Some(e),
             InternalRequestError::Io(e) => Some(e),
             InternalRequestError::InvalidContentLength(e) => Some(e),
-            _ => None,
+            InternalRequestError::MissingHeader(_) => None,
+            InternalRequestError::InvalidContentType(_) => None,
+            InternalRequestError::ContentLengthTooLarge(_) => None,
         }
     }
 }

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -122,7 +122,7 @@ impl UncheckedProposal {
         self.psbt.clone().extract_tx_unchecked_fee_rate()
     }
 
-    fn psbt_fee_rate(&self) -> Result<FeeRate, Error> {
+    fn psbt_fee_rate(&self) -> Result<FeeRate, InternalRequestError> {
         let original_psbt_fee = self.psbt.fee().map_err(InternalRequestError::Psbt)?;
         Ok(original_psbt_fee / self.extract_tx_to_schedule_broadcast().weight())
     }

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -32,16 +32,19 @@ use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::rand::seq::SliceRandom;
 use bitcoin::secp256k1::rand::{self, Rng};
 use bitcoin::{Amount, FeeRate, OutPoint, Script, TxIn, TxOut, Weight};
+pub(crate) use error::InternalRequestError;
+pub use error::RequestError;
 
 use super::error::{
-    InternalInputContributionError, InternalOutputSubstitutionError, InternalRequestError,
+    InputContributionError, InternalInputContributionError, InternalOutputSubstitutionError,
     InternalSelectionError,
 };
 use super::optional_parameters::Params;
-use super::{
-    Error, InputContributionError, InputPair, OutputSubstitutionError, RequestError, SelectionError,
-};
+use super::{Error, InputPair, OutputSubstitutionError, SelectionError};
 use crate::psbt::PsbtExt;
+use crate::receive::InternalPayloadError;
+
+mod error;
 
 const SUPPORTED_VERSIONS: &[usize] = &[1];
 
@@ -79,7 +82,7 @@ impl UncheckedProposal {
         mut body: impl std::io::Read,
         query: &str,
         headers: impl Headers,
-    ) -> Result<Self, RequestError> {
+    ) -> Result<Self, Error> {
         let content_type = headers
             .get_header("content-type")
             .ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
@@ -102,12 +105,12 @@ impl UncheckedProposal {
         let base64 = BASE64_STANDARD.decode(&buf).map_err(InternalRequestError::Base64)?;
         let unchecked_psbt = Psbt::deserialize(&base64).map_err(InternalRequestError::Psbt)?;
 
-        let psbt = unchecked_psbt.validate().map_err(InternalRequestError::InconsistentPsbt)?;
+        let psbt = unchecked_psbt.validate().map_err(InternalPayloadError::InconsistentPsbt)?;
         log::debug!("Received original psbt: {:?}", psbt);
 
         let pairs = url::form_urlencoded::parse(query.as_bytes());
         let params = Params::from_query_pairs(pairs, SUPPORTED_VERSIONS)
-            .map_err(InternalRequestError::SenderParams)?;
+            .map_err(InternalPayloadError::SenderParams)?;
         log::debug!("Received request with params: {:?}", params);
 
         // TODO check that params are valid for the request's Original PSBT
@@ -148,7 +151,7 @@ impl UncheckedProposal {
         let original_psbt_fee_rate = self.psbt_fee_rate()?;
         if let Some(min_fee_rate) = min_fee_rate {
             if original_psbt_fee_rate < min_fee_rate {
-                return Err(InternalRequestError::PsbtBelowFeeRate(
+                return Err(InternalPayloadError::PsbtBelowFeeRate(
                     original_psbt_fee_rate,
                     min_fee_rate,
                 )
@@ -158,7 +161,7 @@ impl UncheckedProposal {
         if can_broadcast(&self.psbt.clone().extract_tx_unchecked_fee_rate())? {
             Ok(MaybeInputsOwned { psbt: self.psbt, params: self.params })
         } else {
-            Err(InternalRequestError::OriginalPsbtNotBroadcastable.into())
+            Err(InternalPayloadError::OriginalPsbtNotBroadcastable.into())
         }
     }
 
@@ -197,14 +200,14 @@ impl MaybeInputsOwned {
             .scan(&mut err, |err, input| match input.previous_txout() {
                 Ok(txout) => Some(txout.script_pubkey.to_owned()),
                 Err(e) => {
-                    **err = Err(Error::Validation(InternalRequestError::PrevTxOut(e).into()));
+                    **err = Err(Error::Validation(InternalPayloadError::PrevTxOut(e).into()));
                     None
                 }
             })
             .find_map(|script| match is_owned(&script) {
                 Ok(false) => None,
                 Ok(true) =>
-                    Some(Error::Validation(InternalRequestError::InputOwned(script).into())),
+                    Some(Error::Validation(InternalPayloadError::InputOwned(script).into())),
                 Err(e) => Some(Error::Implementation(e.into())),
             })
         {
@@ -238,7 +241,7 @@ impl MaybeInputsSeen {
                 Ok(true) =>  {
                     log::warn!("Request contains an input we've seen before: {}. Preventing possible probing attack.", input.txin.previous_output);
                     Err(Error::Validation(
-                        InternalRequestError::InputSeen(input.txin.previous_output).into(),
+                        InternalPayloadError::InputSeen(input.txin.previous_output).into(),
                     ))?
                 },
                 Err(e) => Err(Error::Implementation(e.into()))?,
@@ -279,7 +282,7 @@ impl OutputsUnknown {
             .collect::<Result<Vec<_>, _>>()?;
 
         if owned_vouts.is_empty() {
-            return Err(Error::Validation(InternalRequestError::MissingPayment.into()));
+            return Err(Error::Validation(InternalPayloadError::MissingPayment.into()));
         }
 
         let mut params = self.params.clone();
@@ -677,7 +680,7 @@ impl ProvisionalProposal {
         &mut self,
         min_feerate: Option<FeeRate>,
         max_feerate: FeeRate,
-    ) -> Result<&Psbt, RequestError> {
+    ) -> Result<&Psbt, InternalPayloadError> {
         let min_feerate = min_feerate.unwrap_or(FeeRate::MIN);
         log::trace!("min_feerate: {:?}", min_feerate);
         log::trace!("params.min_feerate: {:?}", self.params.min_feerate);
@@ -734,7 +737,7 @@ impl ProvisionalProposal {
         if receiver_additional_fee > max_fee {
             let proposed_feerate =
                 receiver_additional_fee / (input_contribution_weight + output_contribution_weight);
-            return Err(InternalRequestError::FeeTooHigh(proposed_feerate, max_feerate).into());
+            return Err(InternalPayloadError::FeeTooHigh(proposed_feerate, max_feerate));
         }
         if receiver_additional_fee > Amount::ZERO {
             // Remove additional miner fee from the receiver's specified output
@@ -744,14 +747,14 @@ impl ProvisionalProposal {
     }
 
     /// Calculate the additional input weight contributed by the receiver
-    fn additional_input_weight(&self) -> Result<Weight, RequestError> {
-        fn inputs_weight(psbt: &Psbt) -> Result<Weight, RequestError> {
+    fn additional_input_weight(&self) -> Result<Weight, InternalPayloadError> {
+        fn inputs_weight(psbt: &Psbt) -> Result<Weight, InternalPayloadError> {
             psbt.input_pairs().try_fold(
                 Weight::ZERO,
-                |acc, input_pair| -> Result<Weight, RequestError> {
+                |acc, input_pair| -> Result<Weight, InternalPayloadError> {
                     let input_weight = input_pair
                         .expected_input_weight()
-                        .map_err(InternalRequestError::InputWeight)?;
+                        .map_err(InternalPayloadError::InputWeight)?;
                     Ok(acc + input_weight)
                 },
             )
@@ -783,7 +786,7 @@ impl ProvisionalProposal {
     }
 
     /// Prepare the PSBT by clearing the fields that the sender expects to be empty
-    fn prepare_psbt(mut self, processed_psbt: Psbt) -> Result<PayjoinProposal, RequestError> {
+    fn prepare_psbt(mut self, processed_psbt: Psbt) -> PayjoinProposal {
         self.payjoin_psbt = processed_psbt;
         log::trace!("Preparing PSBT {:#?}", self.payjoin_psbt);
         for output in self.payjoin_psbt.outputs_mut() {
@@ -806,7 +809,7 @@ impl ProvisionalProposal {
             self.payjoin_psbt.inputs[i].tap_key_sig = None;
         }
 
-        Ok(PayjoinProposal { payjoin_psbt: self.payjoin_psbt, params: self.params })
+        PayjoinProposal { payjoin_psbt: self.payjoin_psbt, params: self.params }
     }
 
     /// Return the indexes of the sender inputs
@@ -851,7 +854,7 @@ impl ProvisionalProposal {
             psbt.inputs[i].tap_key_sig = None;
         }
         let psbt = wallet_process_psbt(&psbt)?;
-        let payjoin_proposal = self.prepare_psbt(psbt)?;
+        let payjoin_proposal = self.prepare_psbt(psbt);
         Ok(payjoin_proposal)
     }
 }
@@ -904,7 +907,7 @@ pub(crate) mod test {
         }
     }
 
-    pub fn proposal_from_test_vector() -> Result<UncheckedProposal, RequestError> {
+    pub(crate) fn proposal_from_test_vector() -> Result<UncheckedProposal, Error> {
         // OriginalPSBT Test Vector from BIP
         // | InputScriptType | Orginal PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|
         // |-----------------|-----------------------|------------------------------|-------------------------|

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -25,9 +25,8 @@
 //! [reference implementation](https://github.com/payjoin/rust-payjoin/tree/master/payjoin-cli)
 
 use std::cmp::{max, min};
+use std::str::FromStr;
 
-use bitcoin::base64::prelude::BASE64_STANDARD;
-use bitcoin::base64::Engine;
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::rand::seq::SliceRandom;
 use bitcoin::secp256k1::rand::{self, Rng};
@@ -102,8 +101,8 @@ impl UncheckedProposal {
         // enforce the limit
         let mut buf = vec![0; content_length as usize]; // 4_000_000 * 4 / 3 fits in u32
         body.read_exact(&mut buf).map_err(InternalRequestError::Io)?;
-        let base64 = BASE64_STANDARD.decode(&buf).map_err(InternalRequestError::Base64)?;
-        let unchecked_psbt = Psbt::deserialize(&base64).map_err(InternalRequestError::Psbt)?;
+        let base64 = String::from_utf8(buf).map_err(InternalPayloadError::Utf8)?;
+        let unchecked_psbt = Psbt::from_str(&base64).map_err(InternalPayloadError::ParsePsbt)?;
 
         let psbt = unchecked_psbt.validate().map_err(InternalPayloadError::InconsistentPsbt)?;
         log::debug!("Received original psbt: {:?}", psbt);

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -1,61 +1,24 @@
 use core::fmt;
 use std::error;
 
+use super::Error;
+use crate::hpke::HpkeError;
 use crate::ohttp::OhttpEncapsulationError;
 
-/// Error that may occur when the v2 request from sender is malformed.
+/// Error that may occur during a v2 session typestate change
 ///
 /// This is currently opaque type because we aren't sure which variants will stay.
 /// You can only display it.
 #[derive(Debug)]
-pub struct RequestError(InternalRequestError);
-
-#[derive(Debug)]
-pub(crate) enum InternalRequestError {
-    /// Serde deserialization failed
-    ParsePsbt(bitcoin::psbt::PsbtParseError),
-    Utf8(std::string::FromUtf8Error),
-}
-
-impl From<InternalRequestError> for RequestError {
-    fn from(value: InternalRequestError) -> Self { RequestError(value) }
-}
-
-impl fmt::Display for RequestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use InternalRequestError::*;
-        fn write_error(
-            f: &mut fmt::Formatter,
-            code: &str,
-            message: impl fmt::Display,
-        ) -> fmt::Result {
-            write!(f, r#"{{ "errorCode": "{}", "message": "{}" }}"#, code, message)
-        }
-
-        match &self.0 {
-            ParsePsbt(e) => write_error(f, "Error parsing PSBT:", e),
-            Utf8(e) => write_error(f, "Error parsing PSBT:", e),
-        }
-    }
-}
-
-impl std::error::Error for RequestError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use InternalRequestError::*;
-
-        match &self.0 {
-            ParsePsbt(e) => Some(e),
-            Utf8(e) => Some(e),
-        }
-    }
-}
-
-impl From<InternalRequestError> for super::Error {
-    fn from(e: InternalRequestError) -> Self { super::Error::Validation(e.into()) }
-}
-
-#[derive(Debug)]
 pub struct SessionError(InternalSessionError);
+
+impl From<InternalSessionError> for SessionError {
+    fn from(value: InternalSessionError) -> Self { SessionError(value) }
+}
+
+impl From<InternalSessionError> for super::Error {
+    fn from(e: InternalSessionError) -> Self { super::Error::Validation(e.into()) }
+}
 
 #[derive(Debug)]
 pub(crate) enum InternalSessionError {
@@ -63,10 +26,26 @@ pub(crate) enum InternalSessionError {
     Expired(std::time::SystemTime),
     /// OHTTP Encapsulation failed
     OhttpEncapsulation(OhttpEncapsulationError),
+    /// Hybrid Public Key Encryption failed
+    Hpke(HpkeError),
     /// Unexpected response size
     UnexpectedResponseSize(usize),
     /// Unexpected status code
     UnexpectedStatusCode(http::StatusCode),
+}
+
+impl From<std::time::SystemTime> for Error {
+    fn from(e: std::time::SystemTime) -> Self { InternalSessionError::Expired(e).into() }
+}
+
+impl From<OhttpEncapsulationError> for Error {
+    fn from(e: OhttpEncapsulationError) -> Self {
+        InternalSessionError::OhttpEncapsulation(e).into()
+    }
+}
+
+impl From<HpkeError> for Error {
+    fn from(e: HpkeError) -> Self { InternalSessionError::Hpke(e).into() }
 }
 
 impl fmt::Display for SessionError {
@@ -75,6 +54,7 @@ impl fmt::Display for SessionError {
             InternalSessionError::Expired(expiry) => write!(f, "Session expired at {:?}", expiry),
             InternalSessionError::OhttpEncapsulation(e) =>
                 write!(f, "OHTTP Encapsulation Error: {}", e),
+            InternalSessionError::Hpke(e) => write!(f, "Hpke decryption failed: {}", e),
             InternalSessionError::UnexpectedResponseSize(size) => write!(
                 f,
                 "Unexpected response size {}, expected {} bytes",
@@ -92,28 +72,9 @@ impl error::Error for SessionError {
         match &self.0 {
             InternalSessionError::Expired(_) => None,
             InternalSessionError::OhttpEncapsulation(e) => Some(e),
+            InternalSessionError::Hpke(e) => Some(e),
             InternalSessionError::UnexpectedResponseSize(_) => None,
             InternalSessionError::UnexpectedStatusCode(_) => None,
         }
-    }
-}
-
-impl From<InternalSessionError> for SessionError {
-    fn from(e: InternalSessionError) -> Self { SessionError(e) }
-}
-
-impl From<OhttpEncapsulationError> for SessionError {
-    fn from(e: OhttpEncapsulationError) -> Self {
-        SessionError(InternalSessionError::OhttpEncapsulation(e))
-    }
-}
-
-impl From<crate::hpke::HpkeError> for super::Error {
-    fn from(e: crate::hpke::HpkeError) -> Self { super::Error::Implementation(Box::new(e)) }
-}
-
-impl From<crate::ohttp::OhttpEncapsulationError> for super::Error {
-    fn from(e: crate::ohttp::OhttpEncapsulationError) -> Self {
-        super::Error::Implementation(Box::new(e))
     }
 }

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -3,6 +3,57 @@ use std::error;
 
 use crate::ohttp::OhttpEncapsulationError;
 
+/// Error that may occur when the v2 request from sender is malformed.
+///
+/// This is currently opaque type because we aren't sure which variants will stay.
+/// You can only display it.
+#[derive(Debug)]
+pub struct RequestError(InternalRequestError);
+
+#[derive(Debug)]
+pub(crate) enum InternalRequestError {
+    /// Serde deserialization failed
+    ParsePsbt(bitcoin::psbt::PsbtParseError),
+    Utf8(std::string::FromUtf8Error),
+}
+
+impl From<InternalRequestError> for RequestError {
+    fn from(value: InternalRequestError) -> Self { RequestError(value) }
+}
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use InternalRequestError::*;
+        fn write_error(
+            f: &mut fmt::Formatter,
+            code: &str,
+            message: impl fmt::Display,
+        ) -> fmt::Result {
+            write!(f, r#"{{ "errorCode": "{}", "message": "{}" }}"#, code, message)
+        }
+
+        match &self.0 {
+            ParsePsbt(e) => write_error(f, "Error parsing PSBT:", e),
+            Utf8(e) => write_error(f, "Error parsing PSBT:", e),
+        }
+    }
+}
+
+impl std::error::Error for RequestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use InternalRequestError::*;
+
+        match &self.0 {
+            ParsePsbt(e) => Some(e),
+            Utf8(e) => Some(e),
+        }
+    }
+}
+
+impl From<InternalRequestError> for super::Error {
+    fn from(e: InternalRequestError) -> Self { super::Error::Validation(e.into()) }
+}
+
 #[derive(Debug)]
 pub struct SessionError(InternalSessionError);
 
@@ -54,5 +105,15 @@ impl From<InternalSessionError> for SessionError {
 impl From<OhttpEncapsulationError> for SessionError {
     fn from(e: OhttpEncapsulationError) -> Self {
         SessionError(InternalSessionError::OhttpEncapsulation(e))
+    }
+}
+
+impl From<crate::hpke::HpkeError> for super::Error {
+    fn from(e: crate::hpke::HpkeError) -> Self { super::Error::Implementation(Box::new(e)) }
+}
+
+impl From<crate::ohttp::OhttpEncapsulationError> for super::Error {
+    fn from(e: crate::ohttp::OhttpEncapsulationError) -> Self {
+        super::Error::Implementation(Box::new(e))
     }
 }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -151,7 +151,7 @@ impl Receiver {
     fn extract_proposal_from_v2(&mut self, response: Vec<u8>) -> Result<UncheckedProposal, Error> {
         let (payload_bytes, e) = decrypt_message_a(&response, self.context.s.secret_key().clone())?;
         self.context.e = Some(e);
-        let payload = String::from_utf8(payload_bytes).map_err(InternalRequestError::Utf8)?;
+        let payload = String::from_utf8(payload_bytes).map_err(InternalPayloadError::Utf8)?;
         self.unchecked_from_payload(payload)
     }
 
@@ -159,7 +159,7 @@ impl Receiver {
         let (base64, padded_query) = payload.split_once('\n').unwrap_or_default();
         let query = padded_query.trim_matches('\0');
         log::trace!("Received query: {}, base64: {}", query, base64); // my guess is no \n so default is wrong
-        let unchecked_psbt = Psbt::from_str(base64).map_err(InternalRequestError::ParsePsbt)?;
+        let unchecked_psbt = Psbt::from_str(base64).map_err(InternalPayloadError::ParsePsbt)?;
         let psbt = unchecked_psbt.validate().map_err(InternalPayloadError::InconsistentPsbt)?;
         log::debug!("Received original psbt: {:?}", psbt);
         let mut params = Params::from_query_pairs(


### PR DESCRIPTION
This big move isolates v1/v2 module-specific error variants into clean module v1/v2 error modules. 

- First commit renames the `crate::receive::Error` variants to be module agnostic. Before they were v1, http response-specific. Reviewers: What do you think about the `Validation` and `External` variant names? (part of #312)
- Second commit roughly separates the modules
- Third commit unifies some variants that lived in module-specific error types but were actually shared
- Fourth commit recognizes unifies v2-module-specific error variant from the remaining RequestError stub
- Fifth commit properly scopes the `crate::receive::Error` variant to its own module, and I think that may resolve #312

There are probably too many `impl<From>` for error variants, but I think the straight path forward is addressing the structure first with this PR and then taking a magnifying glass to the way specific variants are handled.

This still also leaves `OutputSubstitutionError`, `SelectionError` and `InputContributionError` from producing JSON error responses to cancel a session with a v2 receiver. We're going to need to address that as part of #403. v2 Error variants also improperly produce JSON errors, but I think the way this was done by abusing `fmt::Display` is also an antipattern to fix at the same time that's addressed. I'd like to leave the JSON receiver error fixes to a follow up since what gets revealed is potentially sensitive and we should be reviewing that change with extra scrutiny.

See: #312, #392, #403