### PR TITLE
Use FeeRate::BROADCAST_MIN for minfeerate defaults

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -374,7 +374,7 @@ impl App {
                     })
                     .map_err(|e| Error::Implementation(e.into()))?
             },
-            Some(bitcoin::FeeRate::MIN),
+            None,
             self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
                 FeeRate::from_sat_per_vb(fee_rate)
                     .ok_or(Error::Implementation("Invalid fee rate".into()))

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -322,7 +322,7 @@ impl App {
                     })
                     .map_err(|e| Error::Implementation(e.into()))?
             },
-            Some(bitcoin::FeeRate::MIN),
+            None,
             self.config.max_fee_rate.map_or(Ok(FeeRate::ZERO), |fee_rate| {
                 FeeRate::from_sat_per_vb(fee_rate)
                     .ok_or(Error::Implementation("Invalid fee rate".into()))

--- a/payjoin/src/receive/optional_parameters.rs
+++ b/payjoin/src/receive/optional_parameters.rs
@@ -22,7 +22,7 @@ impl Default for Params {
             v: 1,
             disable_output_substitution: false,
             additional_fee_contribution: None,
-            min_feerate: FeeRate::ZERO,
+            min_feerate: FeeRate::BROADCAST_MIN,
         }
     }
 }

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -680,7 +680,7 @@ impl ProvisionalProposal {
         min_feerate: Option<FeeRate>,
         max_feerate: FeeRate,
     ) -> Result<&Psbt, InternalPayloadError> {
-        let min_feerate = min_feerate.unwrap_or(FeeRate::MIN);
+        let min_feerate = min_feerate.unwrap_or(FeeRate::BROADCAST_MIN);
         log::trace!("min_feerate: {:?}", min_feerate);
         log::trace!("params.min_feerate: {:?}", self.params.min_feerate);
         let min_feerate = max(min_feerate, self.params.min_feerate);


### PR DESCRIPTION
Relay policy's BROADCAST_MIN is far more usual than FeeRate::MIN (ZERO) when it comes to thinking of minnimum feerates to paramaterize.

This is only a default. If some implementation wants to use a lower fee rate they still may.

Close #489