### PR TITLE
RFC 9540 directory and receiver

### DIFF
--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -202,7 +202,7 @@ mod e2e {
 
             let directory = &services.directory_url().to_string();
             // Mock ohttp_relay since the ohttp_relay's http client doesn't have the certificate for the directory
-            let mock_ohttp_relay = directory;
+            let mock_ohttp_relay = &services.ohttp_gateway_url().to_string();
 
             let cli_receive_initiator = Command::new(payjoin_cli)
                 .arg("--rpchost")

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -185,6 +185,9 @@ async fn serve_payjoin_directory(
     let path_segments: Vec<&str> = path.split('/').collect();
     debug!("serve_payjoin_directory: {:?}", &path_segments);
     let mut response = match (parts.method, path_segments.as_slice()) {
+        (Method::POST, ["", ".well-known", "ohttp-gateway"]) =>
+            handle_ohttp_gateway(body, pool, ohttp).await,
+        (Method::GET, ["", ".well-known", "ohttp-gateway"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp).await,
         (Method::GET, ["", "ohttp-keys"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", id]) => post_fallback_v1(id, query, body, pool).await,

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -78,6 +78,11 @@ impl TestServices {
         Url::parse(&format!("http://localhost:{}", self.ohttp_relay.0)).expect("invalid URL")
     }
 
+    pub fn ohttp_gateway_url(&self) -> Url {
+        let url = self.directory_url();
+        url.join("/.well-known/ohttp-gateway").expect("invalid URL")
+    }
+
     pub fn take_ohttp_relay_handle(&mut self) -> JoinHandle<Result<(), BoxSendSyncError>> {
         self.ohttp_relay.1.take().expect("ohttp relay handle not found")
     }

--- a/payjoin/src/ohttp.rs
+++ b/payjoin/src/ohttp.rs
@@ -41,7 +41,7 @@ pub fn ohttp_encapsulate(
     }
 
     let mut bhttp_req = [0u8; PADDED_BHTTP_REQ_BYTES];
-    let _ = bhttp_message.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_req.as_mut_slice());
+    bhttp_message.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_req.as_mut_slice())?;
     let (encapsulated, ohttp_ctx) = ctx.encapsulate(&bhttp_req)?;
 
     let mut buffer = [0u8; ENCAPSULATED_MESSAGE_BYTES];

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -200,7 +200,7 @@ mod integration {
                 let agent = services.http_agent();
                 services.wait_for_services_ready().await?;
                 let directory = services.directory_url();
-                let mock_ohttp_relay = directory.clone(); // pass through to directory
+                let mock_ohttp_relay = services.ohttp_gateway_url();
                 let mock_address = Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")?
                     .assume_checked();
                 let mut bad_initializer =
@@ -228,7 +228,7 @@ mod integration {
                 let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
                 services.wait_for_services_ready().await?;
                 let directory = services.directory_url();
-                let ohttp_relay = services.ohttp_relay_url();
+                let ohttp_relay = services.ohttp_gateway_url();
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
                 // **********************
                 // Inside the Receiver:
@@ -290,7 +290,7 @@ mod integration {
                     Receiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None)?;
                 println!("session: {:#?}", &session);
                 // Poll receive request
-                let mock_ohttp_relay = directory.clone();
+                let mock_ohttp_relay = services.ohttp_gateway_url();
                 let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
                 let response = agent.post(req.url).body(req.body).send().await?;
                 assert!(response.status().is_success(), "error response: {}", response.status());
@@ -483,7 +483,7 @@ mod integration {
                 let agent_clone: Arc<Client> = agent.clone();
                 let receiver: Arc<bitcoincore_rpc::Client> = Arc::new(receiver);
                 let receiver_clone = receiver.clone();
-                let mock_ohttp_relay = directory.clone();
+                let mock_ohttp_relay = services.ohttp_gateway_url();
                 let receiver_loop = tokio::task::spawn(async move {
                     let agent_clone = agent_clone.clone();
                     let (response, ctx) = loop {


### PR DESCRIPTION
This is a backwards compatible change to support RFC 9540.

The directory accepts requests at `/.well-known/ohttp-gateway`. The receiver also fetches OHTTP keys from the new RFC 9540 endpoint, instead of `/ohttp-keys`.

Unblocks payjoin/ohttp-relay#47.