### PR TITLE
Add tests for send v2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ cargo update -p zstd-sys --precise 2.0.8+zstd.1.5.5
 
 ## Contributing
 
+### Commit Messages
+
+The git repository is our source of truth for development history. Therefore the commit history is the most important communication
+artifact we produce. Commit messages must follow [the seven rules in this guide by cbeams](https://cbea.ms/git-commit/#seven-rules).
+
 ### Nix Development Shells
 
 Where nix is available (NixOS or

--- a/payjoin-cli/contrib/test.sh
+++ b/payjoin-cli/contrib/test.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-cargo test --locked --package payjoin-cli --verbose --no-default-features --features=_danger-local-https,v2 --test e2e
-cargo test --locked --package payjoin-cli --verbose --no-default-features --features=v1,_danger-local-https
+cargo test --locked --package payjoin-cli --verbose --all-features

--- a/payjoin-cli/example.config.toml
+++ b/payjoin-cli/example.config.toml
@@ -37,24 +37,20 @@ rpcuser = "user"
 # The rpcpassword of the user to connect to (specified in bitcoin.conf).
 rpcpassword = "password"
 
-# Version 1 Settings
-# -----------------
-[v1]
-# (v1, receiver only) The port for v1 receiving servers to bind to.
-port = 3000
+# Version Configuration
+# -------------------
+# Uncomment ONE of the following version configurations depending on which version you want to use
 
-# (v1, receiver only) The payjoin endpoint which coordinates the transaction.
-pj_endpoint = "https://localhost:3000"
+# Version 1 Configuration
+# [v1]
+# port = 3000
+# pj_endpoint = "https://localhost:3000"
 
-# Version 2 Settings
-# -----------------
-[v2]
-# (v2 only) The payjoin directory to rendezvous at.
-pj_directory = "https://payjo.in"
-
-# (v2 only) The OHTTP relay that will forward requests to the OHTTP Gateway, which will forward to the pj_endpoint directory.
-ohttp_relay = "https://pj.bobspacebkk.com"
-
-# (v2 only, optional) The HPKE keys which need to be fetched ahead of time from the pj_endpoint for the payjoin packets to be encrypted.
-# These can now be fetched and no longer need to be configured.
-ohttp_keys = "./path/to/ohttp_keys"
+# Version 2 Configuration
+# [v2]
+# pj_directory = "https://payjo.in"
+# ohttp_relay = "https://pj.bobspacebkk.com"
+# # Optional: The HPKE keys which need to be fetched ahead of time from the pj_endpoint
+# # for the payjoin packets to be encrypted.
+# # These can now be fetched and no longer need to be configured.
+# ohttp_keys = "./path/to/ohttp_keys"

--- a/payjoin-cli/example.config.toml
+++ b/payjoin-cli/example.config.toml
@@ -2,18 +2,25 @@
 ## Payjoin config.toml configuration file. Lines beginning with # are comments.
 ##
 
+# Common Settings
+# --------------
+
+# The path to the database file
+db_path = "payjoin.db"
+
+# The maximum fee rate that the receiver is willing to pay (in sat/vB)
+max_fee_rate = 2.0
+
 # Bitcoin RPC Connection Settings
 # ------------------------------
-
-
+[bitcoind]
 # The RPC host of the wallet to connect to.
 # For example, if the wallet is "sender", then default values are:
 # 	- mainnet: http://localhost:8332/wallet/sender
 # 	- testnet: http://localhost:18332/wallet/sender
 # 	- regtest: http://localhost:18443/wallet/sender
 # 	- signet: http://localhost:38332/wallet/sender
-bitcoind_rpchost="http://localhost:18443/wallet/sender"
-
+rpchost = "http://localhost:18443/wallet/sender"
 
 # The RPC .cookie file used only for local authentication to bitcoind.
 # If rpcuser and rpcpassword are being used, this is not necessary.
@@ -22,36 +29,32 @@ bitcoind_rpchost="http://localhost:18443/wallet/sender"
 # 	MacOS: ~/Library/Application Support/Bitcoin/<NETWORK>/.cookie
 # 	Windows Vista and later: C:\Users\YourUserName\AppData\Roaming\Bitcoin\<NETWORK>\.cookie
 # 	Windows XP: C:\Documents and Settings\YourUserName\Application Data\Bitcoin\<NETWORK>\.cookie
-# bitcoind_cookie=
-
+cookie = ""
 
 # The rpcuser to connect to (specified in bitcoin.conf).
-bitcoind_rpcuser="user"
-
+rpcuser = "user"
 
 # The rpcpassword of the user to connect to (specified in bitcoin.conf).
-bitcoind_rpcpassword="password"
+rpcpassword = "password"
 
-## Payjoin Settings
-## ----------------
-
-
+# Version 1 Settings
+# -----------------
+[v1]
 # (v1, receiver only) The port for v1 receiving servers to bind to.
-port="3000"
-
+port = 3000
 
 # (v1, receiver only) The payjoin endpoint which coordinates the transaction.
-pj_endpoint="https://localhost:3000"
+pj_endpoint = "https://localhost:3000"
 
-
+# Version 2 Settings
+# -----------------
+[v2]
 # (v2 only) The payjoin directory to rendezvous at.
 pj_directory = "https://payjo.in"
 
-
 # (v2 only) The OHTTP relay that will forward requests to the OHTTP Gateway, which will forward to the pj_endpoint directory.
-ohttp_relay="https://pj.bobspacebkk.com"
-
+ohttp_relay = "https://pj.bobspacebkk.com"
 
 # (v2 only, optional) The HPKE keys which need to be fetched ahead of time from the pj_endpoint for the payjoin packets to be encrypted.
 # These can now be fetched and no longer need to be configured.
-ohttp_keys="./path/to/ohttp_keys"
+ohttp_keys = "./path/to/ohttp_keys"

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -2,12 +2,15 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::ArgMatches;
+use config::builder::DefaultState;
 use config::{ConfigError, File, FileFormat};
 use payjoin::bitcoin::FeeRate;
 use serde::Deserialize;
 use url::Url;
 
 use crate::db;
+
+type Builder = config::builder::ConfigBuilder<DefaultState>;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct BitcoindConfig {
@@ -46,96 +49,126 @@ pub struct Config {
 
 impl Config {
     pub(crate) fn new(matches: &ArgMatches) -> Result<Self, ConfigError> {
-        let builder = config::Config::builder()
-            // BitcoindConfig defaults
-            .set_default("bitcoind.rpchost", "http://localhost:18443")?
-            .set_override_option(
-                "bitcoind.rpchost",
-                matches.get_one::<Url>("rpchost").map(|s| s.as_str()),
-            )?
-            .set_default("bitcoind.cookie", None::<String>)?
-            .set_override_option(
-                "bitcoind.cookie",
-                matches.get_one::<String>("cookie_file").map(|s| s.as_str()),
-            )?
-            .set_default("bitcoind.rpcuser", "bitcoin")?
-            .set_override_option(
-                "bitcoind.rpcuser",
-                matches.get_one::<String>("rpcuser").map(|s| s.as_str()),
-            )?
-            .set_default("bitcoind.rpcpassword", "")?
-            .set_override_option(
-                "bitcoind.rpcpassword",
-                matches.get_one::<String>("rpcpassword").map(|s| s.as_str()),
-            )?
-            // Common defaults
-            .set_default("db_path", db::DB_PATH)?
-            .set_override_option(
-                "db_path",
-                matches.get_one::<String>("db_path").map(|s| s.as_str()),
-            )?
-            .add_source(File::new("config.toml", FileFormat::Toml).required(false));
+        let mut builder = config::Config::builder();
+        builder = add_bitcoind_defaults(builder, matches)?;
+        builder = add_common_defaults(builder, matches)?;
 
-        // Add V1Config defaults when not using V2
         #[cfg(feature = "v1")]
-        let builder = builder
-            .set_default("v1.port", 3000_u16)?
-            .set_default("v1.pj_endpoint", "https://localhost:3000")?;
+        {
+            builder = add_v1_defaults(builder)?;
+        }
 
-        // Add V2Config defaults when using V2
         #[cfg(feature = "v2")]
-        let builder = builder
-            .set_override_option(
-                "v2.ohttp_relay",
-                matches.get_one::<Url>("ohttp_relay").map(|s| s.as_str()),
-            )?
-            .set_default("v2.pj_directory", "https://payjo.in")?
-            .set_default("v2.ohttp_keys", None::<String>)?;
+        {
+            builder = add_v2_defaults(builder, matches)?;
+        }
 
-        let builder = match matches.subcommand() {
-            Some(("send", _)) => builder,
-            Some(("receive", matches)) => {
-                #[cfg(not(feature = "v2"))]
-                let builder = {
-                    let port = matches
-                        .get_one::<String>("port")
-                        .map(|port| port.parse::<u16>())
-                        .transpose()
-                        .map_err(|_| {
-                            ConfigError::Message("\"port\" must be a valid number".to_string())
-                        })?;
-                    builder.set_override_option("v1.port", port)?.set_override_option(
-                        "v1.pj_endpoint",
-                        matches.get_one::<Url>("pj_endpoint").map(|s| s.as_str()),
-                    )?
-                };
-
-                #[cfg(feature = "v2")]
-                let builder = {
-                    builder
-                        .set_override_option(
-                            "v2.pj_directory",
-                            matches.get_one::<Url>("pj_directory").map(|s| s.as_str()),
-                        )?
-                        .set_override_option(
-                            "v2.ohttp_keys",
-                            matches.get_one::<String>("ohttp_keys").map(|s| s.as_str()),
-                        )?
-                };
-
-                let max_fee_rate = matches.get_one::<FeeRate>("max_fee_rate");
-                builder.set_override_option("max_fee_rate", max_fee_rate.map(|f| f.to_string()))?
-            }
-            #[cfg(feature = "v2")]
-            Some(("resume", _)) => builder,
-            _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
-        };
+        builder = handle_subcommands(builder, matches)?;
+        builder = builder.add_source(File::new("config.toml", FileFormat::Toml).required(false));
 
         let config = builder.build()?;
         let app_config: Config = config.try_deserialize()?;
         log::debug!("App config: {:?}", app_config);
         Ok(app_config)
     }
+}
+
+/// Set up default values and CLI overrides for Bitcoin RPC connection settings
+fn add_bitcoind_defaults(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
+    builder
+        .set_default("bitcoind.rpchost", "http://localhost:18443")?
+        .set_override_option(
+            "bitcoind.rpchost",
+            matches.get_one::<Url>("rpchost").map(|s| s.as_str()),
+        )?
+        .set_default("bitcoind.cookie", None::<String>)?
+        .set_override_option(
+            "bitcoind.cookie",
+            matches.get_one::<String>("cookie_file").map(|s| s.as_str()),
+        )?
+        .set_default("bitcoind.rpcuser", "bitcoin")?
+        .set_override_option(
+            "bitcoind.rpcuser",
+            matches.get_one::<String>("rpcuser").map(|s| s.as_str()),
+        )?
+        .set_default("bitcoind.rpcpassword", "")?
+        .set_override_option(
+            "bitcoind.rpcpassword",
+            matches.get_one::<String>("rpcpassword").map(|s| s.as_str()),
+        )
+}
+
+/// Set up default values and CLI overrides for common settings shared between v1 and v2
+fn add_common_defaults(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
+    builder
+        .set_default("db_path", db::DB_PATH)?
+        .set_override_option("db_path", matches.get_one::<String>("db_path").map(|s| s.as_str()))
+}
+
+/// Set up default values for v1-specific settings when v2 is not enabled
+#[cfg(feature = "v1")]
+fn add_v1_defaults(builder: Builder) -> Result<Builder, ConfigError> {
+    builder
+        .set_default("v1.port", 3000_u16)?
+        .set_default("v1.pj_endpoint", "https://localhost:3000")
+}
+
+/// Set up default values and CLI overrides for v2-specific settings
+#[cfg(feature = "v2")]
+fn add_v2_defaults(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
+    builder
+        .set_override_option(
+            "v2.ohttp_relay",
+            matches.get_one::<Url>("ohttp_relay").map(|s| s.as_str()),
+        )?
+        .set_default("v2.pj_directory", "https://payjo.in")?
+        .set_default("v2.ohttp_keys", None::<String>)
+}
+
+/// Handles configuration overrides based on CLI subcommands
+fn handle_subcommands(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
+    match matches.subcommand() {
+        Some(("send", _)) => Ok(builder),
+        Some(("receive", matches)) => {
+            let builder = handle_receive_command(builder, matches)?;
+            let max_fee_rate = matches.get_one::<FeeRate>("max_fee_rate");
+            builder.set_override_option("max_fee_rate", max_fee_rate.map(|f| f.to_string()))
+        }
+        #[cfg(feature = "v2")]
+        Some(("resume", _)) => Ok(builder),
+        _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
+    }
+}
+
+/// Handle configuration overrides specific to the receive command
+fn handle_receive_command(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
+    #[cfg(not(feature = "v2"))]
+    let builder = {
+        let port = matches
+            .get_one::<String>("port")
+            .map(|port| port.parse::<u16>())
+            .transpose()
+            .map_err(|_| ConfigError::Message("\"port\" must be a valid number".to_string()))?;
+        builder.set_override_option("v1.port", port)?.set_override_option(
+            "v1.pj_endpoint",
+            matches.get_one::<Url>("pj_endpoint").map(|s| s.as_str()),
+        )?
+    };
+
+    #[cfg(feature = "v2")]
+    let builder = {
+        builder
+            .set_override_option(
+                "v2.pj_directory",
+                matches.get_one::<Url>("pj_directory").map(|s| s.as_str()),
+            )?
+            .set_override_option(
+                "v2.ohttp_keys",
+                matches.get_one::<String>("ohttp_keys").map(|s| s.as_str()),
+            )?
+    };
+
+    Ok(builder)
 }
 
 #[cfg(feature = "v2")]

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::ArgMatches;
-use config::{Config, ConfigError, File, FileFormat};
+use config::{ConfigError, File, FileFormat};
 use payjoin::bitcoin::FeeRate;
 use serde::Deserialize;
 use url::Url;
@@ -34,7 +34,7 @@ pub struct V2Config {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct AppConfig {
+pub struct Config {
     pub db_path: PathBuf,
     pub max_fee_rate: Option<FeeRate>,
     pub bitcoind: BitcoindConfig,
@@ -44,9 +44,9 @@ pub struct AppConfig {
     pub v2: V2Config,
 }
 
-impl AppConfig {
+impl Config {
     pub(crate) fn new(matches: &ArgMatches) -> Result<Self, ConfigError> {
-        let builder = Config::builder()
+        let builder = config::Config::builder()
             // BitcoindConfig defaults
             .set_default("bitcoind.rpchost", "http://localhost:18443")?
             .set_override_option(
@@ -132,7 +132,7 @@ impl AppConfig {
         };
 
         let config = builder.build()?;
-        let app_config: AppConfig = config.try_deserialize()?;
+        let app_config: Config = config.try_deserialize()?;
         log::debug!("App config: {:?}", app_config);
         Ok(app_config)
     }

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -16,7 +16,7 @@ use tokio::sync::watch;
 pub mod config;
 use crate::app::config::AppConfig;
 
-#[cfg(all(not(feature = "v2"), feature = "v1"))]
+#[cfg(feature = "v1")]
 pub(crate) mod v1;
 #[cfg(feature = "v2")]
 pub(crate) mod v2;

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -106,7 +106,6 @@ fn http_agent_builder() -> Result<reqwest::ClientBuilder> {
     let mut root_cert_store = RootCertStore::empty();
     root_cert_store.add(CertificateDer::from(cert_der.as_slice()))?;
     Ok(reqwest::ClientBuilder::new()
-        .danger_accept_invalid_certs(true)
         .use_rustls_tls()
         .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice())?))
 }

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -22,7 +22,7 @@ pub(crate) mod v2;
 pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 #[async_trait::async_trait]
-pub trait App {
+pub trait App: Send + Sync {
     fn new(config: Config) -> Result<Self>
     where
         Self: Sized;

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -14,7 +14,7 @@ use tokio::signal;
 use tokio::sync::watch;
 
 pub mod config;
-use crate::app::config::AppConfig;
+use crate::app::config::Config;
 
 #[cfg(feature = "v1")]
 pub(crate) mod v1;
@@ -26,7 +26,7 @@ pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 #[async_trait::async_trait]
 pub trait App {
-    fn new(config: AppConfig) -> Result<Self>
+    fn new(config: Config) -> Result<Self>
     where
         Self: Sized;
     fn bitcoind(&self) -> Result<bitcoincore_rpc::Client>;

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -1,20 +1,17 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 
-use anyhow::{anyhow, Context, Result};
-use bitcoin::psbt::Input as PsbtInput;
-use bitcoin::TxIn;
+use anyhow::{anyhow, Result};
 use bitcoincore_rpc::bitcoin::Amount;
-use bitcoincore_rpc::RpcApi;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::FeeRate;
-use payjoin::receive::InputPair;
 use payjoin::{bitcoin, PjUri};
 use tokio::signal;
 use tokio::sync::watch;
 
 pub mod config;
+pub mod wallet;
 use crate::app::config::Config;
+use crate::app::wallet::BitcoindWallet;
 
 #[cfg(feature = "v1")]
 pub(crate) mod v1;
@@ -29,7 +26,7 @@ pub trait App {
     fn new(config: Config) -> Result<Self>
     where
         Self: Sized;
-    fn bitcoind(&self) -> Result<bitcoincore_rpc::Client>;
+    fn wallet(&self) -> BitcoindWallet;
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()>;
     async fn receive_payjoin(&self, amount: Amount) -> Result<()>;
     #[cfg(feature = "v2")]
@@ -41,53 +38,18 @@ pub trait App {
         // wallet_create_funded_psbt requires a HashMap<address: String, Amount>
         let mut outputs = HashMap::with_capacity(1);
         outputs.insert(uri.address.to_string(), amount);
-        let fee_sat_per_kvb =
-            fee_rate.to_sat_per_kwu().checked_mul(4).ok_or(anyhow!("Invalid fee rate"))?;
-        let fee_per_kvb = Amount::from_sat(fee_sat_per_kvb);
-        log::debug!("Fee rate sat/kvb: {}", fee_per_kvb.display_in(bitcoin::Denomination::Satoshi));
-        let options = bitcoincore_rpc::json::WalletCreateFundedPsbtOptions {
-            lock_unspent: Some(true),
-            fee_rate: Some(fee_per_kvb),
-            ..Default::default()
-        };
-        let psbt = self
-            .bitcoind()?
-            .wallet_create_funded_psbt(
-                &[], // inputs
-                &outputs,
-                None, // locktime
-                Some(options),
-                None,
-            )
-            .context("Failed to create PSBT")?
-            .psbt;
-        let psbt = self
-            .bitcoind()?
-            .wallet_process_psbt(&psbt, None, None, None)
-            .with_context(|| "Failed to process PSBT")?
-            .psbt;
-        let psbt = Psbt::from_str(&psbt).with_context(|| "Failed to load PSBT from base64")?;
-        log::debug!("Original psbt: {:#?}", psbt);
-        Ok(psbt)
+
+        self.wallet().create_psbt(outputs, fee_rate, true)
     }
 
     fn process_pj_response(&self, psbt: Psbt) -> Result<bitcoin::Txid> {
         log::debug!("Proposed psbt: {:#?}", psbt);
-        let psbt = self
-            .bitcoind()?
-            .wallet_process_psbt(&psbt.to_string(), None, None, None)
-            .with_context(|| "Failed to process PSBT")?
-            .psbt;
-        let tx = self
-            .bitcoind()?
-            .finalize_psbt(&psbt, Some(true))
-            .with_context(|| "Failed to finalize PSBT")?
-            .hex
-            .ok_or_else(|| anyhow!("Incomplete PSBT"))?;
-        let txid = self
-            .bitcoind()?
-            .send_raw_transaction(&tx)
-            .with_context(|| "Failed to send raw transaction")?;
+
+        let signed = self.wallet().process_psbt(&psbt)?;
+        let tx = self.wallet().finalize_psbt(&signed)?;
+
+        let txid = self.wallet().broadcast_tx(&tx)?;
+
         println!("Payjoin sent. TXID: {}", txid);
         Ok(txid)
     }
@@ -117,27 +79,6 @@ fn read_local_cert() -> Result<Vec<u8>> {
     let mut local_cert_path = std::env::temp_dir();
     local_cert_path.push(LOCAL_CERT_FILE);
     Ok(std::fs::read(local_cert_path)?)
-}
-
-pub fn input_pair_from_list_unspent(
-    utxo: bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry,
-) -> InputPair {
-    let psbtin = PsbtInput {
-        // NOTE: non_witness_utxo is not necessary because bitcoin-cli always supplies
-        // witness_utxo, even for non-witness inputs
-        witness_utxo: Some(bitcoin::TxOut {
-            value: utxo.amount,
-            script_pubkey: utxo.script_pub_key.clone(),
-        }),
-        redeem_script: utxo.redeem_script.clone(),
-        witness_script: utxo.witness_script.clone(),
-        ..Default::default()
-    };
-    let txin = TxIn {
-        previous_output: bitcoin::OutPoint { txid: utxo.txid, vout: utxo.vout },
-        ..Default::default()
-    };
-    InputPair::new(txin, psbtin).expect("Input pair should be valid")
 }
 
 async fn handle_interrupt(tx: watch::Sender<()>) {

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -31,7 +31,9 @@ pub trait App {
         Self: Sized;
     fn bitcoind(&self) -> Result<bitcoincore_rpc::Client>;
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()>;
-    async fn receive_payjoin(self, amount: Amount) -> Result<()>;
+    async fn receive_payjoin(&self, amount: Amount) -> Result<()>;
+    #[cfg(feature = "v2")]
+    async fn resume_payjoins(&self) -> Result<()>;
 
     fn create_original_psbt(&self, uri: &PjUri, fee_rate: FeeRate) -> Result<Psbt> {
         let amount = uri.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -113,7 +113,7 @@ impl AppTrait for App {
         Ok(())
     }
 
-    async fn receive_payjoin(self, amount: Amount) -> Result<()> {
+    async fn receive_payjoin(&self, amount: Amount) -> Result<()> {
         let pj_uri_string = self.construct_payjoin_uri(amount, None)?;
         println!(
             "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
@@ -129,6 +129,11 @@ impl AppTrait for App {
             }
         }
         Ok(())
+    }
+
+    #[cfg(feature = "v2")]
+    async fn resume_payjoins(&self) -> Result<()> {
+        unimplemented!("resume_payjoins not implemented for v1");
     }
 }
 
@@ -153,7 +158,7 @@ impl App {
         Ok(pj_uri.to_string())
     }
 
-    async fn start_http_server(self) -> Result<()> {
+    async fn start_http_server(&self) -> Result<()> {
         let addr = SocketAddr::from(([0, 0, 0, 0], self.config.port));
         let listener = TcpListener::bind(addr).await?;
         let app = self.clone();

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::bitcoin::Amount;
-use bitcoincore_rpc::RpcApi;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Buf, Bytes, Incoming};
@@ -14,7 +13,7 @@ use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use payjoin::bitcoin::psbt::Psbt;
-use payjoin::bitcoin::{self, FeeRate};
+use payjoin::bitcoin::FeeRate;
 use payjoin::receive::v1::{PayjoinProposal, UncheckedProposal};
 use payjoin::receive::ImplementationError;
 use payjoin::receive::ReplyableError::{self, Implementation, V1};
@@ -24,8 +23,9 @@ use tokio::net::TcpListener;
 use tokio::sync::watch;
 
 use super::config::Config;
+use super::wallet::BitcoindWallet;
 use super::App as AppTrait;
-use crate::app::{handle_interrupt, http_agent, input_pair_from_list_unspent};
+use crate::app::{handle_interrupt, http_agent};
 use crate::db::Database;
 #[cfg(feature = "_danger-local-https")]
 pub const LOCAL_CERT_FILE: &str = "localhost.der";
@@ -41,6 +41,7 @@ impl payjoin::receive::v1::Headers for Headers<'_> {
 pub(crate) struct App {
     config: Config,
     db: Arc<Database>,
+    wallet: BitcoindWallet,
     interrupt: watch::Receiver<()>,
 }
 
@@ -50,29 +51,15 @@ impl AppTrait for App {
         let db = Arc::new(Database::create(&config.db_path)?);
         let (interrupt_tx, interrupt_rx) = watch::channel(());
         tokio::spawn(handle_interrupt(interrupt_tx));
-        let app = Self { config, db, interrupt: interrupt_rx };
-        app.bitcoind()?
-            .get_blockchain_info()
+        let wallet = BitcoindWallet::new(&config.bitcoind)?;
+        let app = Self { config, db, wallet, interrupt: interrupt_rx };
+        app.wallet()
+            .network()
             .context("Failed to connect to bitcoind. Check config RPC connection.")?;
         Ok(app)
     }
 
-    fn bitcoind(&self) -> Result<bitcoincore_rpc::Client> {
-        match &self.config.bitcoind.cookie {
-            Some(cookie) => bitcoincore_rpc::Client::new(
-                self.config.bitcoind.rpchost.as_str(),
-                bitcoincore_rpc::Auth::CookieFile(cookie.into()),
-            ),
-            None => bitcoincore_rpc::Client::new(
-                self.config.bitcoind.rpchost.as_str(),
-                bitcoincore_rpc::Auth::UserPass(
-                    self.config.bitcoind.rpcuser.clone(),
-                    self.config.bitcoind.rpcpassword.clone(),
-                ),
-            ),
-        }
-        .with_context(|| "Failed to connect to bitcoind")
-    }
+    fn wallet(&self) -> BitcoindWallet { self.wallet.clone() }
 
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         let uri =
@@ -143,7 +130,7 @@ impl App {
         amount: Amount,
         fallback_target: Option<&str>,
     ) -> Result<String> {
-        let pj_receiver_address = self.bitcoind()?.get_new_address(None, None)?.assume_checked();
+        let pj_receiver_address = self.wallet.get_new_address()?;
         let pj_part = match fallback_target {
             Some(target) => target,
             None => self.config.v1.pj_endpoint.as_str(),
@@ -263,12 +250,7 @@ impl App {
         &self,
         amount: Option<Amount>,
     ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, ReplyableError> {
-        let address = self
-            .bitcoind()
-            .map_err(|e| Implementation(e.into()))?
-            .get_new_address(None, None)
-            .map_err(|e| Implementation(e.into()))?
-            .assume_checked();
+        let address = self.wallet.get_new_address().map_err(|e| Implementation(e.into()))?;
         let uri_string = if let Some(amount) = amount {
             format!(
                 "{}?amount={}&pj={}",
@@ -310,38 +292,18 @@ impl App {
         &self,
         proposal: UncheckedProposal,
     ) -> Result<PayjoinProposal, ReplyableError> {
-        let bitcoind = self.bitcoind().map_err(|e| Implementation(e.into()))?;
+        let wallet = self.wallet();
 
         // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
         let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
-        // The network is used for checks later
-        let network = bitcoind.get_blockchain_info().map_err(|e| Implementation(e.into()))?.chain;
-
         // Receive Check 1: Can Broadcast
         let proposal =
-            proposal.check_broadcast_suitability(None, |tx| {
-                let raw_tx = bitcoin::consensus::encode::serialize_hex(&tx);
-                let mempool_results = bitcoind
-                    .test_mempool_accept(&[raw_tx])
-                    .map_err(|e| Implementation(e.into()))?;
-                match mempool_results.first() {
-                    Some(result) => Ok(result.allowed),
-                    None => Err(ImplementationError::from(
-                        "No mempool results returned on broadcast check",
-                    )),
-                }
-            })?;
+            proposal.check_broadcast_suitability(None, |tx| Ok(wallet.can_broadcast(tx)?))?;
         log::trace!("check1");
 
         // Receive Check 2: receiver can't sign for proposal inputs
-        let proposal = proposal.check_inputs_not_owned(|input| {
-            if let Ok(address) = bitcoin::Address::from_script(input, network) {
-                Ok(bitcoind.get_address_info(&address).map(|info| info.is_mine.unwrap_or(false))?)
-            } else {
-                Ok(false)
-            }
-        })?;
+        let proposal = proposal.check_inputs_not_owned(|input| Ok(wallet.is_mine(input)?))?;
         log::trace!("check2");
 
         // Receive Check 3: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
@@ -349,35 +311,25 @@ impl App {
             .check_no_inputs_seen_before(|input| Ok(self.db.insert_input_seen_before(*input)?))?;
         log::trace!("check3");
 
-        let payjoin = payjoin.identify_receiver_outputs(|output_script| {
-            if let Ok(address) = bitcoin::Address::from_script(output_script, network) {
-                Ok(bitcoind.get_address_info(&address).map(|info| info.is_mine.unwrap_or(false))?)
-            } else {
-                Ok(false)
-            }
-        })?;
+        let payjoin = payjoin
+            .identify_receiver_outputs(|output_script| Ok(wallet.is_mine(output_script)?))?;
 
         let payjoin = payjoin
             .substitute_receiver_script(
-                &bitcoind
-                    .get_new_address(None, None)
-                    .map_err(|e| Implementation(e.into()))?
-                    .require_network(network)
+                &self
+                    .wallet
+                    .get_new_address()
                     .map_err(|e| Implementation(e.into()))?
                     .script_pubkey(),
             )
             .map_err(|e| Implementation(e.into()))?
             .commit_outputs();
 
-        let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &bitcoind)
+        let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &self.wallet)
             .map_err(ReplyableError::Implementation)?;
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
-            |psbt: &Psbt| {
-                let res =
-                    bitcoind.wallet_process_psbt(&psbt.to_string(), None, None, Some(false))?;
-                Ok(Psbt::from_str(&res.psbt)?)
-            },
+            |psbt| Ok(self.wallet.process_psbt(psbt)?),
             None,
             self.config.max_fee_rate,
         )?;
@@ -387,13 +339,9 @@ impl App {
 
 fn try_contributing_inputs(
     payjoin: payjoin::receive::v1::WantsInputs,
-    bitcoind: &bitcoincore_rpc::Client,
+    wallet: &BitcoindWallet,
 ) -> Result<payjoin::receive::v1::ProvisionalProposal, ImplementationError> {
-    let candidate_inputs = bitcoind
-        .list_unspent(None, None, None, None, None)
-        .map_err(ImplementationError::from)?
-        .into_iter()
-        .map(input_pair_from_list_unspent);
+    let candidate_inputs = wallet.list_unspent()?;
 
     let selected_input =
         payjoin.try_preserving_privacy(candidate_inputs).map_err(ImplementationError::from)?;

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -23,7 +23,7 @@ use payjoin::{Uri, UriExt};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 
-use super::config::AppConfig;
+use super::config::Config;
 use super::App as AppTrait;
 use crate::app::{handle_interrupt, http_agent, input_pair_from_list_unspent};
 use crate::db::Database;
@@ -39,14 +39,14 @@ impl payjoin::receive::v1::Headers for Headers<'_> {
 
 #[derive(Clone)]
 pub(crate) struct App {
-    config: AppConfig,
+    config: Config,
     db: Arc<Database>,
     interrupt: watch::Receiver<()>,
 }
 
 #[async_trait::async_trait]
 impl AppTrait for App {
-    fn new(config: AppConfig) -> Result<Self> {
+    fn new(config: Config) -> Result<Self> {
         let db = Arc::new(Database::create(&config.db_path)?);
         let (interrupt_tx, interrupt_rx) = watch::channel(());
         tokio::spawn(handle_interrupt(interrupt_tx));

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -147,7 +147,7 @@ impl App {
             .map_err(|e| anyhow!("Failed to parse pj_endpoint: {}", e))?;
 
         let mut pj_uri =
-            payjoin::receive::v1::build_v1_pj_uri(&pj_receiver_address, &pj_part, false);
+            payjoin::receive::v1::build_v1_pj_uri(&pj_receiver_address, &pj_part, false)?;
         pj_uri.amount = Some(amount);
 
         Ok(pj_uri.to_string())

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -12,21 +12,21 @@ use payjoin::send::v2::{Sender, SenderBuilder};
 use payjoin::{bitcoin, Uri};
 use tokio::sync::watch;
 
-use super::config::AppConfig;
+use super::config::Config;
 use super::App as AppTrait;
 use crate::app::{handle_interrupt, http_agent, input_pair_from_list_unspent};
 use crate::db::Database;
 
 #[derive(Clone)]
 pub(crate) struct App {
-    config: AppConfig,
+    config: Config,
     db: Arc<Database>,
     interrupt: watch::Receiver<()>,
 }
 
 #[async_trait::async_trait]
 impl AppTrait for App {
-    fn new(config: AppConfig) -> Result<Self> {
+    fn new(config: Config) -> Result<Self> {
         let db = Arc::new(Database::create(&config.db_path)?);
         let (interrupt_tx, interrupt_rx) = watch::channel(());
         tokio::spawn(handle_interrupt(interrupt_tx));
@@ -370,7 +370,7 @@ fn try_contributing_inputs(
         .commit_inputs())
 }
 
-async fn unwrap_ohttp_keys_or_else_fetch(config: &AppConfig) -> Result<payjoin::OhttpKeys> {
+async fn unwrap_ohttp_keys_or_else_fetch(config: &Config) -> Result<payjoin::OhttpKeys> {
     if let Some(keys) = config.v2.ohttp_keys.clone() {
         println!("Using OHTTP Keys from config");
         Ok(keys)

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -304,10 +304,7 @@ impl App {
             .commit_outputs();
 
         let provisional_payjoin = try_contributing_inputs(payjoin.clone(), &bitcoind)
-            .unwrap_or_else(|e| {
-                log::warn!("Failed to contribute inputs: {}", e);
-                payjoin.commit_inputs()
-            });
+            .map_err(ReplyableError::Implementation)?;
 
         let payjoin_proposal = provisional_payjoin.finalize_proposal(
             |psbt: &Psbt| {
@@ -355,20 +352,19 @@ async fn handle_recoverable_error(
 fn try_contributing_inputs(
     payjoin: payjoin::receive::v2::WantsInputs,
     bitcoind: &bitcoincore_rpc::Client,
-) -> Result<payjoin::receive::v2::ProvisionalProposal> {
+) -> Result<payjoin::receive::v2::ProvisionalProposal, ImplementationError> {
     let candidate_inputs = bitcoind
         .list_unspent(None, None, None, None, None)
-        .context("Failed to list unspent from bitcoind")?
+        .map_err(ImplementationError::from)?
         .into_iter()
         .map(input_pair_from_list_unspent);
-    let selected_input = payjoin
-        .try_preserving_privacy(candidate_inputs)
-        .map_err(|e| anyhow!("Failed to make privacy preserving selection: {}", e))?;
-    log::debug!("selected input: {:#?}", selected_input);
+
+    let selected_input =
+        payjoin.try_preserving_privacy(candidate_inputs).map_err(ImplementationError::from)?;
 
     Ok(payjoin
         .contribute_inputs(vec![selected_input])
-        .expect("This shouldn't happen. Failed to contribute inputs.")
+        .map_err(ImplementationError::from)?
         .commit_inputs())
 }
 

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -80,7 +80,7 @@ impl AppTrait for App {
         let address = self.bitcoind()?.get_new_address(None, None)?.assume_checked();
         let ohttp_keys = unwrap_ohttp_keys_or_else_fetch(&self.config).await?;
         let session =
-            Receiver::new(address, self.config.pj_directory.clone(), ohttp_keys.clone(), None);
+            Receiver::new(address, self.config.pj_directory.clone(), ohttp_keys.clone(), None)?;
         self.db.insert_recv_session(session.clone())?;
         self.spawn_payjoin_receiver(session, Some(amount)).await
     }

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -1,0 +1,175 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use bitcoincore_rpc::json::WalletCreateFundedPsbtOptions;
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use payjoin::bitcoin::consensus::encode::{deserialize, serialize_hex};
+use payjoin::bitcoin::consensus::Encodable;
+use payjoin::bitcoin::psbt::{Input, Psbt};
+use payjoin::bitcoin::{
+    Address, Amount, Denomination, FeeRate, Network, OutPoint, Script, Transaction, TxIn, TxOut,
+    Txid,
+};
+use payjoin::receive::InputPair;
+
+/// Implementation of PayjoinWallet for bitcoind
+#[derive(Clone, Debug)]
+pub struct BitcoindWallet {
+    pub bitcoind: std::sync::Arc<Client>,
+}
+
+impl BitcoindWallet {
+    pub fn new(config: &crate::app::config::BitcoindConfig) -> Result<Self> {
+        let client = match &config.cookie {
+            Some(cookie) => Client::new(config.rpchost.as_str(), Auth::CookieFile(cookie.into())),
+            None => Client::new(
+                config.rpchost.as_str(),
+                Auth::UserPass(config.rpcuser.clone(), config.rpcpassword.clone()),
+            ),
+        }?;
+        Ok(Self { bitcoind: Arc::new(client) })
+    }
+}
+
+impl BitcoindWallet {
+    /// Create a PSBT with the given outputs and fee rate
+    pub fn create_psbt(
+        &self,
+        outputs: HashMap<String, Amount>,
+        fee_rate: FeeRate,
+        lock_unspent: bool,
+    ) -> Result<Psbt> {
+        let fee_sat_per_kvb =
+            fee_rate.to_sat_per_kwu().checked_mul(4).ok_or_else(|| anyhow!("Invalid fee rate"))?;
+        let fee_per_kvb = Amount::from_sat(fee_sat_per_kvb);
+        log::debug!("Fee rate sat/kvb: {}", fee_per_kvb.display_in(Denomination::Satoshi));
+
+        let options = WalletCreateFundedPsbtOptions {
+            lock_unspent: Some(lock_unspent),
+            fee_rate: Some(fee_per_kvb),
+            ..Default::default()
+        };
+
+        let psbt = self
+            .bitcoind
+            .wallet_create_funded_psbt(
+                &[], // inputs
+                &outputs,
+                None, // locktime
+                Some(options),
+                None,
+            )
+            .context("Failed to create PSBT")?
+            .psbt;
+
+        let psbt = self
+            .bitcoind
+            .wallet_process_psbt(&psbt, None, None, None)
+            .context("Failed to process PSBT")?
+            .psbt;
+
+        Psbt::from_str(&psbt).context("Failed to load PSBT from base64")
+    }
+
+    /// Process a PSBT, validating and signing inputs owned by this wallet
+    ///
+    /// Does not include bip32 derivations in the PSBT
+    pub fn process_psbt(&self, psbt: &Psbt) -> Result<Psbt> {
+        let psbt_str = psbt.to_string();
+        let processed = self
+            .bitcoind
+            .wallet_process_psbt(&psbt_str, None, None, Some(false))
+            .context("Failed to process PSBT")?
+            .psbt;
+        Psbt::from_str(&processed).context("Failed to parse processed PSBT")
+    }
+
+    /// Finalize a PSBT and extract the transaction
+    pub fn finalize_psbt(&self, psbt: &Psbt) -> Result<Transaction> {
+        let result = self
+            .bitcoind
+            .finalize_psbt(&psbt.to_string(), Some(true))
+            .context("Failed to finalize PSBT")?;
+        let tx = deserialize(&result.hex.ok_or_else(|| anyhow!("Incomplete PSBT"))?)?;
+        Ok(tx)
+    }
+
+    pub fn can_broadcast(&self, tx: &Transaction) -> Result<bool> {
+        let raw_tx = serialize_hex(&tx);
+        let mempool_results = self.bitcoind.test_mempool_accept(&[raw_tx])?;
+        match mempool_results.first() {
+            Some(result) => Ok(result.allowed),
+            None => Err(anyhow!("No mempool results returned on broadcast check",)),
+        }
+    }
+
+    /// Broadcast a raw transaction
+    pub fn broadcast_tx(&self, tx: &Transaction) -> Result<Txid> {
+        let mut serialized_tx = Vec::new();
+        tx.consensus_encode(&mut serialized_tx)?;
+        self.bitcoind
+            .send_raw_transaction(&serialized_tx)
+            .context("Failed to broadcast transaction")
+    }
+
+    /// Check if a script belongs to this wallet
+    pub fn is_mine(&self, script: &Script) -> Result<bool> {
+        if let Ok(address) = Address::from_script(script, self.network()?) {
+            self.bitcoind
+                .get_address_info(&address)
+                .map(|info| info.is_mine.unwrap_or(false))
+                .context("Failed to get address info")
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Get a new address from the wallet
+    pub fn get_new_address(&self) -> Result<Address> {
+        self.bitcoind
+            .get_new_address(None, None)
+            .context("Failed to get new address")?
+            .require_network(self.network()?)
+            .context("Invalid network for address")
+    }
+
+    /// List unspent UTXOs
+    pub fn list_unspent(&self) -> Result<Vec<InputPair>> {
+        let unspent = self
+            .bitcoind
+            .list_unspent(None, None, None, None, None)
+            .context("Failed to list unspent")?;
+        Ok(unspent.into_iter().map(input_pair_from_list_unspent).collect())
+    }
+
+    /// Get the network this wallet is operating on
+    pub fn network(&self) -> Result<Network> {
+        self.bitcoind
+            .get_blockchain_info()
+            .map_err(|_| anyhow!("Failed to get blockchain info"))
+            .map(|info| info.chain)
+    }
+}
+
+pub fn input_pair_from_list_unspent(
+    utxo: bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry,
+) -> InputPair {
+    let psbtin = Input {
+        // NOTE: non_witness_utxo is not necessary because bitcoin-cli always supplies
+        // witness_utxo, even for non-witness inputs
+        witness_utxo: Some(TxOut {
+            value: utxo.amount,
+            script_pubkey: utxo.script_pub_key.clone(),
+        }),
+        redeem_script: utxo.redeem_script.clone(),
+        witness_script: utxo.witness_script.clone(),
+        ..Default::default()
+    };
+    let txin = TxIn {
+        previous_output: OutPoint { txid: utxo.txid, vout: utxo.vout },
+        ..Default::default()
+    };
+    InputPair::new(txin, psbtin).expect("Input pair should be valid")
+}

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use app::config::AppConfig;
+use app::config::Config;
 use app::App as AppTrait;
 use clap::{arg, value_parser, Arg, ArgMatches, Command};
 use payjoin::bitcoin::amount::ParseAmountError;
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let matches = cli();
-    let config = AppConfig::new(&matches)?;
+    let config = Config::new(&matches)?;
     let app: Box<dyn AppTrait> = {
         #[cfg(feature = "v2")]
         {

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -9,6 +9,9 @@ use url::Url;
 mod app;
 mod db;
 
+#[cfg(not(any(feature = "v1", feature = "v2")))]
+compile_error!("At least one of the features ['v1', 'v2'] must be enabled");
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -19,9 +19,9 @@ mod e2e {
 
     const RECEIVE_SATS: &str = "54321";
 
-    #[cfg(not(feature = "v2"))]
+    #[cfg(feature = "v1")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn send_receive_payjoin() -> Result<(), BoxError> {
+    async fn send_receive_payjoin_v1() -> Result<(), BoxError> {
         let (bitcoind, _sender, _receiver) = init_bitcoind_sender_receiver(None, None)?;
         let temp_dir = env::temp_dir();
         let receiver_db_path = temp_dir.join("receiver_db");
@@ -38,6 +38,7 @@ mod e2e {
             let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
 
             let mut cli_receiver = Command::new(payjoin_cli)
+                .arg("--bip78")
                 .arg("--rpchost")
                 .arg(&receiver_rpchost)
                 .arg("--cookie-file")
@@ -79,6 +80,7 @@ mod e2e {
             log::debug!("Got bip21 {}", &bip21);
 
             let mut cli_sender = Command::new(payjoin_cli)
+                .arg("--bip78")
                 .arg("--rpchost")
                 .arg(&sender_rpchost)
                 .arg("--cookie-file")
@@ -142,7 +144,7 @@ mod e2e {
 
     #[cfg(feature = "v2")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn send_receive_payjoin() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn send_receive_payjoin_v2() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use std::path::PathBuf;
 
         use payjoin_test_utils::{init_tracing, TestServices};

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -161,7 +161,7 @@ pub fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxSendSyncError> {
 }
 
 fn http_agent_builder(cert_der: Vec<u8>) -> ClientBuilder {
-    ClientBuilder::new().danger_accept_invalid_certs(true).use_rustls_tls().add_root_certificate(
+    ClientBuilder::new().use_rustls_tls().add_root_certificate(
         reqwest::tls::Certificate::from_der(cert_der.as_slice())
             .expect("cert_der should be a valid DER-encoded certificate"),
     )

--- a/payjoin/src/into_url.rs
+++ b/payjoin/src/into_url.rs
@@ -1,0 +1,114 @@
+use url::{ParseError, Url};
+
+#[derive(Debug)]
+pub enum Error {
+    BadScheme,
+    ParseError(ParseError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+
+        match self {
+            BadScheme => write!(f, "URL scheme is not allowed"),
+            ParseError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Error { Error::ParseError(err) }
+}
+
+type Result<T> = core::result::Result<T, Error>;
+
+/// Try to convert some type into a [`Url`].
+///
+/// This trait is "sealed", such that only types within payjoin can
+/// implement it.
+///
+/// This design is inspired by the `reqwest` crate's design:
+/// see <https://docs.rs/reqwest/latest/reqwest/trait.IntoUrl.html>
+pub trait IntoUrl: IntoUrlSealed {}
+
+impl IntoUrl for &Url {}
+impl IntoUrl for Url {}
+impl IntoUrl for &str {}
+impl IntoUrl for &String {}
+impl IntoUrl for String {}
+
+pub trait IntoUrlSealed {
+    /// Besides parsing as a valid `Url`, the `Url` must be a valid
+    /// `http::Uri`, in that it makes sense to use in a network request.
+    fn into_url(self) -> Result<Url>;
+
+    fn as_str(&self) -> &str;
+}
+
+impl IntoUrlSealed for &Url {
+    fn into_url(self) -> Result<Url> { self.clone().into_url() }
+
+    fn as_str(&self) -> &str { self.as_ref() }
+}
+
+impl IntoUrlSealed for Url {
+    fn into_url(self) -> Result<Url> {
+        if self.has_host() {
+            Ok(self)
+        } else {
+            Err(Error::BadScheme)
+        }
+    }
+
+    fn as_str(&self) -> &str { self.as_ref() }
+}
+
+impl IntoUrlSealed for &str {
+    fn into_url(self) -> Result<Url> { Url::parse(self)?.into_url() }
+
+    fn as_str(&self) -> &str { self }
+}
+
+impl IntoUrlSealed for &String {
+    fn into_url(self) -> Result<Url> { (&**self).into_url() }
+
+    fn as_str(&self) -> &str { self.as_ref() }
+}
+
+impl IntoUrlSealed for String {
+    fn into_url(self) -> Result<Url> { (&*self).into_url() }
+
+    fn as_str(&self) -> &str { self.as_ref() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_uri_scheme_is_allowed() {
+        let url = "http://localhost".into_url().unwrap();
+        assert_eq!(url.scheme(), "http");
+    }
+
+    #[test]
+    fn https_uri_scheme_is_allowed() {
+        let url = "https://localhost".into_url().unwrap();
+        assert_eq!(url.scheme(), "https");
+    }
+
+    #[test]
+    fn into_url_file_scheme() {
+        let err = "file:///etc/hosts".into_url().unwrap_err();
+        assert_eq!(err.to_string(), "URL scheme is not allowed");
+    }
+
+    #[test]
+    fn into_url_blob_scheme() {
+        let err = "blob:https://example.com".into_url().unwrap_err();
+        assert_eq!(err.to_string(), "URL scheme is not allowed");
+    }
+}

--- a/payjoin/src/io.rs
+++ b/payjoin/src/io.rs
@@ -44,7 +44,6 @@ pub async fn fetch_ohttp_keys_with_cert(
     let ohttp_keys_url = payjoin_directory.into_url()?.join("/ohttp-keys")?;
     let proxy = Proxy::all(ohttp_relay.into_url()?.as_str())?;
     let client = Client::builder()
-        .danger_accept_invalid_certs(true)
         .use_rustls_tls()
         .add_root_certificate(reqwest::tls::Certificate::from_der(&cert_der)?)
         .proxy(proxy)

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -39,6 +39,8 @@ pub(crate) mod bech32;
 #[cfg_attr(docsrs, doc(cfg(feature = "directory")))]
 pub mod directory;
 
+#[cfg(feature = "_core")]
+pub(crate) mod into_url;
 #[cfg(feature = "io")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io")))]
 pub mod io;
@@ -52,9 +54,10 @@ pub use request::*;
 mod uri;
 
 #[cfg(feature = "_core")]
+pub use into_url::{Error as IntoUrlError, IntoUrl};
+#[cfg(feature = "_core")]
 pub use uri::{PjParseError, PjUri, Uri, UriExt};
 #[cfg(feature = "_core")]
 pub use url::{ParseError, Url};
-
 #[cfg(feature = "_core")]
 pub(crate) mod error_codes;

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -17,6 +17,9 @@
 //!
 //! **Use at your own risk. This crate has not yet been reviewed by independent Rust and Bitcoin security professionals.**
 
+#[cfg(not(any(feature = "directory", feature = "v1", feature = "v2")))]
+compile_error!("At least one of the features ['directory', 'v1', 'v2'] must be enabled");
+
 #[cfg(feature = "_core")]
 pub extern crate bitcoin;
 

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -337,6 +337,17 @@ impl fmt::Display for SelectionError {
     }
 }
 
+impl error::Error for SelectionError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use InternalSelectionError::*;
+
+        match &self.0 {
+            Empty => None,
+            UnsupportedOutputLength => None,
+            NotFound => None,
+        }
+    }
+}
 impl From<InternalSelectionError> for SelectionError {
     fn from(value: InternalSelectionError) -> Self { SelectionError(value) }
 }
@@ -359,6 +370,14 @@ impl fmt::Display for InputContributionError {
         match &self.0 {
             InternalInputContributionError::ValueTooLow =>
                 write!(f, "Total input value is not enough to cover additional output value"),
+        }
+    }
+}
+
+impl error::Error for InputContributionError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.0 {
+            InternalInputContributionError::ValueTooLow => None,
         }
     }
 }

--- a/payjoin/src/receive/v1/exclusive/mod.rs
+++ b/payjoin/src/receive/v1/exclusive/mod.rs
@@ -3,6 +3,7 @@ pub(crate) use error::InternalRequestError;
 pub use error::RequestError;
 
 use super::*;
+use crate::into_url::IntoUrl;
 
 /// 4_000_000 * 4 / 3 fits in u32
 const MAX_CONTENT_LENGTH: usize = 4_000_000 * 4 / 3;
@@ -14,12 +15,12 @@ pub trait Headers {
 
 pub fn build_v1_pj_uri<'a>(
     address: &bitcoin::Address,
-    endpoint: &url::Url,
+    endpoint: impl IntoUrl,
     disable_output_substitution: bool,
-) -> crate::uri::PjUri<'a> {
+) -> Result<crate::uri::PjUri<'a>, crate::into_url::Error> {
     let extras =
-        crate::uri::PayjoinExtras { endpoint: endpoint.clone(), disable_output_substitution };
-    bitcoin_uri::Uri::with_extras(address.clone(), extras)
+        crate::uri::PayjoinExtras { endpoint: endpoint.into_url()?, disable_output_substitution };
+    Ok(bitcoin_uri::Uri::with_extras(address.clone(), extras))
 }
 
 impl UncheckedProposal {

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -57,33 +57,35 @@ impl From<HpkeError> for Error {
 
 impl fmt::Display for SessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use InternalSessionError::*;
+
         match &self.0 {
-            InternalSessionError::ParseUrl(e) => write!(f, "URL parsing failed: {}", e),
-            InternalSessionError::Expired(expiry) => write!(f, "Session expired at {:?}", expiry),
-            InternalSessionError::OhttpEncapsulation(e) =>
-                write!(f, "OHTTP Encapsulation Error: {}", e),
-            InternalSessionError::Hpke(e) => write!(f, "Hpke decryption failed: {}", e),
-            InternalSessionError::UnexpectedResponseSize(size) => write!(
+            ParseUrl(e) => write!(f, "URL parsing failed: {}", e),
+            Expired(expiry) => write!(f, "Session expired at {:?}", expiry),
+            OhttpEncapsulation(e) => write!(f, "OHTTP Encapsulation Error: {}", e),
+            Hpke(e) => write!(f, "Hpke decryption failed: {}", e),
+            UnexpectedResponseSize(size) => write!(
                 f,
                 "Unexpected response size {}, expected {} bytes",
                 size,
                 crate::directory::ENCAPSULATED_MESSAGE_BYTES
             ),
-            InternalSessionError::UnexpectedStatusCode(status) =>
-                write!(f, "Unexpected status code: {}", status),
+            UnexpectedStatusCode(status) => write!(f, "Unexpected status code: {}", status),
         }
     }
 }
 
 impl error::Error for SessionError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use InternalSessionError::*;
+
         match &self.0 {
-            InternalSessionError::ParseUrl(e) => Some(e),
-            InternalSessionError::Expired(_) => None,
-            InternalSessionError::OhttpEncapsulation(e) => Some(e),
-            InternalSessionError::Hpke(e) => Some(e),
-            InternalSessionError::UnexpectedResponseSize(_) => None,
-            InternalSessionError::UnexpectedStatusCode(_) => None,
+            ParseUrl(e) => Some(e),
+            Expired(_) => None,
+            OhttpEncapsulation(e) => Some(e),
+            Hpke(e) => Some(e),
+            UnexpectedResponseSize(_) => None,
+            UnexpectedStatusCode(_) => None,
         }
     }
 }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -583,17 +583,15 @@ mod test {
     const KEM: Kem = Kem::K256Sha256;
     const SYMMETRIC: &[SymmetricSuite] =
         &[ohttp::SymmetricSuite::new(Kdf::HkdfSha256, Aead::ChaCha20Poly1305)];
-    static EXAMPLE_DIRECTORY_URL: Lazy<Url> =
-        Lazy::new(|| Url::parse("https://directory.com").expect("invalid URL"));
 
-    static EXAMPLE_OHTTP_RELAY: Lazy<Url> =
+    static EXAMPLE_URL: Lazy<Url> =
         Lazy::new(|| Url::parse("https://relay.com").expect("invalid URL"));
 
     static SHARED_CONTEXT: Lazy<SessionContext> = Lazy::new(|| SessionContext {
         address: Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")
             .expect("valid address")
             .assume_checked(),
-        directory: EXAMPLE_DIRECTORY_URL.clone(),
+        directory: EXAMPLE_URL.clone(),
         subdirectory: None,
         ohttp_keys: OhttpKeys(
             ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
@@ -619,12 +617,10 @@ mod test {
             server_error.to_json(),
             r#"{ "errorCode": "unavailable", "message": "Receiver error" }"#
         );
-        let (_req, _ctx) =
-            proposal.clone().extract_err_req(&server_error, EXAMPLE_OHTTP_RELAY.to_owned())?;
+        let (_req, _ctx) = proposal.clone().extract_err_req(&server_error, &*EXAMPLE_URL)?;
 
         let internal_error = InternalPayloadError::MissingPayment.into();
-        let (_req, _ctx) =
-            proposal.extract_err_req(&internal_error, EXAMPLE_OHTTP_RELAY.to_owned())?;
+        let (_req, _ctx) = proposal.extract_err_req(&internal_error, &*EXAMPLE_URL)?;
         Ok(())
     }
 
@@ -640,7 +636,7 @@ mod test {
     #[test]
     fn test_v2_pj_uri() {
         let uri = Receiver { context: SHARED_CONTEXT.clone() }.pj_uri();
-        assert_ne!(uri.extras.endpoint, EXAMPLE_DIRECTORY_URL.clone());
+        assert_ne!(uri.extras.endpoint, EXAMPLE_URL.clone());
         assert!(!uri.extras.disable_output_substitution);
     }
 }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -484,7 +484,6 @@ impl PayjoinProposal {
 
     pub fn psbt(&self) -> &Psbt { self.v1.psbt() }
 
-    #[cfg(feature = "v2")]
     pub fn extract_v2_req(
         &mut self,
         ohttp_relay: impl IntoUrl,

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -12,7 +12,7 @@ pub struct CreateRequestError(InternalCreateRequestError);
 
 #[derive(Debug)]
 pub(crate) enum InternalCreateRequestError {
-    Url(url::ParseError),
+    Url(crate::into_url::Error),
     Hpke(crate::hpke::HpkeError),
     OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
     ParseReceiverPubkey(ParseReceiverPubkeyParamError),
@@ -53,6 +53,12 @@ impl std::error::Error for CreateRequestError {
 
 impl From<InternalCreateRequestError> for CreateRequestError {
     fn from(value: InternalCreateRequestError) -> Self { CreateRequestError(value) }
+}
+
+impl From<crate::into_url::Error> for CreateRequestError {
+    fn from(value: crate::into_url::Error) -> Self {
+        CreateRequestError(InternalCreateRequestError::Url(value))
+    }
 }
 
 impl From<ParseReceiverPubkeyParamError> for CreateRequestError {

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -319,6 +319,7 @@ impl HpkeContext {
     }
 }
 
+#[cfg(test)]
 mod test {
     #[test]
     fn req_ctx_ser_de_roundtrip() {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -9,17 +9,13 @@ mod integration {
     use bitcoin::{Amount, FeeRate, OutPoint, TxIn, TxOut, Weight};
     use bitcoind::bitcoincore_rpc::json::{AddressType, WalletProcessPsbtResult};
     use bitcoind::bitcoincore_rpc::{self, RpcApi};
-    use once_cell::sync::Lazy;
     use payjoin::receive::v1::build_v1_pj_uri;
     use payjoin::receive::ReplyableError::Implementation;
     use payjoin::receive::{ImplementationError, InputPair};
     use payjoin::{PjUri, Request, Uri};
     use payjoin_test_utils::{init_bitcoind_sender_receiver, init_tracing, BoxError};
-    use url::Url;
 
-    static EXAMPLE_URL: Lazy<Url> =
-        Lazy::new(|| Url::parse("https://example.com").expect("Invalid Url"));
-
+    const EXAMPLE_URL: &str = "https://example.com";
     #[cfg(feature = "v1")]
     mod v1 {
         use log::debug;
@@ -76,7 +72,7 @@ mod integration {
         ) -> Result<(), BoxError> {
             // Receiver creates the payjoin URI
             let pj_receiver_address = receiver.get_new_address(None, None)?.assume_checked();
-            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, &EXAMPLE_URL, false);
+            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, EXAMPLE_URL, false)?;
             pj_uri.amount = Some(Amount::ONE_BTC);
 
             // **********************
@@ -140,7 +136,7 @@ mod integration {
 
             // Receiver creates the payjoin URI
             let pj_receiver_address = receiver.get_new_address(None, None)?.assume_checked();
-            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, &EXAMPLE_URL, false);
+            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, EXAMPLE_URL, false)?;
             pj_uri.amount = Some(Amount::ONE_BTC);
 
             // **********************
@@ -208,7 +204,7 @@ mod integration {
                 let mock_address = Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")?
                     .assume_checked();
                 let mut bad_initializer =
-                    Receiver::new(mock_address, directory, bad_ohttp_keys, None);
+                    Receiver::new(mock_address, directory, bad_ohttp_keys, None)?;
                 let (req, _ctx) = bad_initializer.extract_req(&mock_ohttp_relay)?;
                 agent.post(req.url).body(req.body).send().await.map_err(|e| e.into())
             }
@@ -243,7 +239,7 @@ mod integration {
                     directory.clone(),
                     ohttp_keys.clone(),
                     Some(Duration::from_secs(0)),
-                );
+                )?;
                 match expired_receiver.extract_req(&ohttp_relay) {
                     // Internal error types are private, so check against a string
                     Err(err) => assert!(err.to_string().contains("expired")),
@@ -291,7 +287,7 @@ mod integration {
 
                 // test session with expiry in the future
                 let mut session =
-                    Receiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None);
+                    Receiver::new(address.clone(), directory.clone(), ohttp_keys.clone(), None)?;
                 println!("session: {:#?}", &session);
                 // Poll receive request
                 let mock_ohttp_relay = directory.clone();
@@ -390,7 +386,7 @@ mod integration {
             let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
             // Receiver creates the payjoin URI
             let pj_receiver_address = receiver.get_new_address(None, None)?.assume_checked();
-            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, &EXAMPLE_URL, false);
+            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, EXAMPLE_URL, false)?;
             pj_uri.amount = Some(Amount::ONE_BTC);
 
             // **********************
@@ -453,7 +449,7 @@ mod integration {
                 let address = receiver.get_new_address(None, None)?.assume_checked();
 
                 let mut session =
-                    Receiver::new(address, directory.clone(), ohttp_keys.clone(), None);
+                    Receiver::new(address, directory.clone(), ohttp_keys.clone(), None)?;
 
                 // **********************
                 // Inside the V1 Sender:
@@ -690,7 +686,7 @@ mod integration {
 
             // Receiver creates the payjoin URI
             let pj_receiver_address = receiver.get_new_address(None, None)?.assume_checked();
-            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, &EXAMPLE_URL, false);
+            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, EXAMPLE_URL, false)?;
             pj_uri.amount = Some(Amount::ONE_BTC);
 
             // **********************
@@ -767,7 +763,7 @@ mod integration {
 
             // Receiver creates the payjoin URI
             let pj_receiver_address = receiver.get_new_address(None, None)?.assume_checked();
-            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, &EXAMPLE_URL, false);
+            let mut pj_uri = build_v1_pj_uri(&pj_receiver_address, EXAMPLE_URL, false)?;
             pj_uri.amount = Some(Amount::ONE_BTC);
 
             // **********************


### PR DESCRIPTION
This is an attempt to both add some additional test vectors and create so headway on cargo mutants catches.
Currently missing is the test for process_response which I was unable to make headway on given I was not able to parse what an expected value for comparison was during the ohttp encapsulation/decapsulation. Ideally we should have a test for that method included so I added a TODO for it here.

I tried my best to keep these tests in line with avoiding `.unwrap()` as outlined in #487 