### PR TITLE
Only derive JsonError for errors that can return Json

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -16,7 +16,7 @@ use hyper_util::rt::TokioIo;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::{self, FeeRate};
 use payjoin::receive::v1::{PayjoinProposal, UncheckedProposal};
-use payjoin::receive::Error;
+use payjoin::receive::ReplyableError::{self, Implementation, V1};
 use payjoin::send::v1::SenderBuilder;
 use payjoin::{Uri, UriExt};
 use tokio::net::TcpListener;
@@ -225,7 +225,7 @@ impl App {
                 .handle_payjoin_post(req)
                 .await
                 .map_err(|e| match e {
-                    Error::Validation(e) => {
+                    V1(e) => {
                         log::error!("Error handling request: {}", e);
                         Response::builder().status(400).body(full(e.to_string())).unwrap()
                     }
@@ -246,12 +246,12 @@ impl App {
     fn handle_get_bip21(
         &self,
         amount: Option<Amount>,
-    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error> {
+    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, ReplyableError> {
         let address = self
             .bitcoind()
-            .map_err(|e| Error::Implementation(e.into()))?
+            .map_err(|e| Implementation(e.into()))?
             .get_new_address(None, None)
-            .map_err(|e| Error::Implementation(e.into()))?
+            .map_err(|e| Implementation(e.into()))?
             .assume_checked();
         let uri_string = if let Some(amount) = amount {
             format!(
@@ -263,9 +263,8 @@ impl App {
         } else {
             format!("{}?pj={}", address.to_qr_uri(), self.config.pj_endpoint)
         };
-        let uri = Uri::try_from(uri_string.clone()).map_err(|_| {
-            Error::Implementation(anyhow!("Could not parse payjoin URI string.").into())
-        })?;
+        let uri = Uri::try_from(uri_string.clone())
+            .map_err(|_| Implementation(anyhow!("Could not parse payjoin URI string.").into()))?;
         let _ = uri.assume_checked(); // we just got it from bitcoind above
 
         Ok(Response::new(full(uri_string)))
@@ -274,12 +273,11 @@ impl App {
     async fn handle_payjoin_post(
         &self,
         req: Request<Incoming>,
-    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error> {
+    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, ReplyableError> {
         let (parts, body) = req.into_parts();
         let headers = Headers(&parts.headers);
         let query_string = parts.uri.query().unwrap_or("");
-        let body =
-            body.collect().await.map_err(|e| Error::Implementation(e.into()))?.aggregate().reader();
+        let body = body.collect().await.map_err(|e| Implementation(e.into()))?.aggregate().reader();
         let proposal = UncheckedProposal::from_request(body, query_string, headers)?;
 
         let payjoin_proposal = self.process_v1_proposal(proposal)?;
@@ -292,25 +290,26 @@ impl App {
         Ok(Response::new(full(body)))
     }
 
-    fn process_v1_proposal(&self, proposal: UncheckedProposal) -> Result<PayjoinProposal, Error> {
-        let bitcoind = self.bitcoind().map_err(|e| Error::Implementation(e.into()))?;
+    fn process_v1_proposal(
+        &self,
+        proposal: UncheckedProposal,
+    ) -> Result<PayjoinProposal, ReplyableError> {
+        let bitcoind = self.bitcoind().map_err(|e| Implementation(e.into()))?;
 
         // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network =
-            bitcoind.get_blockchain_info().map_err(|e| Error::Implementation(e.into()))?.chain;
+        let network = bitcoind.get_blockchain_info().map_err(|e| Implementation(e.into()))?.chain;
 
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
-            let mempool_results = bitcoind
-                .test_mempool_accept(&[raw_tx])
-                .map_err(|e| Error::Implementation(e.into()))?;
+            let mempool_results =
+                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Implementation(e.into()))?;
             match mempool_results.first() {
                 Some(result) => Ok(result.allowed),
-                None => Err(Error::Implementation(
+                None => Err(Implementation(
                     anyhow!("No mempool results returned on broadcast check").into(),
                 )),
             }
@@ -323,7 +322,7 @@ impl App {
                 bitcoind
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Error::Implementation(e.into()))
+                    .map_err(|e| Implementation(e.into()))
             } else {
                 Ok(false)
             }
@@ -332,7 +331,7 @@ impl App {
 
         // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
         let payjoin = proposal.check_no_inputs_seen_before(|input| {
-            self.db.insert_input_seen_before(*input).map_err(|e| Error::Implementation(e.into()))
+            self.db.insert_input_seen_before(*input).map_err(|e| Implementation(e.into()))
         })?;
         log::trace!("check3");
 
@@ -341,7 +340,7 @@ impl App {
                 bitcoind
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Error::Implementation(e.into()))
+                    .map_err(|e| Implementation(e.into()))
             } else {
                 Ok(false)
             }
@@ -351,12 +350,12 @@ impl App {
             .substitute_receiver_script(
                 &bitcoind
                     .get_new_address(None, None)
-                    .map_err(|e| Error::Implementation(e.into()))?
+                    .map_err(|e| Implementation(e.into()))?
                     .require_network(network)
-                    .map_err(|e| Error::Implementation(e.into()))?
+                    .map_err(|e| Implementation(e.into()))?
                     .script_pubkey(),
             )
-            .map_err(|e| Error::Implementation(e.into()))?
+            .map_err(|e| Implementation(e.into()))?
             .commit_outputs();
 
         let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &bitcoind)
@@ -369,10 +368,8 @@ impl App {
             |psbt: &Psbt| {
                 bitcoind
                     .wallet_process_psbt(&psbt.to_string(), None, None, Some(false))
-                    .map(|res| {
-                        Psbt::from_str(&res.psbt).map_err(|e| Error::Implementation(e.into()))
-                    })
-                    .map_err(|e| Error::Implementation(e.into()))?
+                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Implementation(e.into())))
+                    .map_err(|e| Implementation(e.into()))?
             },
             None,
             self.config.max_fee_rate,

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -7,8 +7,7 @@ use payjoin::bitcoin::consensus::encode::serialize_hex;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::{Amount, FeeRate};
 use payjoin::receive::v2::{Receiver, UncheckedProposal};
-use payjoin::receive::ReplyableError::Implementation;
-use payjoin::receive::{Error, ReplyableError};
+use payjoin::receive::{Error, ImplementationError, ReplyableError};
 use payjoin::send::v2::{Sender, SenderBuilder};
 use payjoin::{bitcoin, Uri};
 use tokio::signal;
@@ -254,25 +253,29 @@ impl App {
         &self,
         proposal: payjoin::receive::v2::UncheckedProposal,
     ) -> Result<payjoin::receive::v2::PayjoinProposal, Error> {
-        let bitcoind = self.bitcoind().map_err(|e| Implementation(e.into()))?;
+        let bitcoind = self.bitcoind().map_err(|e| ReplyableError::Implementation(e.into()))?;
 
         // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // The network is used for checks later
-        let network = bitcoind.get_blockchain_info().map_err(|e| Implementation(e.into()))?.chain;
+        let network = bitcoind
+            .get_blockchain_info()
+            .map_err(|e| ReplyableError::Implementation(e.into()))?
+            .chain;
         // Receive Check 1: Can Broadcast
-        let proposal = proposal.check_broadcast_suitability(None, |tx| {
-            let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
-            let mempool_results =
-                bitcoind.test_mempool_accept(&[raw_tx]).map_err(|e| Implementation(e.into()))?;
-            match mempool_results.first() {
-                Some(result) => Ok(result.allowed),
-                None => Err(Implementation(
-                    anyhow!("No mempool results returned on broadcast check").into(),
-                )),
-            }
-        })?;
+        let proposal =
+            proposal.check_broadcast_suitability(None, |tx| {
+                let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
+                let mempool_results =
+                    bitcoind.test_mempool_accept(&[raw_tx]).map_err(ImplementationError::from)?;
+                match mempool_results.first() {
+                    Some(result) => Ok(result.allowed),
+                    None => Err(ImplementationError::from(
+                        "No mempool results returned on broadcast check",
+                    )),
+                }
+            })?;
         log::trace!("check1");
 
         // Receive Check 2: receiver can't sign for proposal inputs
@@ -281,7 +284,7 @@ impl App {
                 bitcoind
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Implementation(e.into()))
+                    .map_err(ImplementationError::from)
             } else {
                 Ok(false)
             }
@@ -290,7 +293,7 @@ impl App {
 
         // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
         let payjoin = proposal.check_no_inputs_seen_before(|input| {
-            self.db.insert_input_seen_before(*input).map_err(|e| Implementation(e.into()))
+            self.db.insert_input_seen_before(*input).map_err(ImplementationError::from)
         })?;
         log::trace!("check3");
 
@@ -300,7 +303,7 @@ impl App {
                     bitcoind
                         .get_address_info(&address)
                         .map(|info| info.is_mine.unwrap_or(false))
-                        .map_err(|e| Implementation(e.into()))
+                        .map_err(ImplementationError::from)
                 } else {
                     Ok(false)
                 }
@@ -315,10 +318,10 @@ impl App {
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {
-                bitcoind
+                let res = bitcoind
                     .wallet_process_psbt(&psbt.to_string(), None, None, Some(false))
-                    .map(|res| Psbt::from_str(&res.psbt).map_err(|e| Implementation(e.into())))
-                    .map_err(|e| Implementation(e.into()))?
+                    .map_err(ImplementationError::from)?;
+                Psbt::from_str(&res.psbt).map_err(ImplementationError::from)
             },
             None,
             self.config.max_fee_rate,

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -4,6 +4,8 @@ use crate::error_codes::{
     NOT_ENOUGH_MONEY, ORIGINAL_PSBT_REJECTED, UNAVAILABLE, VERSION_UNSUPPORTED,
 };
 
+pub type ImplementationError = Box<dyn error::Error + Send + Sync>;
+
 /// The top-level error type for the payjoin receiver
 #[derive(Debug)]
 #[non_exhaustive]
@@ -57,7 +59,7 @@ pub enum ReplyableError {
     /// Error arising due to the specific receiver implementation
     ///
     /// e.g. database errors, network failures, wallet errors
-    Implementation(Box<dyn error::Error + Send + Sync>),
+    Implementation(ImplementationError),
 }
 
 /// A trait for errors that can be serialized to JSON in a standardized format.

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -13,7 +13,9 @@ use std::str::FromStr;
 
 use bitcoin::{psbt, AddressType, Psbt, TxIn, TxOut};
 pub(crate) use error::InternalPayloadError;
-pub use error::{Error, JsonError, OutputSubstitutionError, PayloadError, SelectionError};
+pub use error::{
+    Error, JsonError, OutputSubstitutionError, PayloadError, ReplyableError, SelectionError,
+};
 use optional_parameters::Params;
 
 pub use crate::psbt::PsbtInputError;

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -14,7 +14,8 @@ use std::str::FromStr;
 use bitcoin::{psbt, AddressType, Psbt, TxIn, TxOut};
 pub(crate) use error::InternalPayloadError;
 pub use error::{
-    Error, JsonError, OutputSubstitutionError, PayloadError, ReplyableError, SelectionError,
+    Error, ImplementationError, JsonError, OutputSubstitutionError, PayloadError, ReplyableError,
+    SelectionError,
 };
 use optional_parameters::Params;
 

--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -27,7 +27,7 @@ pub(crate) enum InternalRequestError {
     /// The Content-Length header could not be parsed as a number
     InvalidContentLength(std::num::ParseIntError),
     /// The Content-Length value exceeds the maximum allowed size
-    ContentLengthTooLarge(u64),
+    ContentLengthTooLarge(usize),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::error;
 
-use crate::receive::error::{JsonError, ValidationError};
+use crate::receive::error::JsonError;
 
 /// Error that occurs during validation of an incoming v1 payjoin request.
 ///
@@ -34,12 +34,8 @@ impl From<InternalRequestError> for RequestError {
     fn from(value: InternalRequestError) -> Self { RequestError(value) }
 }
 
-impl From<InternalRequestError> for super::Error {
-    fn from(e: InternalRequestError) -> Self { super::Error::Validation(e.into()) }
-}
-
-impl From<InternalRequestError> for ValidationError {
-    fn from(e: InternalRequestError) -> Self { ValidationError::V1(e.into()) }
+impl From<InternalRequestError> for super::ReplyableError {
+    fn from(e: InternalRequestError) -> Self { super::ReplyableError::V1(e.into()) }
 }
 
 impl JsonError for RequestError {

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -36,7 +36,9 @@ use super::error::{
     InternalSelectionError,
 };
 use super::optional_parameters::Params;
-use super::{InputPair, OutputSubstitutionError, ReplyableError, SelectionError};
+use super::{
+    ImplementationError, InputPair, OutputSubstitutionError, ReplyableError, SelectionError,
+};
 use crate::psbt::PsbtExt;
 use crate::receive::InternalPayloadError;
 
@@ -91,7 +93,7 @@ impl UncheckedProposal {
     pub fn check_broadcast_suitability(
         self,
         min_fee_rate: Option<FeeRate>,
-        can_broadcast: impl Fn(&bitcoin::Transaction) -> Result<bool, ReplyableError>,
+        can_broadcast: impl Fn(&bitcoin::Transaction) -> Result<bool, ImplementationError>,
     ) -> Result<MaybeInputsOwned, ReplyableError> {
         let original_psbt_fee_rate = self.psbt_fee_rate()?;
         if let Some(min_fee_rate) = min_fee_rate {
@@ -103,7 +105,9 @@ impl UncheckedProposal {
                 .into());
             }
         }
-        if can_broadcast(&self.psbt.clone().extract_tx_unchecked_fee_rate())? {
+        if can_broadcast(&self.psbt.clone().extract_tx_unchecked_fee_rate())
+            .map_err(ReplyableError::Implementation)?
+        {
             Ok(MaybeInputsOwned { psbt: self.psbt, params: self.params })
         } else {
             Err(InternalPayloadError::OriginalPsbtNotBroadcastable.into())
@@ -136,7 +140,7 @@ impl MaybeInputsOwned {
     /// An attacker could try to spend receiver's own inputs. This check prevents that.
     pub fn check_inputs_not_owned(
         self,
-        is_owned: impl Fn(&Script) -> Result<bool, ReplyableError>,
+        is_owned: impl Fn(&Script) -> Result<bool, ImplementationError>,
     ) -> Result<MaybeInputsSeen, ReplyableError> {
         let mut err: Result<(), ReplyableError> = Ok(());
         if let Some(e) = self
@@ -152,7 +156,7 @@ impl MaybeInputsOwned {
             .find_map(|script| match is_owned(&script) {
                 Ok(false) => None,
                 Ok(true) => Some(InternalPayloadError::InputOwned(script).into()),
-                Err(e) => Some(ReplyableError::Implementation(e.into())),
+                Err(e) => Some(ReplyableError::Implementation(e)),
             })
         {
             return Err(e);
@@ -177,7 +181,7 @@ impl MaybeInputsSeen {
     /// proposes a Payjoin PSBT as a new Original PSBT for a new Payjoin.
     pub fn check_no_inputs_seen_before(
         self,
-        is_known: impl Fn(&OutPoint) -> Result<bool, ReplyableError>,
+        is_known: impl Fn(&OutPoint) -> Result<bool, ImplementationError>,
     ) -> Result<OutputsUnknown, ReplyableError> {
         self.psbt.input_pairs().try_for_each(|input| {
             match is_known(&input.txin.previous_output) {
@@ -186,7 +190,7 @@ impl MaybeInputsSeen {
                     log::warn!("Request contains an input we've seen before: {}. Preventing possible probing attack.", input.txin.previous_output);
                     Err(InternalPayloadError::InputSeen(input.txin.previous_output))?
                 },
-                Err(e) => Err(ReplyableError::Implementation(e.into()))?,
+                Err(e) => Err(ReplyableError::Implementation(e))?,
             }
         })?;
 
@@ -208,7 +212,7 @@ impl OutputsUnknown {
     /// Find which outputs belong to the receiver
     pub fn identify_receiver_outputs(
         self,
-        is_receiver_output: impl Fn(&Script) -> Result<bool, ReplyableError>,
+        is_receiver_output: impl Fn(&Script) -> Result<bool, ImplementationError>,
     ) -> Result<WantsOutputs, ReplyableError> {
         let owned_vouts: Vec<usize> = self
             .psbt
@@ -221,7 +225,8 @@ impl OutputsUnknown {
                 Ok(false) => None,
                 Err(e) => Some(Err(e)),
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ReplyableError::Implementation)?;
 
         if owned_vouts.is_empty() {
             return Err(InternalPayloadError::MissingPayment.into());
@@ -742,7 +747,7 @@ impl ProvisionalProposal {
     /// wallet_process_psbt should sign and finalize receiver inputs
     pub fn finalize_proposal(
         mut self,
-        wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, ReplyableError>,
+        wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, ImplementationError>,
         min_fee_rate: Option<FeeRate>,
         max_effective_fee_rate: Option<FeeRate>,
     ) -> Result<PayjoinProposal, ReplyableError> {
@@ -754,7 +759,7 @@ impl ProvisionalProposal {
             psbt.inputs[i].final_script_witness = None;
             psbt.inputs[i].tap_key_sig = None;
         }
-        let psbt = wallet_process_psbt(&psbt)?;
+        let psbt = wallet_process_psbt(&psbt).map_err(ReplyableError::Implementation)?;
         let payjoin_proposal = self.prepare_psbt(psbt);
         Ok(payjoin_proposal)
     }

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -1,10 +1,10 @@
 use core::fmt;
 use std::error;
 
-use super::Error;
+use super::Error::V2;
 use crate::hpke::HpkeError;
 use crate::ohttp::OhttpEncapsulationError;
-use crate::receive::JsonError;
+use crate::receive::error::Error;
 
 /// Error that may occur during a v2 session typestate change
 ///
@@ -17,8 +17,8 @@ impl From<InternalSessionError> for SessionError {
     fn from(value: InternalSessionError) -> Self { SessionError(value) }
 }
 
-impl From<InternalSessionError> for super::Error {
-    fn from(e: InternalSessionError) -> Self { super::Error::Validation(e.into()) }
+impl From<InternalSessionError> for Error {
+    fn from(e: InternalSessionError) -> Self { V2(e.into()) }
 }
 
 #[derive(Debug)]
@@ -47,21 +47,6 @@ impl From<OhttpEncapsulationError> for Error {
 
 impl From<HpkeError> for Error {
     fn from(e: HpkeError) -> Self { InternalSessionError::Hpke(e).into() }
-}
-
-impl JsonError for SessionError {
-    fn to_json(&self) -> String {
-        use InternalSessionError::*;
-
-        use crate::receive::error::serialize_json_error;
-        match &self.0 {
-            Expired(_) => serialize_json_error("session-expired", self),
-            OhttpEncapsulation(_) => serialize_json_error("ohttp-encapsulation-error", self),
-            Hpke(_) => serialize_json_error("hpke-error", self),
-            UnexpectedResponseSize(_) => serialize_json_error("unexpected-response-size", self),
-            UnexpectedStatusCode(_) => serialize_json_error("unexpected-status-code", self),
-        }
-    }
 }
 
 impl fmt::Display for SessionError {

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -11,11 +11,12 @@ use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::error::InputContributionError;
-use super::{v1, Error, InternalPayloadError, JsonError, OutputSubstitutionError, SelectionError};
+use super::error::{Error, InputContributionError};
+use super::{
+    v1, InternalPayloadError, JsonError, OutputSubstitutionError, ReplyableError, SelectionError,
+};
 use crate::hpke::{decrypt_message_a, encrypt_message_b, HpkeKeyPair, HpkePublicKey};
 use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate, OhttpEncapsulationError, OhttpKeys};
-use crate::receive::error::ValidationError;
 use crate::receive::{parse_payload, InputPair};
 use crate::uri::ShortId;
 use crate::Request;
@@ -115,11 +116,11 @@ impl Receiver {
         context: ohttp::ClientResponse,
     ) -> Result<Option<UncheckedProposal>, Error> {
         let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
-            body.try_into().map_err(|_| {
-                Error::Validation(InternalSessionError::UnexpectedResponseSize(body.len()).into())
-            })?;
+            body.try_into()
+                .map_err(|_| InternalSessionError::UnexpectedResponseSize(body.len()))?;
         log::trace!("decapsulating directory response");
-        let response = ohttp_decapsulate(context, response_array)?;
+        let response = ohttp_decapsulate(context, response_array)
+            .map_err(InternalSessionError::OhttpEncapsulation)?;
         if response.body().is_empty() {
             log::debug!("response is empty");
             return Ok(None);
@@ -142,24 +143,30 @@ impl Receiver {
         ohttp_encapsulate(&mut self.context.ohttp_keys, "GET", fallback_target.as_str(), None)
     }
 
-    fn extract_proposal_from_v1(&mut self, response: String) -> Result<UncheckedProposal, Error> {
+    fn extract_proposal_from_v1(
+        &mut self,
+        response: String,
+    ) -> Result<UncheckedProposal, ReplyableError> {
         self.unchecked_from_payload(response)
     }
 
     fn extract_proposal_from_v2(&mut self, response: Vec<u8>) -> Result<UncheckedProposal, Error> {
         let (payload_bytes, e) = decrypt_message_a(&response, self.context.s.secret_key().clone())?;
         self.context.e = Some(e);
-        let payload = String::from_utf8(payload_bytes).map_err(InternalPayloadError::Utf8)?;
-        self.unchecked_from_payload(payload)
+        let payload = String::from_utf8(payload_bytes)
+            .map_err(|e| Error::ReplyToSender(InternalPayloadError::Utf8(e).into()))?;
+        self.unchecked_from_payload(payload).map_err(Error::ReplyToSender)
     }
 
-    fn unchecked_from_payload(&mut self, payload: String) -> Result<UncheckedProposal, Error> {
+    fn unchecked_from_payload(
+        &mut self,
+        payload: String,
+    ) -> Result<UncheckedProposal, ReplyableError> {
         let (base64, padded_query) = payload.split_once('\n').unwrap_or_default();
         let query = padded_query.trim_matches('\0');
         log::trace!("Received query: {}, base64: {}", query, base64); // my guess is no \n so default is wrong
-
         let (psbt, mut params) = parse_payload(base64.to_string(), query, SUPPORTED_VERSIONS)
-            .map_err(|e| Error::Validation(ValidationError::Payload(e)))?;
+            .map_err(ReplyableError::Payload)?;
 
         // Output substitution must be disabled for V1 sessions in V2 contexts.
         //
@@ -228,8 +235,8 @@ impl UncheckedProposal {
     pub fn check_broadcast_suitability(
         self,
         min_fee_rate: Option<FeeRate>,
-        can_broadcast: impl Fn(&bitcoin::Transaction) -> Result<bool, Error>,
-    ) -> Result<MaybeInputsOwned, Error> {
+        can_broadcast: impl Fn(&bitcoin::Transaction) -> Result<bool, ReplyableError>,
+    ) -> Result<MaybeInputsOwned, ReplyableError> {
         let inner = self.v1.check_broadcast_suitability(min_fee_rate, can_broadcast)?;
         Ok(MaybeInputsOwned { v1: inner, context: self.context })
     }
@@ -248,7 +255,7 @@ impl UncheckedProposal {
     /// a Receiver Error Response
     pub fn extract_err_req(
         &mut self,
-        err: &Error,
+        err: &ReplyableError,
         ohttp_relay: &Url,
     ) -> Result<(Request, ohttp::ClientResponse), SessionError> {
         let subdir = subdir(&self.context.directory, &id(&self.context.s));
@@ -300,8 +307,8 @@ impl MaybeInputsOwned {
     /// An attacker could try to spend receiver's own inputs. This check prevents that.
     pub fn check_inputs_not_owned(
         self,
-        is_owned: impl Fn(&Script) -> Result<bool, Error>,
-    ) -> Result<MaybeInputsSeen, Error> {
+        is_owned: impl Fn(&Script) -> Result<bool, ReplyableError>,
+    ) -> Result<MaybeInputsSeen, ReplyableError> {
         let inner = self.v1.check_inputs_not_owned(is_owned)?;
         Ok(MaybeInputsSeen { v1: inner, context: self.context })
     }
@@ -322,8 +329,8 @@ impl MaybeInputsSeen {
     /// proposes a Payjoin PSBT as a new Original PSBT for a new Payjoin.
     pub fn check_no_inputs_seen_before(
         self,
-        is_known: impl Fn(&OutPoint) -> Result<bool, Error>,
-    ) -> Result<OutputsUnknown, Error> {
+        is_known: impl Fn(&OutPoint) -> Result<bool, ReplyableError>,
+    ) -> Result<OutputsUnknown, ReplyableError> {
         let inner = self.v1.check_no_inputs_seen_before(is_known)?;
         Ok(OutputsUnknown { inner, context: self.context })
     }
@@ -343,8 +350,8 @@ impl OutputsUnknown {
     /// Find which outputs belong to the receiver
     pub fn identify_receiver_outputs(
         self,
-        is_receiver_output: impl Fn(&Script) -> Result<bool, Error>,
-    ) -> Result<WantsOutputs, Error> {
+        is_receiver_output: impl Fn(&Script) -> Result<bool, ReplyableError>,
+    ) -> Result<WantsOutputs, ReplyableError> {
         let inner = self.inner.identify_receiver_outputs(is_receiver_output)?;
         Ok(WantsOutputs { v1: inner, context: self.context })
     }
@@ -448,10 +455,10 @@ pub struct ProvisionalProposal {
 impl ProvisionalProposal {
     pub fn finalize_proposal(
         self,
-        wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, Error>,
+        wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, ReplyableError>,
         min_fee_rate: Option<FeeRate>,
         max_effective_fee_rate: Option<FeeRate>,
-    ) -> Result<PayjoinProposal, Error> {
+    ) -> Result<PayjoinProposal, ReplyableError> {
         let inner =
             self.v1.finalize_proposal(wallet_process_psbt, min_fee_rate, max_effective_fee_rate)?;
         Ok(PayjoinProposal { v1: inner, context: self.context })
@@ -493,7 +500,7 @@ impl PayjoinProposal {
                 .context
                 .directory
                 .join(&sender_subdir.to_string())
-                .map_err(|e| Error::Implementation(e.into()))?;
+                .map_err(|e| ReplyableError::Implementation(e.into()))?;
             body = encrypt_message_b(payjoin_bytes, &self.context.s, e)?;
             method = "POST";
         } else {
@@ -504,7 +511,7 @@ impl PayjoinProposal {
                 .context
                 .directory
                 .join(&receiver_subdir.to_string())
-                .map_err(|e| Error::Implementation(e.into()))?;
+                .map_err(|e| ReplyableError::Implementation(e.into()))?;
             method = "PUT";
         }
         log::debug!("Payjoin PSBT target: {}", target_resource.as_str());
@@ -532,17 +539,13 @@ impl PayjoinProposal {
         ohttp_context: ohttp::ClientResponse,
     ) -> Result<(), Error> {
         let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
-            res.try_into().map_err(|_| {
-                Error::Validation(InternalSessionError::UnexpectedResponseSize(res.len()).into())
-            })?;
-        let res = ohttp_decapsulate(ohttp_context, response_array)?;
+            res.try_into().map_err(|_| InternalSessionError::UnexpectedResponseSize(res.len()))?;
+        let res = ohttp_decapsulate(ohttp_context, response_array)
+            .map_err(InternalSessionError::OhttpEncapsulation)?;
         if res.status().is_success() {
             Ok(())
         } else {
-            Err(Error::Implementation(
-                format!("Payjoin Post failed, expected Success status, got {}", res.status())
-                    .into(),
-            ))
+            Err(InternalSessionError::UnexpectedStatusCode(res.status()).into())
         }
     }
 }
@@ -604,7 +607,9 @@ mod test {
 
         let server_error = proposal
             .clone()
-            .check_broadcast_suitability(None, |_| Err(Error::Implementation("mock error".into())))
+            .check_broadcast_suitability(None, |_| {
+                Err(ReplyableError::Implementation("mock error".into()))
+            })
             .err()
             .unwrap();
         assert_eq!(
@@ -613,7 +618,7 @@ mod test {
         );
         let (_req, _ctx) = proposal.clone().extract_err_req(&server_error, &EXAMPLE_OHTTP_RELAY)?;
 
-        let internal_error = Error::Validation(InternalPayloadError::MissingPayment.into());
+        let internal_error = InternalPayloadError::MissingPayment.into();
         let (_req, _ctx) = proposal.extract_err_req(&internal_error, &EXAMPLE_OHTTP_RELAY)?;
         Ok(())
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -11,8 +11,8 @@ mod integration {
     use bitcoind::bitcoincore_rpc::{self, RpcApi};
     use once_cell::sync::Lazy;
     use payjoin::receive::v1::build_v1_pj_uri;
-    use payjoin::receive::Error::Implementation;
     use payjoin::receive::InputPair;
+    use payjoin::receive::ReplyableError::Implementation;
     use payjoin::{PjUri, Request, Uri};
     use payjoin_test_utils::{init_bitcoind_sender_receiver, init_tracing, BoxError};
     use url::Url;

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -11,8 +11,8 @@ mod integration {
     use bitcoind::bitcoincore_rpc::{self, RpcApi};
     use once_cell::sync::Lazy;
     use payjoin::receive::v1::build_v1_pj_uri;
-    use payjoin::receive::InputPair;
     use payjoin::receive::ReplyableError::Implementation;
+    use payjoin::receive::{ImplementationError, InputPair};
     use payjoin::{PjUri, Request, Uri};
     use payjoin_test_utils::{init_bitcoind_sender_receiver, init_tracing, BoxError};
     use url::Url;
@@ -566,20 +566,20 @@ mod integration {
             let proposal = proposal.check_broadcast_suitability(None, |tx| {
                 Ok(receiver
                     .test_mempool_accept(&[bitcoin::consensus::encode::serialize_hex(&tx)])
-                    .map_err(|e| Implementation(e.into()))?
+                    .map_err(ImplementationError::from)?
                     .first()
-                    .ok_or(Implementation("testmempoolaccept should return a result".into()))?
+                    .ok_or(ImplementationError::from("testmempoolaccept should return a result"))?
                     .allowed)
             })?;
 
             // Receive Check 2: receiver can't sign for proposal inputs
             let proposal = proposal.check_inputs_not_owned(|input| {
                 let address = bitcoin::Address::from_script(input, bitcoin::Network::Regtest)
-                    .map_err(|e| Implementation(e.into()))?;
+                    .map_err(ImplementationError::from)?;
                 receiver
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Implementation(e.into()))
+                    .map_err(ImplementationError::from)
             })?;
 
             // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
@@ -588,11 +588,11 @@ mod integration {
                 .identify_receiver_outputs(|output_script| {
                     let address =
                         bitcoin::Address::from_script(output_script, bitcoin::Network::Regtest)
-                            .map_err(|e| Implementation(e.into()))?;
+                            .map_err(ImplementationError::from)?;
                     receiver
                         .get_address_info(&address)
                         .map(|info| info.is_mine.unwrap_or(false))
-                        .map_err(|e| Implementation(e.into()))
+                        .map_err(ImplementationError::from)
                 })?;
 
             let payjoin = payjoin.commit_outputs();
@@ -630,7 +630,7 @@ mod integration {
                         .map(|res: WalletProcessPsbtResult| {
                             Psbt::from_str(&res.psbt).expect("psbt should be valid")
                         })
-                        .map_err(|e| Implementation(e.into()))
+                        .map_err(ImplementationError::from)
                 },
                 Some(FeeRate::BROADCAST_MIN),
                 Some(FeeRate::from_sat_per_vb_unchecked(2)),
@@ -910,20 +910,20 @@ mod integration {
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             Ok(receiver
                 .test_mempool_accept(&[bitcoin::consensus::encode::serialize_hex(&tx)])
-                .map_err(|e| Implementation(e.into()))?
+                .map_err(ImplementationError::from)?
                 .first()
-                .ok_or(Implementation("testmempoolaccept should return a result".into()))?
+                .ok_or(ImplementationError::from("testmempoolaccept should return a result"))?
                 .allowed)
         })?;
 
         // Receive Check 2: receiver can't sign for proposal inputs
         let proposal = proposal.check_inputs_not_owned(|input| {
             let address = bitcoin::Address::from_script(input, bitcoin::Network::Regtest)
-                .map_err(|e| Implementation(e.into()))?;
+                .map_err(ImplementationError::from)?;
             receiver
                 .get_address_info(&address)
                 .map(|info| info.is_mine.unwrap_or(false))
-                .map_err(|e| Implementation(e.into()))
+                .map_err(ImplementationError::from)
         })?;
 
         // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
@@ -932,11 +932,11 @@ mod integration {
             .identify_receiver_outputs(|output_script| {
                 let address =
                     bitcoin::Address::from_script(output_script, bitcoin::Network::Regtest)
-                        .map_err(|e| Implementation(e.into()))?;
+                        .map_err(ImplementationError::from)?;
                 receiver
                     .get_address_info(&address)
                     .map(|info| info.is_mine.unwrap_or(false))
-                    .map_err(|e| Implementation(e.into()))
+                    .map_err(ImplementationError::from)
             })?;
 
         let payjoin = match custom_outputs {
@@ -980,7 +980,7 @@ mod integration {
                     .map(|res: WalletProcessPsbtResult| {
                         Psbt::from_str(&res.psbt).expect("psbt should be valid")
                     })
-                    .map_err(|e| Implementation(e.into()))
+                    .map_err(ImplementationError::from)
             },
             Some(FeeRate::BROADCAST_MIN),
             Some(FeeRate::from_sat_per_vb_unchecked(2)),


### PR DESCRIPTION
- 1st commit de-duplicates
- 2nd commit: Only some errors are actually recoverable and must return JSON. Fix https://github.com/payjoin/rust-payjoin/issues/522.

Re: #403 