### PR TITLE
Persistable payjoin types

### DIFF
--- a/payjoin-cli/src/db/error.rs
+++ b/payjoin-cli/src/db/error.rs
@@ -13,6 +13,8 @@ pub(crate) enum Error {
     Serialize(serde_json::Error),
     #[cfg(feature = "v2")]
     Deserialize(serde_json::Error),
+    #[cfg(feature = "v2")]
+    NotFound(String),
 }
 
 impl fmt::Display for Error {
@@ -23,6 +25,8 @@ impl fmt::Display for Error {
             Error::Serialize(e) => write!(f, "Serialization failed: {}", e),
             #[cfg(feature = "v2")]
             Error::Deserialize(e) => write!(f, "Deserialization failed: {}", e),
+            #[cfg(feature = "v2")]
+            Error::NotFound(key) => write!(f, "Key not found: {}", key),
         }
     }
 }

--- a/payjoin-cli/src/db/mod.rs
+++ b/payjoin-cli/src/db/mod.rs
@@ -27,4 +27,4 @@ impl Database {
 }
 
 #[cfg(feature = "v2")]
-mod v2;
+pub(crate) mod v2;

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -3,11 +3,35 @@ use std::sync::Arc;
 use bitcoincore_rpc::jsonrpc::serde_json;
 use payjoin::persist::{Persister, Value};
 use payjoin::receive::v2::{Receiver, ReceiverToken};
-use payjoin::send::v2::Sender;
+use payjoin::send::v2::{Sender, SenderToken};
 use sled::Tree;
 use url::Url;
 
 use super::*;
+
+pub(crate) struct SenderPersister(Arc<Database>);
+impl SenderPersister {
+    pub fn new(db: Arc<Database>) -> Self { Self(db) }
+}
+
+impl Persister<Sender> for SenderPersister {
+    type Token = SenderToken;
+    type Error = crate::db::error::Error;
+    fn save(&mut self, value: Sender) -> std::result::Result<SenderToken, Self::Error> {
+        let send_tree = self.0 .0.open_tree("send_sessions")?;
+        let key = value.key();
+        let value = serde_json::to_vec(&value).map_err(Error::Serialize)?;
+        send_tree.insert(key.clone(), value.as_slice())?;
+        send_tree.flush()?;
+        Ok(key)
+    }
+
+    fn load(&self, key: SenderToken) -> std::result::Result<Sender, Self::Error> {
+        let send_tree = self.0 .0.open_tree("send_sessions")?;
+        let value = send_tree.get(key.as_ref())?.ok_or(Error::NotFound(key.to_string()))?;
+        serde_json::from_slice(&value).map_err(Error::Deserialize)
+    }
+}
 
 pub(crate) struct ReceiverPersister(Arc<Database>);
 impl ReceiverPersister {
@@ -51,14 +75,6 @@ impl Database {
         Ok(())
     }
 
-    pub(crate) fn insert_send_session(&self, session: &mut Sender, pj_url: &Url) -> Result<()> {
-        let send_tree: Tree = self.0.open_tree("send_sessions")?;
-        let value = serde_json::to_string(session).map_err(Error::Serialize)?;
-        send_tree.insert(pj_url.to_string(), IVec::from(value.as_str()))?;
-        send_tree.flush()?;
-        Ok(())
-    }
-
     pub(crate) fn get_send_sessions(&self) -> Result<Vec<Sender>> {
         let send_tree: Tree = self.0.open_tree("send_sessions")?;
         let mut sessions = Vec::new();
@@ -72,7 +88,7 @@ impl Database {
 
     pub(crate) fn get_send_session(&self, pj_url: &Url) -> Result<Option<Sender>> {
         let send_tree = self.0.open_tree("send_sessions")?;
-        if let Some(val) = send_tree.get(pj_url.to_string())? {
+        if let Some(val) = send_tree.get(pj_url.as_str())? {
             let session: Sender = serde_json::from_slice(&val).map_err(Error::Deserialize)?;
             Ok(Some(session))
         } else {
@@ -82,7 +98,7 @@ impl Database {
 
     pub(crate) fn clear_send_session(&self, pj_url: &Url) -> Result<()> {
         let send_tree: Tree = self.0.open_tree("send_sessions")?;
-        send_tree.remove(pj_url.to_string())?;
+        send_tree.remove(pj_url.as_str())?;
         send_tree.flush()?;
         Ok(())
     }

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -29,6 +29,9 @@ pub mod receive;
 pub mod send;
 
 #[cfg(feature = "v2")]
+pub mod persist;
+
+#[cfg(feature = "v2")]
 pub(crate) mod hpke;
 #[cfg(feature = "v2")]
 pub use crate::hpke::{HpkeKeyPair, HpkePublicKey};

--- a/payjoin/src/persist/mod.rs
+++ b/payjoin/src/persist/mod.rs
@@ -1,0 +1,61 @@
+use std::fmt::Display;
+
+/// Types that can generate their own keys for persistent storage
+pub trait Value: serde::Serialize + serde::de::DeserializeOwned + Sized + Clone {
+    type Key: AsRef<[u8]> + Clone + Display;
+
+    /// Unique identifier for this persisted value
+    fn key(&self) -> Self::Key;
+}
+
+/// Implemented types that should be persisted by the application.
+pub trait Persister<V: Value> {
+    type Token: From<V>;
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    fn save(&mut self, value: V) -> Result<Self::Token, Self::Error>;
+    fn load(&self, token: Self::Token) -> Result<V, Self::Error>;
+}
+
+/// A key type that stores the value itself for no-op persistence
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct NoopToken<V: Value>(V);
+
+impl<V: Value> AsRef<[u8]> for NoopToken<V> {
+    fn as_ref(&self) -> &[u8] {
+        // Since this is a no-op implementation, we can return an empty slice
+        // as we never actually need to use the bytes
+        &[]
+    }
+}
+
+impl<'de, V: Value> serde::Deserialize<'de> for NoopToken<V> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(NoopToken(V::deserialize(deserializer)?))
+    }
+}
+
+impl<V: Value> Value for NoopToken<V> {
+    type Key = V::Key;
+
+    fn key(&self) -> Self::Key { self.0.key() }
+}
+
+/// A persister that does nothing but store values in memory
+#[derive(Debug, Clone)]
+pub struct NoopPersister;
+
+impl<V: Value> From<V> for NoopToken<V> {
+    fn from(value: V) -> Self { NoopToken(value) }
+}
+impl<V: Value> Persister<V> for NoopPersister {
+    type Token = NoopToken<V>;
+    type Error = std::convert::Infallible;
+
+    fn save(&mut self, value: V) -> Result<Self::Token, Self::Error> { Ok(NoopToken(value)) }
+
+    fn load(&self, token: Self::Token) -> Result<V, Self::Error> { Ok(token.0) }
+}

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 use crate::uri::url_ext::ParseReceiverPubkeyParamError;
 
+pub type ImplementationError = Box<dyn std::error::Error + Send + Sync>;
 /// Error returned when request could not be created.
 ///
 /// This error can currently only happen due to programmer mistake.

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -171,7 +171,8 @@ mod integration {
 
         use bitcoin::Address;
         use http::StatusCode;
-        use payjoin::receive::v2::{PayjoinProposal, Receiver, UncheckedProposal};
+        use payjoin::persist::NoopPersister;
+        use payjoin::receive::v2::{NewReceiver, PayjoinProposal, Receiver, UncheckedProposal};
         use payjoin::send::v2::SenderBuilder;
         use payjoin::{OhttpKeys, PjUri, UriExt};
         use payjoin_test_utils::{BoxSendSyncError, TestServices};
@@ -205,8 +206,9 @@ mod integration {
                 let ohttp_relay = services.ohttp_relay_url();
                 let mock_address = Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")?
                     .assume_checked();
-                let mut bad_initializer =
-                    Receiver::new(mock_address, directory, bad_ohttp_keys, None)?;
+                let new_receiver = NewReceiver::new(mock_address, directory, bad_ohttp_keys, None)?;
+                let storage_token = new_receiver.persist(&mut NoopPersister)?;
+                let mut bad_initializer = Receiver::load(storage_token, &NoopPersister)?;
                 let (req, _ctx) = bad_initializer.extract_req(&ohttp_relay)?;
                 agent
                     .post(req.url)
@@ -242,12 +244,16 @@ mod integration {
                 // Inside the Receiver:
                 let address = receiver.get_new_address(None, None)?.assume_checked();
                 // test session with expiry in the past
-                let mut expired_receiver = Receiver::new(
+                let new_receiver = NewReceiver::new(
                     address.clone(),
                     directory.clone(),
                     ohttp_keys.clone(),
                     Some(Duration::from_secs(0)),
                 )?;
+                let storage_token =
+                    new_receiver.persist(&mut NoopPersister).map_err(|e| e.to_string())?;
+                let mut expired_receiver =
+                    Receiver::load(storage_token, &NoopPersister).map_err(|e| e.to_string())?;
                 match expired_receiver.extract_req(&ohttp_relay) {
                     // Internal error types are private, so check against a string
                     Err(err) => assert!(err.to_string().contains("expired")),
@@ -294,8 +300,12 @@ mod integration {
                 let address = receiver.get_new_address(None, None)?.assume_checked();
 
                 // test session with expiry in the future
+                let new_receiver =
+                    NewReceiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None)?;
+                let storage_token =
+                    new_receiver.persist(&mut NoopPersister).map_err(|e| e.to_string())?;
                 let mut session =
-                    Receiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None)?;
+                    Receiver::load(storage_token, &NoopPersister).map_err(|e| e.to_string())?;
                 println!("session: {:#?}", &session);
                 // Poll receive request
                 let ohttp_relay = services.ohttp_relay_url();
@@ -465,9 +475,12 @@ mod integration {
                 let directory = services.directory_url();
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
                 let address = receiver.get_new_address(None, None)?.assume_checked();
-
+                let new_receiver =
+                    NewReceiver::new(address, directory.clone(), ohttp_keys.clone(), None)?;
+                let storage_token =
+                    new_receiver.persist(&mut NoopPersister).map_err(|e| e.to_string())?;
                 let mut session =
-                    Receiver::new(address, directory.clone(), ohttp_keys.clone(), None)?;
+                    Receiver::load(storage_token, &NoopPersister).map_err(|e| e.to_string())?;
 
                 // **********************
                 // Inside the V1 Sender:
@@ -690,7 +703,8 @@ mod integration {
     #[cfg(feature = "_multiparty")]
     mod multiparty {
         use bitcoin::ScriptBuf;
-        use payjoin::receive::v2::Receiver;
+        use payjoin::persist::NoopPersister;
+        use payjoin::receive::v2::{NewReceiver, Receiver};
         use payjoin::send::multiparty::{
             GetContext as MultiPartyGetContext, SenderBuilder as MultiPartySenderBuilder,
         };
@@ -738,12 +752,16 @@ mod integration {
                 // Senders will generate a sweep psbt and send PSBT to receiver subdir
                 for sender in senders.iter() {
                     let address = receiver.get_new_address(None, None)?.assume_checked();
-                    let receiver_session = Receiver::new(
+                    let new_receiver = NewReceiver::new(
                         address.clone(),
                         directory.clone(),
                         ohttp_keys.clone(),
                         None,
                     )?;
+                    let storage_token =
+                        new_receiver.persist(&mut NoopPersister).map_err(|e| e.to_string())?;
+                    let receiver_session =
+                        Receiver::load(storage_token, &NoopPersister).map_err(|e| e.to_string())?;
                     let pj_uri = receiver_session.pj_uri();
                     let psbt = build_sweep_psbt(sender, &pj_uri)?;
                     let sender_ctx = MultiPartySenderBuilder::new(psbt.clone(), pj_uri.clone())


### PR DESCRIPTION
Drafting this for now. This is at feature parity with the current functionality of payjoin-cli. Persistance is now implemented for both the sender and reciever. We are only persisting when the sender and reciver are first intialized. The trait design is architected in such a way that its easily expandable for other state of the senders and reciever. For example if a application is expecting to save the state at init and finalize and non of the intermediate steps that is an option. And for the reciever I would advocate in a seperate PR that we persist when the reciever when first crated, proposal fetched and payjoin created. 

There is alot to bikeshed when we consider persisting other reciever & sender states. We'll cross that bridge that when we get there but I will say this design is more friendly towards persisting other states, compared to #560.

Alternative design of the same functionality: #560 
Issue: https://github.com/payjoin/rust-payjoin/issues/336 , #477
