### PR TITLE
Expose test helpers

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1695,6 +1695,7 @@ dependencies = [
  "log",
  "ohttp-relay",
  "once_cell",
+ "payjoin",
  "payjoin-directory",
  "rcgen",
  "reqwest",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1612,6 +1612,7 @@ dependencies = [
  "ohttp-relay",
  "once_cell",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1647,6 +1648,7 @@ dependencies = [
  "once_cell",
  "payjoin",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1680,6 +1682,28 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "payjoin-test-utils"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "bitcoincore-rpc",
+ "bitcoind",
+ "http",
+ "log",
+ "ohttp-relay",
+ "once_cell",
+ "payjoin-directory",
+ "rcgen",
+ "reqwest",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1695,6 +1695,7 @@ dependencies = [
  "log",
  "ohttp-relay",
  "once_cell",
+ "payjoin",
  "payjoin-directory",
  "rcgen",
  "reqwest",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1612,6 +1612,7 @@ dependencies = [
  "ohttp-relay",
  "once_cell",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1647,6 +1648,7 @@ dependencies = [
  "once_cell",
  "payjoin",
  "payjoin-directory",
+ "payjoin-test-utils",
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
@@ -1680,6 +1682,28 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "payjoin-test-utils"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "bitcoincore-rpc",
+ "bitcoind",
+ "http",
+ "log",
+ "ohttp-relay",
+ "once_cell",
+ "payjoin-directory",
+ "rcgen",
+ "reqwest",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["payjoin", "payjoin-cli", "payjoin-directory"]
+members = ["payjoin", "payjoin-cli", "payjoin-directory", "payjoin-test-utils"]
 resolver = "2"
 
 [patch.crates-io.payjoin]

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -54,6 +54,7 @@ nix = "0.26.4"
 ohttp-relay = { version = "0.0.9", features = ["_test-util"] }
 once_cell = "1"
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
+payjoin-test-utils = { path = "../payjoin-test-utils" }
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["redis"] }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -3,12 +3,9 @@ mod e2e {
     use std::env;
     use std::process::Stdio;
 
-    use bitcoincore_rpc::json::AddressType;
-    use bitcoind::bitcoincore_rpc::RpcApi;
-    use log::{log_enabled, Level};
     use nix::sys::signal::{kill, Signal};
     use nix::unistd::Pid;
-    use payjoin::bitcoin::Amount;
+    use payjoin_test_utils::init_bitcoind_sender_receiver;
     use tokio::fs;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::process::Command;
@@ -23,34 +20,7 @@ mod e2e {
     #[cfg(not(feature = "v2"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn send_receive_payjoin() {
-        let bitcoind_exe = env::var("BITCOIND_EXE")
-            .ok()
-            .or_else(|| bitcoind::downloaded_exe_path().ok())
-            .expect("version feature or env BITCOIND_EXE is required for tests");
-        let mut conf = bitcoind::Conf::default();
-        conf.view_stdout = log_enabled!(Level::Debug);
-        let bitcoind = bitcoind::BitcoinD::with_conf(bitcoind_exe, &conf).unwrap();
-        let receiver = bitcoind.create_wallet("receiver").unwrap();
-        let receiver_address =
-            receiver.get_new_address(None, Some(AddressType::Bech32)).unwrap().assume_checked();
-        let sender = bitcoind.create_wallet("sender").unwrap();
-        let sender_address =
-            sender.get_new_address(None, Some(AddressType::Bech32)).unwrap().assume_checked();
-        bitcoind.client.generate_to_address(1, &receiver_address).unwrap();
-        bitcoind.client.generate_to_address(101, &sender_address).unwrap();
-
-        assert_eq!(
-            Amount::from_btc(50.0).unwrap(),
-            receiver.get_balances().unwrap().mine.trusted,
-            "receiver doesn't own bitcoin"
-        );
-
-        assert_eq!(
-            Amount::from_btc(50.0).unwrap(),
-            sender.get_balances().unwrap().mine.trusted,
-            "sender doesn't own bitcoin"
-        );
-
+        let (bitcoind, _sender, _receiver) = init_bitcoind_sender_receiver(None, None).unwrap();
         let temp_dir = env::temp_dir();
         let receiver_db_path = temp_dir.join("receiver_db");
         let sender_db_path = temp_dir.join("sender_db");
@@ -171,23 +141,17 @@ mod e2e {
         use std::path::PathBuf;
         use std::str::FromStr;
         use std::sync::Arc;
-        use std::time::Duration;
 
-        use http::StatusCode;
-        use once_cell::sync::{Lazy, OnceCell};
-        use reqwest::{Client, ClientBuilder};
+        use payjoin_test_utils::{
+            http_agent, init_directory, init_tracing, local_cert_key, wait_for_service_ready,
+            BoxError,
+        };
         use testcontainers::clients::Cli;
         use testcontainers_modules::redis::Redis;
         use tokio::process::Child;
         use url::Url;
 
-        type Error = Box<dyn std::error::Error + 'static>;
-        type BoxSendSyncError = Box<dyn std::error::Error + Send + Sync>;
-        type Result<T> = std::result::Result<T, Error>;
-
-        static INIT_TRACING: OnceCell<()> = OnceCell::new();
-        static TESTS_TIMEOUT: Lazy<Duration> = Lazy::new(|| Duration::from_secs(20));
-        static WAIT_SERVICE_INTERVAL: Lazy<Duration> = Lazy::new(|| Duration::from_secs(3));
+        type Result<T> = std::result::Result<T, BoxError>;
 
         init_tracing();
         let (cert, key) = local_cert_key();
@@ -225,33 +189,7 @@ mod e2e {
             receiver_db_path: PathBuf,
             sender_db_path: PathBuf,
         ) -> Result<()> {
-            let bitcoind_exe = env::var("BITCOIND_EXE")
-                .ok()
-                .or_else(|| bitcoind::downloaded_exe_path().ok())
-                .expect("version feature or env BITCOIND_EXE is required for tests");
-            let mut conf = bitcoind::Conf::default();
-            conf.view_stdout = log_enabled!(Level::Debug);
-            let bitcoind = bitcoind::BitcoinD::with_conf(bitcoind_exe, &conf)?;
-            let receiver = bitcoind.create_wallet("receiver")?;
-            let receiver_address =
-                receiver.get_new_address(None, Some(AddressType::Bech32))?.assume_checked();
-            let sender = bitcoind.create_wallet("sender")?;
-            let sender_address =
-                sender.get_new_address(None, Some(AddressType::Bech32))?.assume_checked();
-            bitcoind.client.generate_to_address(1, &receiver_address)?;
-            bitcoind.client.generate_to_address(101, &sender_address)?;
-
-            assert_eq!(
-                Amount::from_btc(50.0)?,
-                receiver.get_balances()?.mine.trusted,
-                "receiver doesn't own bitcoin"
-            );
-
-            assert_eq!(
-                Amount::from_btc(50.0)?,
-                sender.get_balances()?.mine.trusted,
-                "sender doesn't own bitcoin"
-            );
+            let (bitcoind, _sender, _receiver) = init_bitcoind_sender_receiver(None, None)?;
             let temp_dir = env::temp_dir();
             let cert_path = temp_dir.join("localhost.der");
             tokio::fs::write(&cert_path, cert.clone()).await?;
@@ -477,75 +415,6 @@ mod e2e {
 
             assert!(payjoin_sent.unwrap_or(false), "Payjoin send was not detected");
             Ok(())
-        }
-
-        async fn wait_for_service_ready(service_url: Url, agent: Arc<Client>) -> Result<()> {
-            let health_url = service_url.join("/health").map_err(|_| "Invalid URL")?;
-            let start = std::time::Instant::now();
-
-            while start.elapsed() < *TESTS_TIMEOUT {
-                let request_result =
-                    agent.get(health_url.as_str()).send().await.map_err(|_| "Bad request")?;
-
-                match request_result.status() {
-                    StatusCode::OK => {
-                        println!("READY {}", service_url);
-                        return Ok(());
-                    }
-                    StatusCode::NOT_FOUND => return Err("Endpoint not found".into()),
-                    _ => std::thread::sleep(*WAIT_SERVICE_INTERVAL),
-                }
-            }
-
-            Err("Timeout waiting for service to be ready".into())
-        }
-
-        async fn init_directory(
-            db_host: String,
-            local_cert_key: (Vec<u8>, Vec<u8>),
-        ) -> std::result::Result<
-            (u16, tokio::task::JoinHandle<std::result::Result<(), BoxSendSyncError>>),
-            BoxSendSyncError,
-        > {
-            println!("Database running on {}", db_host);
-            let timeout = Duration::from_secs(2);
-            payjoin_directory::listen_tcp_with_tls_on_free_port(db_host, timeout, local_cert_key)
-                .await
-        }
-
-        // generates or gets a DER encoded localhost cert and key.
-        fn local_cert_key() -> (Vec<u8>, Vec<u8>) {
-            let cert = rcgen::generate_simple_self_signed(vec![
-                "0.0.0.0".to_string(),
-                "localhost".to_string(),
-            ])
-            .expect("Failed to generate cert");
-            let cert_der = cert.serialize_der().expect("Failed to serialize cert");
-            let key_der = cert.serialize_private_key_der();
-            (cert_der, key_der)
-        }
-
-        fn http_agent(cert_der: Vec<u8>) -> Result<Client> {
-            Ok(http_agent_builder(cert_der)?.build()?)
-        }
-
-        fn http_agent_builder(cert_der: Vec<u8>) -> Result<ClientBuilder> {
-            Ok(ClientBuilder::new()
-                .danger_accept_invalid_certs(true)
-                .use_rustls_tls()
-                .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice())?))
-        }
-
-        fn init_tracing() {
-            INIT_TRACING.get_or_init(|| {
-                let subscriber = tracing_subscriber::FmtSubscriber::builder()
-                    .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-                    .with_test_writer()
-                    .finish();
-
-                tracing::subscriber::set_global_default(subscriber)
-                    .expect("failed to set global default subscriber");
-            });
         }
     }
 

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -14,6 +14,7 @@ http = "1"
 log = "0.4.7"
 ohttp-relay = { version = "0.0.9", features = ["_test-util"] }
 once_cell = "1"
+payjoin = { path = "../payjoin", features = ["io", "_danger-local-https"] }
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
 rcgen = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "payjoin-test-utils"
+version = "0.1.0"
+edition = "2021"
+authors = ["Dan Gould <d@ngould.dev>"]
+rust-version = "1.63"
+license = "MIT"
+
+[dependencies]
+bitcoin = { version = "0.32.5", features = ["base64"] }
+bitcoincore-rpc = "0.19.0"
+bitcoind = { version = "0.36.0", features = ["0_21_2"] }
+http = "1"
+log = "0.4.7"
+ohttp-relay = { version = "0.0.9", features = ["_test-util"] }
+once_cell = "1"
+payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
+rcgen = "0.11"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+testcontainers = "0.15.0"
+testcontainers-modules = { version = "0.1.3", features = ["redis"] }
+tokio = { version = "1.12.0", features = ["full"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+url = "2.2.2"

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -1,0 +1,116 @@
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bitcoin::Amount;
+use bitcoind::bitcoincore_rpc::json::AddressType;
+use bitcoind::bitcoincore_rpc::{self, RpcApi};
+use http::StatusCode;
+use log::{log_enabled, Level};
+use once_cell::sync::OnceCell;
+use reqwest::{Client, ClientBuilder};
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+use url::Url;
+
+pub type BoxError = Box<dyn std::error::Error + 'static>;
+pub type BoxSendSyncError = Box<dyn std::error::Error + Send + Sync>;
+
+static INIT_TRACING: OnceCell<()> = OnceCell::new();
+
+pub fn init_tracing() {
+    INIT_TRACING.get_or_init(|| {
+        let subscriber = FmtSubscriber::builder()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_test_writer()
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("failed to set global default subscriber");
+    });
+}
+
+pub async fn init_directory(
+    db_host: String,
+    local_cert_key: (Vec<u8>, Vec<u8>),
+) -> std::result::Result<
+    (u16, tokio::task::JoinHandle<std::result::Result<(), BoxSendSyncError>>),
+    BoxSendSyncError,
+> {
+    println!("Database running on {}", db_host);
+    let timeout = Duration::from_secs(2);
+    payjoin_directory::listen_tcp_with_tls_on_free_port(db_host, timeout, local_cert_key).await
+}
+
+// generates or gets a DER encoded localhost cert and key.
+pub fn local_cert_key() -> (Vec<u8>, Vec<u8>) {
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["0.0.0.0".to_string(), "localhost".to_string()])
+            .expect("Failed to generate cert");
+    let cert_der = cert.serialize_der().expect("Failed to serialize cert");
+    let key_der = cert.serialize_private_key_der();
+    (cert_der, key_der)
+}
+
+pub fn init_bitcoind_sender_receiver(
+    sender_address_type: Option<AddressType>,
+    receiver_address_type: Option<AddressType>,
+) -> Result<(bitcoind::BitcoinD, bitcoincore_rpc::Client, bitcoincore_rpc::Client), BoxError> {
+    let bitcoind_exe =
+        env::var("BITCOIND_EXE").ok().or_else(|| bitcoind::downloaded_exe_path().ok()).unwrap();
+    let mut conf = bitcoind::Conf::default();
+    conf.view_stdout = log_enabled!(Level::Debug);
+    let bitcoind = bitcoind::BitcoinD::with_conf(bitcoind_exe, &conf)?;
+    let receiver = bitcoind.create_wallet("receiver")?;
+    let receiver_address = receiver.get_new_address(None, receiver_address_type)?.assume_checked();
+    let sender = bitcoind.create_wallet("sender")?;
+    let sender_address = sender.get_new_address(None, sender_address_type)?.assume_checked();
+    bitcoind.client.generate_to_address(1, &receiver_address)?;
+    bitcoind.client.generate_to_address(101, &sender_address)?;
+
+    assert_eq!(
+        Amount::from_btc(50.0)?,
+        receiver.get_balances()?.mine.trusted,
+        "receiver doesn't own bitcoin"
+    );
+
+    assert_eq!(
+        Amount::from_btc(50.0)?,
+        sender.get_balances()?.mine.trusted,
+        "sender doesn't own bitcoin"
+    );
+    Ok((bitcoind, sender, receiver))
+}
+
+pub fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxError> {
+    Ok(http_agent_builder(cert_der)?.build()?)
+}
+
+fn http_agent_builder(cert_der: Vec<u8>) -> Result<ClientBuilder, BoxError> {
+    Ok(ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .use_rustls_tls()
+        .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice()).unwrap()))
+}
+
+const TESTS_TIMEOUT: Duration = Duration::from_secs(20);
+const WAIT_SERVICE_INTERVAL: Duration = Duration::from_secs(3);
+
+pub async fn wait_for_service_ready(
+    service_url: Url,
+    agent: Arc<Client>,
+) -> Result<(), &'static str> {
+    let health_url = service_url.join("/health").map_err(|_| "Invalid URL")?;
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < TESTS_TIMEOUT {
+        let request_result =
+            agent.get(health_url.as_str()).send().await.map_err(|_| "Bad request")?;
+        match request_result.status() {
+            StatusCode::OK => return Ok(()),
+            StatusCode::NOT_FOUND => return Err("Endpoint not found"),
+            _ => std::thread::sleep(WAIT_SERVICE_INTERVAL),
+        }
+    }
+
+    Err("Timeout waiting for service to be ready")
+}

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = "1.0.108"
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
+payjoin-test-utils = { path = "../payjoin-test-utils" }
 ohttp-relay = { version = "0.0.9", features = ["_test-util"] }
 once_cell = "1"
 rcgen = { version = "0.11" }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -55,16 +55,16 @@ mod integration {
             do_v1_to_v1(sender, receiver, false)
         }
 
-        // TODO: Not supported by bitcoind 0_21_2. Later versions fail for unknown reasons
-        //#[test]
-        //fn v1_to_v1_taproot() -> Result<(), BoxError> {
-        //    init_tracing();
-        //    let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(
-        //        Some(AddressType::Bech32m),
-        //        Some(AddressType::Bech32m),
-        //    )?;
-        //    do_v1_to_v1(sender, receiver, false)
-        //}
+        #[ignore] // TODO: Not supported by bitcoind 0_21_2. Later versions fail for unknown reasons
+        #[test]
+        fn v1_to_v1_taproot() -> Result<(), BoxError> {
+            init_tracing();
+            let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(
+                Some(AddressType::Bech32m),
+                Some(AddressType::Bech32m),
+            )?;
+            do_v1_to_v1(sender, receiver, false)
+        }
 
         fn do_v1_to_v1(
             sender: bitcoincore_rpc::Client,


### PR DESCRIPTION
This is an effort to address https://github.com/payjoin/rust-payjoin/issues/422.

Commonly-used test utilities are moved to a standalone `payjoin-test-utils` crate. This new crate also provides an opportunity to create downstream test fixtures in payjoin-ffi and language bindings downstream of it.

The new crate also introduces `TestServices`, which further facilitates testing by handling common operations such as initializing a payjoin directory and OHTTP relay, fetching OHTTP keys, etc.