### PR TITLE
don't accept invalid certs even in tests

### DIFF
--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -106,7 +106,6 @@ fn http_agent_builder() -> Result<reqwest::ClientBuilder> {
     let mut root_cert_store = RootCertStore::empty();
     root_cert_store.add(CertificateDer::from(cert_der.as_slice()))?;
     Ok(reqwest::ClientBuilder::new()
-        .danger_accept_invalid_certs(true)
         .use_rustls_tls()
         .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice())?))
 }

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -161,7 +161,7 @@ pub fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxSendSyncError> {
 }
 
 fn http_agent_builder(cert_der: Vec<u8>) -> ClientBuilder {
-    ClientBuilder::new().danger_accept_invalid_certs(true).use_rustls_tls().add_root_certificate(
+    ClientBuilder::new().use_rustls_tls().add_root_certificate(
         reqwest::tls::Certificate::from_der(cert_der.as_slice())
             .expect("cert_der should be a valid DER-encoded certificate"),
     )

--- a/payjoin/src/io.rs
+++ b/payjoin/src/io.rs
@@ -44,7 +44,6 @@ pub async fn fetch_ohttp_keys_with_cert(
     let ohttp_keys_url = payjoin_directory.into_url()?.join("/ohttp-keys")?;
     let proxy = Proxy::all(ohttp_relay.into_url()?.as_str())?;
     let client = Client::builder()
-        .danger_accept_invalid_certs(true)
         .use_rustls_tls()
         .add_root_certificate(reqwest::tls::Certificate::from_der(&cert_der)?)
         .proxy(proxy)


### PR DESCRIPTION
This is a minor cleanup change from the WIP self signed certificates that can be merged independently.

Turns out we're actually not (no longer?) relying on invalid certificates because the `with_cert` functionality just asserts that the self signed certificate, which is its own root, is valid.