### PR TITLE
Remove unwrap() in integration/e2e tests

### DIFF
--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -151,8 +151,8 @@ mod e2e {
         let receiver_db_path = temp_dir.join("receiver_db");
         let sender_db_path = temp_dir.join("sender_db");
         let result: Result<()> = tokio::select! {
-            res = services.take_ohttp_relay_handle().unwrap() => Err(format!("Ohttp relay is long running: {:?}", res).into()),
-            res = services.take_directory_handle().unwrap() => Err(format!("Directory server is long running: {:?}", res).into()),
+            res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {:?}", res).into()),
+            res = services.take_directory_handle() => Err(format!("Directory server is long running: {:?}", res).into()),
             res = send_receive_cli_async(&services, receiver_db_path.clone(), sender_db_path.clone()) => res.map_err(|e| format!("send_receive failed: {:?}", e).into()),
         };
 

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -137,7 +137,7 @@ mod e2e {
 
     #[cfg(feature = "v2")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn send_receive_payjoin() {
+    async fn send_receive_payjoin() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use std::path::PathBuf;
 
         use payjoin_test_utils::{init_tracing, BoxError, TestServices};
@@ -146,7 +146,7 @@ mod e2e {
         type Result<T> = std::result::Result<T, BoxError>;
 
         init_tracing();
-        let mut services = TestServices::initialize().await.unwrap();
+        let mut services = TestServices::initialize().await?;
         let temp_dir = env::temp_dir();
         let receiver_db_path = temp_dir.join("receiver_db");
         let sender_db_path = temp_dir.join("sender_db");
@@ -382,6 +382,8 @@ mod e2e {
             assert!(payjoin_sent.unwrap_or(false), "Payjoin send was not detected");
             Ok(())
         }
+
+        Ok(())
     }
 
     async fn cleanup_temp_file(path: &std::path::Path) {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -82,10 +82,10 @@ mod integration {
             // Inside the Sender:
             // Sender create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
             let uri = Uri::from_str(&pj_uri.to_string())
-                .unwrap()
+                .map_err(|e| e.to_string())?
                 .assume_checked()
                 .check_pj_supported()
-                .unwrap();
+                .map_err(|e| e.to_string())?;
             let psbt = build_original_psbt(&sender, &uri)?;
             debug!("Original psbt: {:#?}", psbt);
             let (req, ctx) = SenderBuilder::new(psbt, uri)
@@ -146,10 +146,10 @@ mod integration {
             // Inside the Sender:
             // Sender create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
             let uri = Uri::from_str(&pj_uri.to_string())
-                .unwrap()
+                .map_err(|e| e.to_string())?
                 .assume_checked()
                 .check_pj_supported()
-                .unwrap();
+                .map_err(|e| e.to_string())?;
             let psbt = build_original_psbt(&sender, &uri)?;
             debug!("Original psbt: {:#?}", psbt);
             let (req, _ctx) = SenderBuilder::new(psbt, uri)
@@ -287,7 +287,6 @@ mod integration {
                 let mut session =
                     Receiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None);
                 println!("session: {:#?}", &session);
-                let pj_uri_string = session.pj_uri().to_string();
                 // Poll receive request
                 let mock_ohttp_relay = directory.clone();
                 let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
@@ -301,11 +300,11 @@ mod integration {
                 // **********************
                 // Inside the Sender:
                 // Create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
-                let pj_uri = Uri::from_str(&pj_uri_string)
-                    .unwrap()
+                let pj_uri = Uri::from_str(&session.pj_uri().to_string())
+                    .map_err(|e| e.to_string())?
                     .assume_checked()
                     .check_pj_supported()
-                    .unwrap();
+                    .map_err(|e| e.to_string())?;
                 let psbt = build_sweep_psbt(&sender, &pj_uri)?;
                 let req_ctx = SenderBuilder::new(psbt.clone(), pj_uri.clone())
                     .build_recommended(FeeRate::BROADCAST_MIN)?;
@@ -390,10 +389,10 @@ mod integration {
             // Inside the Sender:
             // Create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
             let pj_uri = Uri::from_str(&pj_uri.to_string())
-                .unwrap()
+                .map_err(|e| e.to_string())?
                 .assume_checked()
                 .check_pj_supported()
-                .unwrap();
+                .map_err(|e| e.to_string())?;
             let psbt = build_original_psbt(&sender, &pj_uri)?;
             let req_ctx = SenderBuilder::new(psbt.clone(), pj_uri.clone())
                 .build_recommended(FeeRate::BROADCAST_MIN)?;
@@ -446,16 +445,14 @@ mod integration {
                 let mut session =
                     Receiver::new(address, directory.clone(), ohttp_keys.clone(), None);
 
-                let pj_uri_string = session.pj_uri().to_string();
-
                 // **********************
                 // Inside the V1 Sender:
                 // Create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
-                let pj_uri = Uri::from_str(&pj_uri_string)
-                    .unwrap()
+                let pj_uri = Uri::from_str(&session.pj_uri().to_string())
+                    .map_err(|e| e.to_string())?
                     .assume_checked()
                     .check_pj_supported()
-                    .unwrap();
+                    .map_err(|e| e.to_string())?;
                 let psbt = build_original_psbt(&sender, &pj_uri)?;
                 let (Request { url, body, content_type, .. }, send_ctx) =
                     SenderBuilder::new(psbt, pj_uri)
@@ -691,10 +688,10 @@ mod integration {
             // Inside the Sender:
             // Sender create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
             let uri = Uri::from_str(&pj_uri.to_string())
-                .unwrap()
+                .map_err(|e| e.to_string())?
                 .assume_checked()
                 .check_pj_supported()
-                .unwrap();
+                .map_err(|e| e.to_string())?;
             let psbt = build_original_psbt(&sender, &uri)?;
             log::debug!("Original psbt: {:#?}", psbt);
             let max_additional_fee = Amount::from_sat(1000);
@@ -768,10 +765,10 @@ mod integration {
             // Inside the Sender:
             // Sender create a funded PSBT (not broadcasted) to address with amount given in the pj_uri
             let uri = Uri::from_str(&pj_uri.to_string())
-                .unwrap()
+                .map_err(|e| e.to_string())?
                 .assume_checked()
                 .check_pj_supported()
-                .unwrap();
+                .map_err(|e| e.to_string())?;
             let psbt = build_original_psbt(&sender, &uri)?;
             log::debug!("Original psbt: {:#?}", psbt);
             let (req, ctx) = SenderBuilder::new(psbt.clone(), uri)

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -187,7 +187,7 @@ mod integration {
                     .expect("Invalid OhttpKeys");
             let mut services = TestServices::initialize().await?;
             tokio::select!(
-            err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
+            err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
                 res = try_request_with_bad_keys(&services, bad_ohttp_keys) => {
                     assert_eq!(
                         res.unwrap().headers().get("content-type").unwrap(),
@@ -223,8 +223,8 @@ mod integration {
             init_tracing();
             let mut services = TestServices::initialize().await?;
             tokio::select!(
-            err = services.take_ohttp_relay_handle().unwrap() => panic!("Ohttp relay exited early: {:?}", err),
-            err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
+            err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
+            err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
             res = do_expiration_tests(&services) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
             );
 
@@ -272,8 +272,8 @@ mod integration {
             init_tracing();
             let mut services = TestServices::initialize().await?;
             tokio::select!(
-            err = services.take_ohttp_relay_handle().unwrap() => panic!("Ohttp relay exited early: {:?}", err),
-            err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
+            err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
+            err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
             res = do_v2_send_receive(&services) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
             );
 
@@ -435,8 +435,8 @@ mod integration {
             init_tracing();
             let mut services = TestServices::initialize().await?;
             tokio::select!(
-            err = services.take_ohttp_relay_handle().unwrap() => panic!("Ohttp relay exited early: {:?}", err),
-            err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
+            err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
+            err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
             res = do_v1_to_v2(&services) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
             );
 

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -175,17 +175,17 @@ mod integration {
         use payjoin::receive::v2::{PayjoinProposal, Receiver, UncheckedProposal};
         use payjoin::send::v2::SenderBuilder;
         use payjoin::{OhttpKeys, PjUri, UriExt};
-        use payjoin_test_utils::TestServices;
+        use payjoin_test_utils::{BoxSendSyncError, TestServices};
         use reqwest::{Client, Error, Response};
 
         use super::*;
 
         #[tokio::test]
-        async fn test_bad_ohttp_keys() {
+        async fn test_bad_ohttp_keys() -> Result<(), BoxSendSyncError> {
             let bad_ohttp_keys =
                 OhttpKeys::from_str("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC")
                     .expect("Invalid OhttpKeys");
-            let mut services = TestServices::initialize().await.unwrap();
+            let mut services = TestServices::initialize().await?;
             tokio::select!(
             err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
                 res = try_request_with_bad_keys(&services, bad_ohttp_keys) => {
@@ -214,12 +214,14 @@ mod integration {
                     .expect("Failed to extract request");
                 agent.post(req.url).body(req.body).send().await
             }
+
+            Ok(())
         }
 
         #[tokio::test]
-        async fn test_session_expiration() {
+        async fn test_session_expiration() -> Result<(), BoxSendSyncError> {
             init_tracing();
-            let mut services = TestServices::initialize().await.unwrap();
+            let mut services = TestServices::initialize().await?;
             tokio::select!(
             err = services.take_ohttp_relay_handle().unwrap() => panic!("Ohttp relay exited early: {:?}", err),
             err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
@@ -261,12 +263,14 @@ mod integration {
                 };
                 Ok(())
             }
+
+            Ok(())
         }
 
         #[tokio::test]
-        async fn v2_to_v2() {
+        async fn v2_to_v2() -> Result<(), BoxSendSyncError> {
             init_tracing();
-            let mut services = TestServices::initialize().await.unwrap();
+            let mut services = TestServices::initialize().await?;
             tokio::select!(
             err = services.take_ohttp_relay_handle().unwrap() => panic!("Ohttp relay exited early: {:?}", err),
             err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
@@ -374,6 +378,8 @@ mod integration {
                 assert_eq!(sender.get_balances()?.mine.untrusted_pending, Amount::from_btc(0.0)?);
                 Ok(())
             }
+
+            Ok(())
         }
 
         #[test]
@@ -425,9 +431,9 @@ mod integration {
         }
 
         #[tokio::test]
-        async fn v1_to_v2() {
+        async fn v1_to_v2() -> Result<(), BoxSendSyncError> {
             init_tracing();
-            let mut services = TestServices::initialize().await.unwrap();
+            let mut services = TestServices::initialize().await?;
             tokio::select!(
             err = services.take_ohttp_relay_handle().unwrap() => panic!("Ohttp relay exited early: {:?}", err),
             err = services.take_directory_handle().unwrap() => panic!("Directory server exited early: {:?}", err),
@@ -543,6 +549,8 @@ mod integration {
                 );
                 Ok(())
             }
+
+            Ok(())
         }
 
         fn handle_directory_proposal(


### PR DESCRIPTION
Partially address https://github.com/payjoin/rust-payjoin/issues/487.

There are other places to clean up, notably unit tests, that can be addressed in later PRs.

The commit messages might be a little repetitive but I wanted to keep each commit bite-sized for easier review. I can squash them if preferred.
