### PR TITLE
[WIP] RFC 9540 support

### DIFF
--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -184,7 +184,7 @@ mod e2e {
 
             let directory = &services.directory_url().to_string();
             // Mock ohttp_relay since the ohttp_relay's http client doesn't have the certificate for the directory
-            let mock_ohttp_relay = directory;
+            let mock_ohttp_relay = &services.ohttp_gateway_url().to_string();
 
             let cli_receive_initiator = Command::new(payjoin_cli)
                 .arg("--rpchost")

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -185,6 +185,9 @@ async fn serve_payjoin_directory(
     let path_segments: Vec<&str> = path.split('/').collect();
     debug!("serve_payjoin_directory: {:?}", &path_segments);
     let mut response = match (parts.method, path_segments.as_slice()) {
+        (Method::POST, ["", ".well-known", "ohttp-gateway"]) =>
+            handle_ohttp_gateway(body, pool, ohttp).await,
+        (Method::GET, ["", ".well-known", "ohttp-gateway"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp).await,
         (Method::GET, ["", "ohttp-keys"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", id]) => post_fallback_v1(id, query, body, pool).await,

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -188,8 +188,8 @@ async fn serve_payjoin_directory(
         (Method::POST, ["", ".well-known", "ohttp-gateway"]) =>
             handle_ohttp_gateway(body, pool, ohttp).await,
         (Method::GET, ["", ".well-known", "ohttp-gateway"]) => get_ohttp_keys(&ohttp).await,
-        (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp).await,
-        (Method::GET, ["", "ohttp-keys"]) => get_ohttp_keys(&ohttp).await,
+        // (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp).await,
+        // (Method::GET, ["", "ohttp-keys"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", id]) => post_fallback_v1(id, query, body, pool).await,
         (Method::GET, ["", "health"]) => health_check().await,
         _ => Ok(not_found()),

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -78,6 +78,11 @@ impl TestServices {
         Url::parse(&format!("http://localhost:{}", self.ohttp_relay.0)).expect("invalid URL")
     }
 
+    pub fn ohttp_gateway_url(&self) -> Url {
+        let url = self.directory_url();
+        url.join("/.well-known/ohttp-gateway").expect("invalid URL")
+    }
+
     pub fn take_ohttp_relay_handle(&mut self) -> JoinHandle<Result<(), BoxSendSyncError>> {
         self.ohttp_relay.1.take().expect("ohttp relay handle not found")
     }

--- a/payjoin/src/io.rs
+++ b/payjoin/src/io.rs
@@ -16,7 +16,7 @@ pub async fn fetch_ohttp_keys(
     ohttp_relay: Url,
     payjoin_directory: Url,
 ) -> Result<OhttpKeys, Error> {
-    let ohttp_keys_url = payjoin_directory.join("/ohttp-keys")?;
+    let ohttp_keys_url = payjoin_directory.join(".well-known/ohttp-gateway")?;
     let proxy = Proxy::all(ohttp_relay.as_str())?;
     let client = Client::builder().proxy(proxy).build()?;
     let res = client.get(ohttp_keys_url).send().await?;
@@ -40,7 +40,7 @@ pub async fn fetch_ohttp_keys_with_cert(
     payjoin_directory: Url,
     cert_der: Vec<u8>,
 ) -> Result<OhttpKeys, Error> {
-    let ohttp_keys_url = payjoin_directory.join("/ohttp-keys")?;
+    let ohttp_keys_url = payjoin_directory.join(".well-known/ohttp-gateway")?;
     let proxy = Proxy::all(ohttp_relay.as_str())?;
     let client = Client::builder()
         .danger_accept_invalid_certs(true)

--- a/payjoin/src/ohttp.rs
+++ b/payjoin/src/ohttp.rs
@@ -41,7 +41,7 @@ pub fn ohttp_encapsulate(
     }
 
     let mut bhttp_req = [0u8; PADDED_BHTTP_REQ_BYTES];
-    let _ = bhttp_message.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_req.as_mut_slice());
+    let _ = bhttp_message.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_req.as_mut_slice())?;
     let (encapsulated, ohttp_ctx) = ctx.encapsulate(&bhttp_req)?;
 
     let mut buffer = [0u8; ENCAPSULATED_MESSAGE_BYTES];

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -204,7 +204,7 @@ mod integration {
                 let agent = services.http_agent();
                 services.wait_for_services_ready().await?;
                 let directory = services.directory_url();
-                let mock_ohttp_relay = directory.clone(); // pass through to directory
+                let mock_ohttp_relay = services.ohttp_gateway_url();
                 let mock_address = Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")?
                     .assume_checked();
                 let mut bad_initializer =
@@ -232,7 +232,7 @@ mod integration {
                 let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
                 services.wait_for_services_ready().await?;
                 let directory = services.directory_url();
-                let ohttp_relay = services.ohttp_relay_url();
+                let ohttp_relay = services.ohttp_gateway_url();
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
                 // **********************
                 // Inside the Receiver:
@@ -294,7 +294,7 @@ mod integration {
                     Receiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None);
                 println!("session: {:#?}", &session);
                 // Poll receive request
-                let mock_ohttp_relay = directory.clone();
+                let mock_ohttp_relay = services.ohttp_gateway_url();
                 let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
                 let response = agent.post(req.url).body(req.body).send().await?;
                 assert!(response.status().is_success(), "error response: {}", response.status());
@@ -487,7 +487,7 @@ mod integration {
                 let agent_clone: Arc<Client> = agent.clone();
                 let receiver: Arc<bitcoincore_rpc::Client> = Arc::new(receiver);
                 let receiver_clone = receiver.clone();
-                let mock_ohttp_relay = directory.clone();
+                let mock_ohttp_relay = services.ohttp_gateway_url();
                 let receiver_loop = tokio::task::spawn(async move {
                     let agent_clone = agent_clone.clone();
                     let (response, ctx) = loop {


### PR DESCRIPTION
This is a draft PR for previewing the changes required for RFC 9540 support, and should be split into two smaller ones:

1. introducing the changes to the directory (2nd commit)
2. updating the ohttp-relay dependency and making use of the functionality dependent on payjoin/ohttp-relay#47
  
Although the changes to support this are very simple, because of the lack of use of the ohttp relay in the e2e tests, I had both a false positive and a false negative (i.e. I thought it was implemented correctly when it wasn't, then I thought it was implemented incorrectly when it was), so still not feeling confident about these changes.

As a result of this confusion I have been working on using rcgen to generate a self signed certificate, as in the ohttp-relay tests, so that the `_danger-local-https` feature can be removed, and the e2e test doesn't bypass the relay but is truly end to end, but i'm not sure how to expose such functionality without making the ohttp relay significantly more complex both in code and in CLI api, so ideas on how to do this are welcome.

The best idea I've got so far is to implement a custom root certificate store that manually adds the webpki roots and optionally a CLI specified root certificate, and gate the additional CLI argument with _test-utils flag, that's still a lot of boilerplate, but feature gating is additive.