### PR TITLE
Cleanup test assertions

### DIFF
--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -152,15 +152,15 @@ mod e2e {
         let temp_dir = env::temp_dir();
         let receiver_db_path = temp_dir.join("receiver_db");
         let sender_db_path = temp_dir.join("sender_db");
-        let result: Result<()> = tokio::select! {
+        let result = tokio::select! {
             res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {:?}", res).into()),
             res = services.take_directory_handle() => Err(format!("Directory server is long running: {:?}", res).into()),
-            res = send_receive_cli_async(&services, receiver_db_path.clone(), sender_db_path.clone()) => res.map_err(|e| format!("send_receive failed: {:?}", e).into()),
+            res = send_receive_cli_async(&services, receiver_db_path.clone(), sender_db_path.clone()) => res,
         };
 
         cleanup_temp_file(&receiver_db_path).await;
         cleanup_temp_file(&sender_db_path).await;
-        assert!(result.is_ok(), "{}", result.unwrap_err());
+        assert!(result.is_ok(), "send_receive failed: {:#?}", result.unwrap_err());
 
         async fn send_receive_cli_async(
             services: &TestServices,

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -187,14 +187,14 @@ mod integration {
                 OhttpKeys::from_str("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC")
                     .expect("Invalid OhttpKeys");
             let mut services = TestServices::initialize().await?;
-            tokio::select!(
+            let result = tokio::select!(
             err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
-                res = try_request_with_bad_keys(&services, bad_ohttp_keys) => {
-                    assert_eq!(
-                        res?.headers().get("content-type").expect("content type should be present"),
-                        "application/problem+json"
-                    );
-                }
+            res = try_request_with_bad_keys(&services, bad_ohttp_keys) => res
+            );
+
+            assert_eq!(
+                result?.headers().get("content-type").expect("content type should be present"),
+                "application/problem+json"
             );
 
             async fn try_request_with_bad_keys(
@@ -220,11 +220,13 @@ mod integration {
         async fn test_session_expiration() -> Result<(), BoxSendSyncError> {
             init_tracing();
             let mut services = TestServices::initialize().await?;
-            tokio::select!(
+            let result = tokio::select!(
             err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
             err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
-            res = do_expiration_tests(&services) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
+            res = do_expiration_tests(&services) => res
             );
+
+            assert!(result.is_ok(), "v2 send receive failed: {:#?}", result.unwrap_err());
 
             async fn do_expiration_tests(services: &TestServices) -> Result<(), BoxError> {
                 let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
@@ -269,11 +271,13 @@ mod integration {
         async fn v2_to_v2() -> Result<(), BoxSendSyncError> {
             init_tracing();
             let mut services = TestServices::initialize().await?;
-            tokio::select!(
+            let result = tokio::select!(
             err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
             err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
-            res = do_v2_send_receive(&services) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
+            res = do_v2_send_receive(&services) => res
             );
+
+            assert!(result.is_ok(), "v2 send receive failed: {:#?}", result.unwrap_err());
 
             async fn do_v2_send_receive(services: &TestServices) -> Result<(), BoxError> {
                 let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
@@ -432,11 +436,13 @@ mod integration {
         async fn v1_to_v2() -> Result<(), BoxSendSyncError> {
             init_tracing();
             let mut services = TestServices::initialize().await?;
-            tokio::select!(
+            let result = tokio::select!(
             err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
             err = services.take_directory_handle() => panic!("Directory server exited early: {:?}", err),
-            res = do_v1_to_v2(&services) => assert!(res.is_ok(), "v2 send receive failed: {:#?}", res)
+            res = do_v1_to_v2(&services) => res
             );
+
+            assert!(result.is_ok(), "v2 send receive failed: {:#?}", result.unwrap_err());
 
             async fn do_v1_to_v2(services: &TestServices) -> Result<(), BoxError> {
                 let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -293,7 +293,7 @@ mod integration {
                 let mock_ohttp_relay = directory.clone();
                 let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
                 let response = agent.post(req.url).body(req.body).send().await?;
-                assert!(response.status().is_success());
+                assert!(response.status().is_success(), "error response: {}", response.status());
                 let response_body =
                     session.process_res(response.bytes().await?.to_vec().as_slice(), ctx)?;
                 // No proposal yet since sender has not responded
@@ -319,7 +319,7 @@ mod integration {
                     .send()
                     .await?;
                 log::info!("Response: {:#?}", &response);
-                assert!(response.status().is_success());
+                assert!(response.status().is_success(), "error response: {}", response.status());
                 let send_ctx = send_ctx.process_response(&response.bytes().await?)?;
                 // POST Original PSBT
 
@@ -523,7 +523,7 @@ mod integration {
                 let response =
                     agent.post(url).header("Content-Type", content_type).body(body).send().await?;
                 log::info!("Response: {:#?}", &response);
-                assert!(response.status().is_success());
+                assert!(response.status().is_success(), "error response: {}", response.status());
 
                 let res = response.bytes().await?.to_vec();
                 let checked_payjoin_proposal_psbt =


### PR DESCRIPTION
The first commit aims to fix https://github.com/payjoin/rust-payjoin/issues/421 - @nothingmuch is this close to what you had in mind?

The second commit mostly just improves legibility on integration/e2e test assertions.