### PR TITLE
Validate_utxo treats missing utxos as an error

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -28,7 +28,7 @@ impl InputPair {
     pub fn new(txin: TxIn, psbtin: psbt::Input) -> Result<Self, PsbtInputError> {
         let input_pair = Self { txin, psbtin };
         let raw = InternalInputPair::from(&input_pair);
-        raw.validate_utxo(true)?;
+        raw.validate_utxo()?;
         let address_type = raw.address_type().map_err(InternalPsbtInputError::AddressType)?;
         if address_type == AddressType::P2sh && input_pair.psbtin.redeem_script.is_none() {
             return Err(InternalPsbtInputError::NoRedeemScript.into());

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -183,7 +183,7 @@ impl<'a> SenderBuilder<'a> {
     fn build(self) -> Result<Sender, BuildSenderError> {
         let mut psbt =
             self.psbt.validate().map_err(InternalBuildSenderError::InconsistentOriginalPsbt)?;
-        psbt.validate_input_utxos(true).map_err(InternalBuildSenderError::InvalidOriginalInput)?;
+        psbt.validate_input_utxos().map_err(InternalBuildSenderError::InvalidOriginalInput)?;
         let endpoint = self.uri.extras.endpoint.clone();
         let disable_output_substitution =
             self.uri.extras.disable_output_substitution || self.disable_output_substitution;


### PR DESCRIPTION
Missing utxo information should always be treated as an error, the flag we had also was always set to true so its seems not helpful to create a function arg to always be set to true.

This Pr is practice to figure out if I am doing commit messages and commit tests correctly