### PR TITLE
Fix payjoin-cli v1 coverage

### DIFF
--- a/contrib/coverage.sh
+++ b/contrib/coverage.sh
@@ -4,4 +4,5 @@ set -e
 # https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#merge-coverages-generated-under-different-test-conditions
 cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage results
 cargo llvm-cov --no-report --all-features
+cargo llvm-cov --no-report --package payjoin-cli --no-default-features --features=v1,_danger-local-https # Explicitly run payjoin-cli v1 e2e tests
 cargo llvm-cov report --lcov --output-path lcov.info # generate report without tests

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -10,6 +10,8 @@ use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::FeeRate;
 use payjoin::receive::InputPair;
 use payjoin::{bitcoin, PjUri};
+use tokio::signal;
+use tokio::sync::watch;
 
 pub mod config;
 use crate::app::config::AppConfig;
@@ -135,4 +137,11 @@ pub fn input_pair_from_list_unspent(
         ..Default::default()
     };
     InputPair::new(txin, psbtin).expect("Input pair should be valid")
+}
+
+async fn handle_interrupt(tx: watch::Sender<()>) {
+    if let Err(e) = signal::ctrl_c().await {
+        eprintln!("Error setting up Ctrl-C handler: {}", e);
+    }
+    let _ = tx.send(());
 }

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -10,12 +10,11 @@ use payjoin::receive::v2::{Receiver, UncheckedProposal};
 use payjoin::receive::Error;
 use payjoin::send::v2::{Sender, SenderBuilder};
 use payjoin::{bitcoin, Uri};
-use tokio::signal;
 use tokio::sync::watch;
 
 use super::config::AppConfig;
 use super::App as AppTrait;
-use crate::app::{http_agent, input_pair_from_list_unspent};
+use crate::app::{handle_interrupt, http_agent, input_pair_from_list_unspent};
 use crate::db::Database;
 
 #[derive(Clone)]
@@ -397,13 +396,6 @@ async fn unwrap_ohttp_keys_or_else_fetch(config: &AppConfig) -> Result<payjoin::
         let ohttp_keys = payjoin::io::fetch_ohttp_keys(ohttp_relay, payjoin_directory).await?;
         Ok(ohttp_keys)
     }
-}
-
-async fn handle_interrupt(tx: watch::Sender<()>) {
-    if let Err(e) = signal::ctrl_c().await {
-        eprintln!("Error setting up Ctrl-C handler: {}", e);
-    }
-    let _ = tx.send(());
 }
 
 async fn post_request(req: payjoin::Request) -> Result<reqwest::Response> {

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -296,24 +296,21 @@ mod e2e {
         async fn send_until_request_timeout(mut cli_sender: Child) -> Result<()> {
             let stdout = cli_sender.stdout.take().expect("Failed to take stdout of child process");
             let reader = BufReader::new(stdout);
+            let mut stdout = tokio::io::stdout();
             let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
             let mut lines = reader.lines();
-            tokio::spawn(async move {
-                let mut stdout = tokio::io::stdout();
-                while let Some(line) =
-                    lines.next_line().await.expect("Failed to read line from stdout")
-                {
-                    stdout
-                        .write_all(format!("{}\n", line).as_bytes())
-                        .await
-                        .expect("Failed to write to stdout");
-                    if line.contains("No response yet.") {
-                        let _ = tx.send(true).await;
-                        break;
-                    }
+            while let Some(line) = lines.next_line().await.expect("Failed to read line from stdout")
+            {
+                stdout
+                    .write_all(format!("{}\n", line).as_bytes())
+                    .await
+                    .expect("Failed to write to stdout");
+                if line.contains("No response yet.") {
+                    let _ = tx.send(true).await;
+                    break;
                 }
-            });
+            }
 
             let timeout = tokio::time::Duration::from_secs(35);
             let fallback_sent = tokio::time::timeout(timeout, rx.recv()).await?;
@@ -328,24 +325,21 @@ mod e2e {
             let stdout =
                 cli_receive_resumer.stdout.take().expect("Failed to take stdout of child process");
             let reader = BufReader::new(stdout);
+            let mut stdout = tokio::io::stdout();
             let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
             let mut lines = reader.lines();
-            tokio::spawn(async move {
-                let mut stdout = tokio::io::stdout();
-                while let Some(line) =
-                    lines.next_line().await.expect("Failed to read line from stdout")
-                {
-                    stdout
-                        .write_all(format!("{}\n", line).as_bytes())
-                        .await
-                        .expect("Failed to write to stdout");
-                    if line.contains("Response successful") {
-                        let _ = tx.send(true).await;
-                        break;
-                    }
+            while let Some(line) = lines.next_line().await.expect("Failed to read line from stdout")
+            {
+                stdout
+                    .write_all(format!("{}\n", line).as_bytes())
+                    .await
+                    .expect("Failed to write to stdout");
+                if line.contains("Response successful") {
+                    let _ = tx.send(true).await;
+                    break;
                 }
-            });
+            }
 
             let timeout = tokio::time::Duration::from_secs(10);
             let response_successful = tokio::time::timeout(timeout, rx.recv()).await?;
@@ -360,24 +354,21 @@ mod e2e {
             let stdout =
                 cli_send_resumer.stdout.take().expect("Failed to take stdout of child process");
             let reader = BufReader::new(stdout);
+            let mut stdout = tokio::io::stdout();
             let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
             let mut lines = reader.lines();
-            tokio::spawn(async move {
-                let mut stdout = tokio::io::stdout();
-                while let Some(line) =
-                    lines.next_line().await.expect("Failed to read line from stdout")
-                {
-                    stdout
-                        .write_all(format!("{}\n", line).as_bytes())
-                        .await
-                        .expect("Failed to write to stdout");
-                    if line.contains("Payjoin sent") {
-                        let _ = tx.send(true).await;
-                        break;
-                    }
+            while let Some(line) = lines.next_line().await.expect("Failed to read line from stdout")
+            {
+                stdout
+                    .write_all(format!("{}\n", line).as_bytes())
+                    .await
+                    .expect("Failed to write to stdout");
+                if line.contains("Payjoin sent") {
+                    let _ = tx.send(true).await;
+                    break;
                 }
-            });
+            }
 
             let timeout = tokio::time::Duration::from_secs(10);
             let payjoin_sent = tokio::time::timeout(timeout, rx.recv()).await?;


### PR DESCRIPTION
Fix #499 

This required a few changes:

- Add an explicit `llvm-cov` command for running the payjoin-cli v1 e2e test, as it is not currently covered by `--all-features`.
- Add graceful SIGINT handling to payjoin-cli v1.
- Modify the `sigint` test function to wait until the child process completely exits, so that the interrupt handlers can actually print to stdout without panicking (`failed printing to stdout: Broken pipe (os error 32)`). This issue also affected the payjoin-cli v2 test, so this fix reduces the noise there as well.
- Remove unnecessary `tokio::spawn`s in tests which moved `cli.stdout` out of the main loop, also causing panics like the former in interrupt handlers.
- The last commit only refactors and extracts shared e2e testing code.