### PR TITLE
add bitcoind to devshell, and setenv BITCOIND_EXE

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,8 @@
               ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
                 cargo-llvm-cov
               ];
+            BITCOIND_EXE = pkgs.lib.getExe' pkgs.bitcoind "bitcoind";
+            BITCOIND_SKIP_DOWNLOAD = 1;
           }
         ) craneLibVersions;
 


### PR DESCRIPTION
This change supplies bitcoind from nixpkgs, and sets `BITCOIND_EXE` to its full path, for more convenient testing.

`BITCOIND_SKIP_DOWNLOAD` is also set, although that's only actually required in sandboxed builds.

Note that this decouples the bitcoind version from that set in the feature flags of the bitcoind crate, with the default version from `nixpkgs` being selected and locked in the flake.lock file. I haven't had any problems with it, and ideally tests should pass with all versions.

Also fixes formatting with `nix fmt`, which I forgot in the cargo-llvm-cov PR.