### PR TITLE
Refactor replacement outputs to be an Iterator of ref TxOuts

### DIFF
--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -270,9 +270,9 @@ impl WantsOutputs {
     pub fn substitute_receiver_script(
         self,
         output_script: &Script,
-    ) -> Result<WantsOutputs, OutputSubstitutionError> {
+    ) -> Result<Self, OutputSubstitutionError> {
         let output_value = self.original_psbt.unsigned_tx.output[self.change_vout].value;
-        let outputs = vec![TxOut { value: output_value, script_pubkey: output_script.into() }];
+        let outputs = [TxOut { value: output_value, script_pubkey: output_script.into() }];
         self.replace_receiver_outputs(outputs, output_script)
     }
 
@@ -283,12 +283,12 @@ impl WantsOutputs {
     /// receiver needs to pay for additional miner fees (e.g. in the case of adding many outputs).
     pub fn replace_receiver_outputs(
         self,
-        replacement_outputs: Vec<TxOut>,
+        replacement_outputs: impl IntoIterator<Item = TxOut>,
         drain_script: &Script,
-    ) -> Result<WantsOutputs, OutputSubstitutionError> {
+    ) -> Result<Self, OutputSubstitutionError> {
         let mut payjoin_psbt = self.original_psbt.clone();
         let mut outputs = vec![];
-        let mut replacement_outputs = replacement_outputs.clone();
+        let mut replacement_outputs: Vec<TxOut> = replacement_outputs.into_iter().collect();
         let mut rng = rand::thread_rng();
         // Substitute the existing receiver outputs, keeping the sender/receiver output ordering
         for (i, original_output) in self.original_psbt.unsigned_tx.output.iter().enumerate() {
@@ -343,7 +343,7 @@ impl WantsOutputs {
         // Update the payjoin PSBT outputs
         payjoin_psbt.outputs = vec![Default::default(); outputs.len()];
         payjoin_psbt.unsigned_tx.output = outputs;
-        Ok(WantsOutputs {
+        Ok(Self {
             original_psbt: self.original_psbt,
             payjoin_psbt,
             params: self.params,

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -373,9 +373,9 @@ impl WantsOutputs {
     pub fn substitute_receiver_script(
         self,
         output_script: &Script,
-    ) -> Result<WantsOutputs, OutputSubstitutionError> {
+    ) -> Result<Self, OutputSubstitutionError> {
         let inner = self.v1.substitute_receiver_script(output_script)?;
-        Ok(WantsOutputs { v1: inner, context: self.context })
+        Ok(Self { v1: inner, context: self.context })
     }
 
     /// Replace **all** receiver outputs with one or more provided outputs.
@@ -385,11 +385,11 @@ impl WantsOutputs {
     /// receiver needs to pay for additional miner fees (e.g. in the case of adding many outputs).
     pub fn replace_receiver_outputs(
         self,
-        replacement_outputs: Vec<TxOut>,
+        replacement_outputs: impl Iterator<Item = TxOut>,
         drain_script: &Script,
-    ) -> Result<WantsOutputs, OutputSubstitutionError> {
+    ) -> Result<Self, OutputSubstitutionError> {
         let inner = self.v1.replace_receiver_outputs(replacement_outputs, drain_script)?;
-        Ok(WantsOutputs { v1: inner, context: self.context })
+        Ok(Self { v1: inner, context: self.context })
     }
 
     /// Proceed to the input contribution step.


### PR DESCRIPTION
We can pass the replacement outputs as a ref Iterator instead of using a Vec of TxOuts.

Same as before I guess the question is whether this is really needed especially considering how little was affected downstream by this arg type change.

Perhaps its still useful to convert this to an Iterator and not a reference but I'm not totally sure, especially since in my approach I end up just converting it back to a Vec to work with `interleave_shuffle` better