### PR TITLE
Refactor new Request impls to use reference types in the signature

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -104,7 +104,7 @@ impl Receiver {
         let (body, ohttp_ctx) =
             self.fallback_req_body().map_err(InternalSessionError::OhttpEncapsulation)?;
         let url = ohttp_relay.clone();
-        let req = Request::new_v2(url, body);
+        let req = Request::new_v2(&url, &body);
         Ok((req, ohttp_ctx))
     }
 
@@ -267,7 +267,7 @@ impl UncheckedProposal {
         )
         .map_err(InternalSessionError::OhttpEncapsulation)?;
 
-        let req = Request::new_v2(ohttp_relay.clone(), body);
+        let req = Request::new_v2(ohttp_relay, &body);
         Ok((req, ohttp_ctx))
     }
 
@@ -521,7 +521,7 @@ impl PayjoinProposal {
             target_resource.as_str(),
             Some(&body),
         )?;
-        let req = Request::new_v2(ohttp_relay.clone(), body);
+        let req = Request::new_v2(ohttp_relay, &body);
         Ok((req, ctx))
     }
 

--- a/payjoin/src/request.rs
+++ b/payjoin/src/request.rs
@@ -28,16 +28,16 @@ pub struct Request {
 
 impl Request {
     /// Construct a new v1 request.
-    pub(crate) fn new_v1(url: Url, body: Vec<u8>) -> Self {
-        Self { url, content_type: V1_REQ_CONTENT_TYPE, body }
+    pub(crate) fn new_v1(url: &Url, body: &[u8]) -> Self {
+        Self { url: url.clone(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 
     /// Construct a new v2 request.
     #[cfg(feature = "v2")]
     pub(crate) fn new_v2(
-        url: Url,
-        body: [u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES],
+        url: &Url,
+        body: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES],
     ) -> Self {
-        Self { url, content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
+        Self { url: url.clone(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 }

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -237,7 +237,7 @@ impl Sender {
         )?;
         let body = self.psbt.to_string().as_bytes().to_vec();
         Ok((
-            Request::new_v1(url, body),
+            Request::new_v1(&url, &body),
             V1Context {
                 psbt_context: PsbtContext {
                     original_psbt: self.psbt.clone(),

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -168,7 +168,7 @@ impl Sender {
             .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
         log::debug!("ohttp_relay_url: {:?}", ohttp_relay);
         Ok((
-            Request::new_v2(ohttp_relay, body),
+            Request::new_v2(&ohttp_relay, &body),
             V2PostContext {
                 endpoint: self.v1.endpoint.clone(),
                 psbt_ctx: PsbtContext {
@@ -273,7 +273,7 @@ impl V2GetContext {
         let (body, ohttp_ctx) = ohttp_encapsulate(&mut ohttp, "GET", url.as_str(), Some(&body))
             .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
 
-        Ok((Request::new_v2(ohttp_relay, body), ohttp_ctx))
+        Ok((Request::new_v2(&ohttp_relay, &body), ohttp_ctx))
     }
 
     pub fn process_response(


### PR DESCRIPTION
We don't need to pass ownership of the URL or the body in the creation of a new request so lets just use references instead!

(Here's hoping my my commits are a little nicer to looks at) :crossed_fingers: 