### PR TITLE
Refactor candidate input pairs to be refs in contribute_inputs

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -389,9 +389,10 @@ fn try_contributing_inputs(
         .list_unspent(None, None, None, None, None)
         .context("Failed to list unspent from bitcoind")?
         .into_iter()
-        .map(input_pair_from_list_unspent);
+        .map(input_pair_from_list_unspent)
+        .collect::<Vec<_>>();
     let selected_input = payjoin
-        .try_preserving_privacy(candidate_inputs)
+        .try_preserving_privacy(candidate_inputs.iter())
         .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
     log::debug!("selected input: {:#?}", selected_input);
 

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -367,9 +367,10 @@ fn try_contributing_inputs(
         .list_unspent(None, None, None, None, None)
         .context("Failed to list unspent from bitcoind")?
         .into_iter()
-        .map(input_pair_from_list_unspent);
+        .map(input_pair_from_list_unspent)
+        .collect::<Vec<_>>();
     let selected_input = payjoin
-        .try_preserving_privacy(candidate_inputs)
+        .try_preserving_privacy(candidate_inputs.iter())
         .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
     log::debug!("selected input: {:#?}", selected_input);
 

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -419,9 +419,9 @@ impl WantsInputs {
     /// BlockSci UIH1 and UIH2:
     /// if min(in) > min(out) then UIH1 else UIH2
     /// <https://eprint.iacr.org/2022/589.pdf>
-    pub fn try_preserving_privacy(
+    pub fn try_preserving_privacy<'a>(
         &self,
-        candidate_inputs: impl IntoIterator<Item = InputPair>,
+        candidate_inputs: impl IntoIterator<Item = &'a InputPair>,
     ) -> Result<InputPair, SelectionError> {
         self.v1.try_preserving_privacy(candidate_inputs)
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -604,9 +604,10 @@ mod integration {
                         .list_unspent(None, None, None, None, None)
                         .map_err(|e| Implementation(e.into()))?
                         .into_iter()
-                        .map(input_pair_from_list_unspent);
+                        .map(input_pair_from_list_unspent)
+                        .collect::<Vec<_>>();
                     let selected_input =
-                        payjoin.try_preserving_privacy(candidate_inputs).map_err(|e| {
+                        payjoin.try_preserving_privacy(candidate_inputs.iter()).map_err(|e| {
                             format!("Failed to make privacy preserving selection: {:?}", e)
                         })?;
                     vec![selected_input]
@@ -956,9 +957,10 @@ mod integration {
                 let candidate_inputs = receiver
                     .list_unspent(None, None, None, None, None)?
                     .into_iter()
-                    .map(input_pair_from_list_unspent);
+                    .map(input_pair_from_list_unspent)
+                    .collect::<Vec<_>>();
                 let selected_input = payjoin
-                    .try_preserving_privacy(candidate_inputs)
+                    .try_preserving_privacy(candidate_inputs.iter())
                     .map_err(|e| format!("Failed to make privacy preserving selection: {:?}", e))?;
                 vec![selected_input]
             }


### PR DESCRIPTION
The candidate_inputs pass ownership through several functions within the WantsInputs impl.
Instead we can use a ref with proper lifetimes to pass this down through to the contribute_inputs function.