### PR TITLE
Produce `receive::JsonError` accurately so that `send` can properly handle it

### DIFF
--- a/payjoin/src/error_codes.rs
+++ b/payjoin/src/error_codes.rs
@@ -1,0 +1,14 @@
+//! Well-known error codes as defined in BIP-78
+//! See: <https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#receivers-well-known-errors>
+
+/// The payjoin endpoint is not available for now.
+pub const UNAVAILABLE: &str = "unavailable";
+
+/// The receiver added some inputs but could not bump the fee of the payjoin proposal.
+pub const NOT_ENOUGH_MONEY: &str = "not-enough-money";
+
+/// This version of payjoin is not supported.
+pub const VERSION_UNSUPPORTED: &str = "version-unsupported";
+
+/// The receiver rejected the original PSBT.
+pub const ORIGINAL_PSBT_REJECTED: &str = "original-psbt-rejected";

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -55,3 +55,6 @@ pub use bitcoin::base64;
 pub use uri::{PjParseError, PjUri, Uri, UriExt};
 #[cfg(feature = "_core")]
 pub use url::{ParseError, Url};
+
+#[cfg(feature = "_core")]
+pub(crate) mod error_codes;

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -1,6 +1,8 @@
 use std::{error, fmt};
 
-use crate::error_codes::{ORIGINAL_PSBT_REJECTED, UNAVAILABLE, VERSION_UNSUPPORTED};
+use crate::error_codes::{
+    NOT_ENOUGH_MONEY, ORIGINAL_PSBT_REJECTED, UNAVAILABLE, VERSION_UNSUPPORTED,
+};
 #[cfg(feature = "v1")]
 use crate::receive::v1;
 #[cfg(feature = "v2")]
@@ -229,7 +231,7 @@ impl JsonError for PayloadError {
             InputWeight(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
             InputSeen(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
             PsbtBelowFeeRate(_, _) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
-            FeeTooHigh(_, _) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            FeeTooHigh(_, _) => serialize_json_error(NOT_ENOUGH_MONEY, self),
         }
     }
 }

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -1,5 +1,6 @@
 use std::{error, fmt};
 
+use crate::error_codes::{ORIGINAL_PSBT_REJECTED, UNAVAILABLE, VERSION_UNSUPPORTED};
 #[cfg(feature = "v1")]
 use crate::receive::v1;
 #[cfg(feature = "v2")]
@@ -43,7 +44,7 @@ impl JsonError for Error {
     fn to_json(&self) -> String {
         match self {
             Self::Validation(e) => e.to_json(),
-            Self::Implementation(_) => serialize_json_error("unavailable", "Receiver error"),
+            Self::Implementation(_) => serialize_json_error(UNAVAILABLE, "Receiver error"),
         }
     }
 }
@@ -206,29 +207,29 @@ impl JsonError for PayloadError {
         use InternalPayloadError::*;
 
         match &self.0 {
-            Utf8(_) => serialize_json_error("original-psbt-rejected", self),
-            ParsePsbt(_) => serialize_json_error("original-psbt-rejected", self),
+            Utf8(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            ParsePsbt(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
             SenderParams(e) => match e {
                 super::optional_parameters::Error::UnknownVersion { supported_versions } => {
                     let supported_versions_json =
                         serde_json::to_string(supported_versions).unwrap_or_default();
                     serialize_json_plus_fields(
-                        "version-unsupported",
+                        VERSION_UNSUPPORTED,
                         "This version of payjoin is not supported.",
                         &format!(r#""supported": {}"#, supported_versions_json),
                     )
                 }
                 _ => serialize_json_error("sender-params-error", self),
             },
-            InconsistentPsbt(_) => serialize_json_error("original-psbt-rejected", self),
-            PrevTxOut(_) => serialize_json_error("original-psbt-rejected", self),
-            MissingPayment => serialize_json_error("original-psbt-rejected", self),
-            OriginalPsbtNotBroadcastable => serialize_json_error("original-psbt-rejected", self),
-            InputOwned(_) => serialize_json_error("original-psbt-rejected", self),
-            InputWeight(_) => serialize_json_error("original-psbt-rejected", self),
-            InputSeen(_) => serialize_json_error("original-psbt-rejected", self),
-            PsbtBelowFeeRate(_, _) => serialize_json_error("original-psbt-rejected", self),
-            FeeTooHigh(_, _) => serialize_json_error("original-psbt-rejected", self),
+            InconsistentPsbt(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            PrevTxOut(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            MissingPayment => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            OriginalPsbtNotBroadcastable => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            InputOwned(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            InputWeight(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            InputSeen(_) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            PsbtBelowFeeRate(_, _) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
+            FeeTooHigh(_, _) => serialize_json_error(ORIGINAL_PSBT_REJECTED, self),
         }
     }
 }

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -1,6 +1,6 @@
 use bitcoin::{psbt, AddressType, TxIn, TxOut};
 pub(crate) use error::InternalPayloadError;
-pub use error::{Error, OutputSubstitutionError, PayloadError, SelectionError};
+pub use error::{Error, JsonError, OutputSubstitutionError, PayloadError, SelectionError};
 
 pub use crate::psbt::PsbtInputError;
 use crate::psbt::{InternalInputPair, InternalPsbtInputError};

--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -48,11 +48,11 @@ impl JsonError for RequestError {
 
         use crate::receive::error::serialize_json_error;
         match &self.0 {
-            Io(_) => serialize_json_error("io-error", self),
-            MissingHeader(_) => serialize_json_error("missing-header", self),
-            InvalidContentType(_) => serialize_json_error("invalid-content-type", self),
-            InvalidContentLength(_) => serialize_json_error("invalid-content-length", self),
-            ContentLengthTooLarge(_) => serialize_json_error("content-length-too-large", self),
+            Io(_) => serialize_json_error("original-psbt-rejected", self),
+            MissingHeader(_) => serialize_json_error("original-psbt-rejected", self),
+            InvalidContentType(_) => serialize_json_error("original-psbt-rejected", self),
+            InvalidContentLength(_) => serialize_json_error("original-psbt-rejected", self),
+            ContentLengthTooLarge(_) => serialize_json_error("original-psbt-rejected", self),
         }
     }
 }

--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::error;
 
-use crate::receive::error::ValidationError;
+use crate::receive::error::{JsonError, ValidationError};
 
 /// Error that occurs during validation of an incoming v1 payjoin request.
 ///
@@ -42,32 +42,31 @@ impl From<InternalRequestError> for ValidationError {
     fn from(e: InternalRequestError) -> Self { ValidationError::V1(e.into()) }
 }
 
+impl JsonError for RequestError {
+    fn to_json(&self) -> String {
+        use InternalRequestError::*;
+
+        use crate::receive::error::serialize_json_error;
+        match &self.0 {
+            Io(_) => serialize_json_error("io-error", self),
+            MissingHeader(_) => serialize_json_error("missing-header", self),
+            InvalidContentType(_) => serialize_json_error("invalid-content-type", self),
+            InvalidContentLength(_) => serialize_json_error("invalid-content-length", self),
+            ContentLengthTooLarge(_) => serialize_json_error("content-length-too-large", self),
+        }
+    }
+}
+
 impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn write_error(
-            f: &mut fmt::Formatter,
-            code: &str,
-            message: impl fmt::Display,
-        ) -> fmt::Result {
-            write!(f, r#"{{ "errorCode": "{}", "message": "{}" }}"#, code, message)
-        }
-
         match &self.0 {
-            InternalRequestError::Io(e) => write_error(f, "io-error", e),
-            InternalRequestError::MissingHeader(header) =>
-                write_error(f, "missing-header", format!("Missing header: {}", header)),
-            InternalRequestError::InvalidContentType(content_type) => write_error(
-                f,
-                "invalid-content-type",
-                format!("Invalid content type: {}", content_type),
-            ),
-            InternalRequestError::InvalidContentLength(e) =>
-                write_error(f, "invalid-content-length", e),
-            InternalRequestError::ContentLengthTooLarge(length) => write_error(
-                f,
-                "content-length-too-large",
-                format!("Content length too large: {}.", length),
-            ),
+            InternalRequestError::Io(e) => write!(f, "{}", e),
+            InternalRequestError::MissingHeader(header) => write!(f, "Missing header: {}", header),
+            InternalRequestError::InvalidContentType(content_type) =>
+                write!(f, "Invalid content type: {}", content_type),
+            InternalRequestError::InvalidContentLength(e) => write!(f, "{}", e),
+            InternalRequestError::ContentLengthTooLarge(length) =>
+                write!(f, "Content length too large: {}.", length),
         }
     }
 }

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -4,6 +4,7 @@ use std::error;
 use super::Error;
 use crate::hpke::HpkeError;
 use crate::ohttp::OhttpEncapsulationError;
+use crate::receive::JsonError;
 
 /// Error that may occur during a v2 session typestate change
 ///
@@ -46,6 +47,21 @@ impl From<OhttpEncapsulationError> for Error {
 
 impl From<HpkeError> for Error {
     fn from(e: HpkeError) -> Self { InternalSessionError::Hpke(e).into() }
+}
+
+impl JsonError for SessionError {
+    fn to_json(&self) -> String {
+        use InternalSessionError::*;
+
+        use crate::receive::error::serialize_json_error;
+        match &self.0 {
+            Expired(_) => serialize_json_error("session-expired", self),
+            OhttpEncapsulation(_) => serialize_json_error("ohttp-encapsulation-error", self),
+            Hpke(_) => serialize_json_error("hpke-error", self),
+            UnexpectedResponseSize(_) => serialize_json_error("unexpected-response-size", self),
+            UnexpectedStatusCode(_) => serialize_json_error("unexpected-status-code", self),
+        }
+    }
 }
 
 impl fmt::Display for SessionError {

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use super::error::InputContributionError;
-use super::{v1, Error, InternalPayloadError, OutputSubstitutionError, SelectionError};
+use super::{v1, Error, InternalPayloadError, JsonError, OutputSubstitutionError, SelectionError};
 use crate::hpke::{decrypt_message_a, encrypt_message_b, HpkeKeyPair, HpkePublicKey};
 use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate, OhttpEncapsulationError, OhttpKeys};
 use crate::psbt::PsbtExt;
@@ -615,7 +615,7 @@ mod test {
             .unwrap();
         assert_eq!(
             server_error.to_json(),
-            "{{ \"errorCode\": \"unavailable\", \"message\": \"Receiver error\" }}"
+            r#"{ "errorCode": "unavailable", "message": "Receiver error" }"#
         );
         let (_req, _ctx) = proposal.clone().extract_err_req(&server_error, &EXAMPLE_OHTTP_RELAY)?;
 


### PR DESCRIPTION
- [Isolate receive::JsonError from fmt::Display](https://github.com/payjoin/rust-payjoin/commit/ffe6281f675c3f2874420b995076489956720251)
- [Reject bad v1 requests as original-psbt-rejected](https://github.com/payjoin/rust-payjoin/commit/9a323ef9eb7d97e583f718bc5fcf4258767fcbc3) since that's the only way v1 senders can really address their issue. It's a payload error but that's the same as Original PSBT [payload] in BIP 78 parlance.

This change could also introduce `const` values for well known error codes for both `send` and `receive` to share to prevent slipped typos during maintenance.

In reviewing the error types for v2, I realize we may want to introduce new well-known error types for the `SessionError` variants. In particular, `Expired` should have a template string to return to sender clients. One other variants seems to approximately fit `original-psbt-rejected` payload errors (Hpke), but UnexpectedResponseSize, OhttpEncapsulation, and UnexpectedStatusCode appear to be directory issues that are unrecoverable and cannot return json to a sender.

Seems like feerate configuration errors are also a special class of recoverable original-psbt-rejected error that might be worth classifying to potentially handle by clever senders.

related: #403 