### PR TITLE
Handle receiver contribution errors as `unavailable`

### DIFF
--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -304,10 +304,7 @@ impl App {
             .commit_outputs();
 
         let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &bitcoind)
-            .unwrap_or_else(|e| {
-                log::warn!("Failed to contribute inputs: {}", e);
-                payjoin.commit_inputs()
-            });
+            .map_err(ReplyableError::Implementation)?;
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {
@@ -355,20 +352,19 @@ async fn handle_recoverable_error(
 fn try_contributing_inputs(
     payjoin: payjoin::receive::v2::WantsInputs,
     bitcoind: &bitcoincore_rpc::Client,
-) -> Result<payjoin::receive::v2::ProvisionalProposal> {
+) -> Result<payjoin::receive::v2::ProvisionalProposal, ImplementationError> {
     let candidate_inputs = bitcoind
         .list_unspent(None, None, None, None, None)
-        .context("Failed to list unspent from bitcoind")?
+        .map_err(ImplementationError::from)?
         .into_iter()
         .map(input_pair_from_list_unspent);
-    let selected_input = payjoin
-        .try_preserving_privacy(candidate_inputs)
-        .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
-    log::debug!("selected input: {:#?}", selected_input);
+
+    let selected_input =
+        payjoin.try_preserving_privacy(candidate_inputs).map_err(ImplementationError::from)?;
 
     Ok(payjoin
         .contribute_inputs(vec![selected_input])
-        .expect("This shouldn't happen. Failed to contribute inputs.")
+        .map_err(ImplementationError::from)?
         .commit_inputs())
 }
 

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -337,6 +337,17 @@ impl fmt::Display for SelectionError {
     }
 }
 
+impl error::Error for SelectionError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use InternalSelectionError::*;
+
+        match &self.0 {
+            Empty => None,
+            UnsupportedOutputLength => None,
+            NotFound => None,
+        }
+    }
+}
 impl From<InternalSelectionError> for SelectionError {
     fn from(value: InternalSelectionError) -> Self { SelectionError(value) }
 }
@@ -359,6 +370,14 @@ impl fmt::Display for InputContributionError {
         match &self.0 {
             InternalInputContributionError::ValueTooLow =>
                 write!(f, "Total input value is not enough to cover additional output value"),
+        }
+    }
+}
+
+impl error::Error for InputContributionError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.0 {
+            InternalInputContributionError::ValueTooLow => None,
         }
     }
 }


### PR DESCRIPTION
Our reference must not panic if input contribution fails, but instead show best practice for a non-automated receiver where the sender may choose to try to payjoin again or broadcast the transaction extracted from the original PSBT.

This is an implementation of my best idea for receiver error handling in [my comment](https://github.com/payjoin/rust-payjoin/issues/403#issuecomment-2651486357) in #403

After this I think the only things to stabilize receiver errors is to decide whether the single-variant `ContributionError` is correct and to mark errors as non-exhaustive, and potentially expose variants as public.