### PR TITLE
Follow up from #456: Update path qualifier and introduce module-specific `Result`

### DIFF
--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -314,7 +314,7 @@ impl From<hyper::http::Error> for HandlerError {
 }
 
 fn handle_peek(
-    result: Result<Vec<u8>, db::Error>,
+    result: db::Result<Vec<u8>>,
     timeout_response: Response<BoxBody<Bytes, hyper::Error>>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError> {
     match result {

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -15,7 +15,7 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, trace};
 
-use crate::db::{DbPool, Error};
+use crate::db::DbPool;
 
 pub const DEFAULT_DIR_PORT: u16 = 8080;
 pub const DEFAULT_DB_HOST: &str = "localhost:6379";
@@ -314,17 +314,17 @@ impl From<hyper::http::Error> for HandlerError {
 }
 
 fn handle_peek(
-    result: Result<Vec<u8>, Error>,
+    result: Result<Vec<u8>, db::Error>,
     timeout_response: Response<BoxBody<Bytes, hyper::Error>>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError> {
     match result {
         Ok(buffered_req) => Ok(Response::new(full(buffered_req))),
         Err(e) => match e {
-            Error::Redis(re) => {
+            db::Error::Redis(re) => {
                 error!("Redis error: {}", re);
                 Err(HandlerError::InternalServerError(anyhow::Error::msg("Internal server error")))
             }
-            Error::Timeout(_) => Ok(timeout_response),
+            db::Error::Timeout(_) => Ok(timeout_response),
         },
     }
 }


### PR DESCRIPTION
From [a comment](https://github.com/payjoin/rust-payjoin/pull/456/files#r1916802964) in #456:

> If I were forced to come up with one TODO on this PR, or feedback for next time, I would suggest that crate::db::Error were not imported in this file, and rather the function signature was qualified as db::Error since db::Error is not semantically the top level Error for lib.rs. We don't have one, which is why there's no conflict, but HandlerError would be the closest thing.
> 
> Writing this also made me notice that some Result types are duplicated in a bunch of places, so there is an argument to be made for
>
> db::Result = Result<Vec<u8>, Error>
HandlerResult = Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError>
The result types are really getting nitty gritty but I figure it can't hurt to share

Updating to `db::Error` made sense, and I had to change `db::Result = Result<Vec<u8>, Error>` to ` Result<T> = anyhow::Result<T, Error>` since `pub async fn new(timeout: Duration, db_host: String) -> RedisResult<Self>` didn't return a `Vec<u8>`

I wasn't sure about the `HandlerResult` update. In `lib.rs`, there are other functions such as `listen_tcp` and `listen_tcp_with_tls` that don't return a `Result` that can be converted into `Result<Response<BoxBody<Bytes, hyper::Error>>, HandlerError>`, so I didn't add the HandlerResult bit