### PR TITLE
Add missing `#[cfg(test)]` to `send::v2` test module

### DIFF
--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -319,6 +319,7 @@ impl HpkeContext {
     }
 }
 
+#[cfg(test)]
 mod test {
     #[test]
     fn req_ctx_ser_de_roundtrip() {


### PR DESCRIPTION
The test module was missing the #[cfg(test)] attribute, causing unnecessary compilation in non-test builds.