### PR TITLE
Add additional tests for v2 send module

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1675,6 +1675,7 @@ name = "payjoin-test-utils"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "bitcoin-ohttp",
  "bitcoincore-rpc",
  "bitcoind",
  "http",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1675,6 +1675,7 @@ name = "payjoin-test-utils"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "bitcoin-ohttp",
  "bitcoincore-rpc",
  "bitcoind",
  "http",

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -12,6 +12,7 @@ bitcoincore-rpc = "0.19.0"
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
 log = "0.4.7"
+ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 ohttp-relay = { version = "0.0.9", features = ["_test-util"] }
 once_cell = "1"
 payjoin = { path = "../payjoin", features = ["io", "_danger-local-https"] }

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -9,7 +9,9 @@ use bitcoind::bitcoincore_rpc::json::AddressType;
 use bitcoind::bitcoincore_rpc::{self, RpcApi};
 use http::{StatusCode, Uri};
 use log::{log_enabled, Level};
-use once_cell::sync::OnceCell;
+use ohttp::hpke::{Aead, Kdf, Kem};
+use ohttp::{KeyId, SymmetricSuite};
+use once_cell::sync::{Lazy, OnceCell};
 use payjoin::io::{fetch_ohttp_keys_with_cert, Error as IOError};
 use payjoin::OhttpKeys;
 use reqwest::{Client, ClientBuilder};
@@ -189,3 +191,11 @@ pub async fn wait_for_service_ready(
 
     Err("Timeout waiting for service to be ready")
 }
+
+pub static EXAMPLE_URL: Lazy<Url> =
+    Lazy::new(|| Url::parse("https://relay.com").expect("invalid URL"));
+
+pub const KEY_ID: KeyId = 1;
+pub const KEM: Kem = Kem::K256Sha256;
+pub const SYMMETRIC: &[SymmetricSuite] =
+    &[ohttp::SymmetricSuite::new(Kdf::HkdfSha256, Aead::ChaCha20Poly1305)];

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -572,20 +572,10 @@ fn id(s: &HpkeKeyPair) -> ShortId {
 mod test {
     use std::str::FromStr;
 
-    use ohttp::hpke::{Aead, Kdf, Kem};
-    use ohttp::{KeyId, SymmetricSuite};
     use once_cell::sync::Lazy;
-    use payjoin_test_utils::BoxError;
+    use payjoin_test_utils::{BoxError, EXAMPLE_URL, KEM, KEY_ID, SYMMETRIC};
 
     use super::*;
-
-    const KEY_ID: KeyId = 1;
-    const KEM: Kem = Kem::K256Sha256;
-    const SYMMETRIC: &[SymmetricSuite] =
-        &[ohttp::SymmetricSuite::new(Kdf::HkdfSha256, Aead::ChaCha20Poly1305)];
-
-    static EXAMPLE_URL: Lazy<Url> =
-        Lazy::new(|| Url::parse("https://relay.com").expect("invalid URL"));
 
     static SHARED_CONTEXT: Lazy<SessionContext> = Lazy::new(|| SessionContext {
         address: Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -326,14 +326,21 @@ impl HpkeContext {
 
 #[cfg(test)]
 mod test {
-    #[test]
-    fn req_ctx_ser_de_roundtrip() -> Result<(), payjoin_test_utils::BoxError> {
-        use super::*;
-        use crate::send::test::ORIGINAL_PSBT;
+    use std::time::{Duration, SystemTime};
 
+    use bitcoin::hex::FromHex;
+    use payjoin_test_utils::{BoxError, EXAMPLE_URL, KEM, KEY_ID, SYMMETRIC};
+
+    use super::*;
+    use crate::receive::v1::test::ORIGINAL_PSBT;
+    use crate::OhttpKeys;
+
+    const SERIALIZED_BODY_V2: &str = "63484e696450384241484d43414141414159386e757447674a647959475857694245623435486f65396c5747626b78682f36624e694f4a6443447544414141414141442b2f2f2f2f41747956754155414141414146366b554865684a38476e536442554f4f7636756a584c72576d734a5244434867495165414141414141415871525233514a62627a30686e513849765130667074476e2b766f746e656f66544141414141414542494b6762317755414141414146366b55336b34656b47484b57524e6241317256357452356b455644564e4348415163584667415578347046636c4e56676f31575741644e3153594e583874706854414243477343527a424541694238512b41366465702b527a393276687932366c5430416a5a6e3450524c6938426639716f422f434d6b30774967502f526a3250575a3367456a556b546c6844524e415130675877544f3774396e2b563134705a366f6c6a554249514d566d7341616f4e5748564d5330324c6654536530653338384c4e697450613155515a794f6968592b464667414241425941464562324769753663344b4f35595730706677336c4770396a4d55554141413d0a763d32";
+
+    fn create_sender_context() -> Result<super::Sender, BoxError> {
         let psbt = Psbt::from_str(ORIGINAL_PSBT)?;
         let endpoint = Url::parse("http://localhost:1234")?;
-        let req_ctx = Sender {
+        let mut sender = super::Sender {
             v1: v1::Sender {
                 psbt,
                 endpoint,
@@ -344,9 +351,107 @@ mod test {
             },
             reply_key: HpkeKeyPair::gen_keypair().0,
         };
-        let serialized = serde_json::to_string(&req_ctx)?;
+        sender.v1.endpoint.set_exp(SystemTime::now() + Duration::from_secs(60));
+        sender.v1.endpoint.set_receiver_pubkey(HpkeKeyPair::gen_keypair().1);
+        sender.v1.endpoint.set_ohttp(OhttpKeys(
+            ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
+        ));
+
+        Ok(sender)
+    }
+
+    #[test]
+    fn sender_ser_de_roundtrip() -> Result<(), BoxError> {
+        let sender = create_sender_context()?;
+        let serialized = serde_json::to_string(&sender)?;
         let deserialized = serde_json::from_str(&serialized)?;
-        assert!(req_ctx == deserialized);
+        assert!(sender == deserialized);
+        Ok(())
+    }
+
+    #[test]
+    fn test_serialize_v2() -> Result<(), BoxError> {
+        let sender = create_sender_context()?;
+        let body = serialize_v2_body(
+            &sender.v1.psbt,
+            sender.v1.disable_output_substitution,
+            sender.v1.fee_contribution,
+            sender.v1.min_fee_rate,
+        );
+        assert_eq!(body.as_ref().unwrap(), &<Vec<u8> as FromHex>::from_hex(SERIALIZED_BODY_V2)?,);
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_v2_success() -> Result<(), BoxError> {
+        let sender = create_sender_context()?;
+        let ohttp_relay = EXAMPLE_URL.clone();
+        let result = sender.extract_v2(ohttp_relay);
+        let (request, context) = result.expect("Result should be ok");
+        assert!(!request.body.is_empty(), "Request body should not be empty");
+        assert_eq!(request.url, EXAMPLE_URL.clone());
+        assert_eq!(context.endpoint, sender.v1.endpoint);
+        assert_eq!(context.psbt_ctx.original_psbt, sender.v1.psbt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_v2_fails_missing_pubkey() -> Result<(), BoxError> {
+        let expected_error = "cannot parse receiver public key: receiver public key is missing";
+        let mut sender = create_sender_context()?;
+        sender.v1.endpoint.set_fragment(Some(""));
+        sender.v1.endpoint.set_exp(SystemTime::now() + Duration::from_secs(60));
+        sender.v1.endpoint.set_ohttp(OhttpKeys(
+            ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
+        ));
+        let ohttp_relay = EXAMPLE_URL.clone();
+        let result = sender.extract_v2(ohttp_relay);
+        assert!(result.is_err(), "Extract v2 expected receiver pubkey error, but it succeeded");
+
+        match result {
+            Ok(_) => panic!("Expected error, got success"),
+            Err(error) => assert_eq!(format!("{}", error), expected_error),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_v2_fails_missing_ohttp_config() -> Result<(), BoxError> {
+        let expected_error = "no ohttp configuration with which to make a v2 request available";
+        let mut sender = create_sender_context()?;
+        sender.v1.endpoint.set_fragment(Some(""));
+        sender.v1.endpoint.set_exp(SystemTime::now() + Duration::from_secs(60));
+        sender.v1.endpoint.set_receiver_pubkey(HpkeKeyPair::gen_keypair().1);
+        let ohttp_relay = EXAMPLE_URL.clone();
+        let result = sender.extract_v2(ohttp_relay);
+        assert!(result.is_err(), "Extract v2 expected missing ohttp error, but it succeeded");
+
+        match result {
+            Ok(_) => panic!("Expected error, got success"),
+            Err(error) => assert_eq!(format!("{}", error), expected_error),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_v2_fails_when_expired() -> Result<(), BoxError> {
+        let expected_error = "session expired at SystemTime";
+        let mut sender = create_sender_context()?;
+        let exp_time = std::time::SystemTime::now();
+        sender.v1.endpoint.set_exp(exp_time);
+        let ohttp_relay = EXAMPLE_URL.clone();
+        let result = sender.extract_v2(ohttp_relay);
+        assert!(result.is_err(), "Extract v2 expected expiry error, but it succeeded");
+
+        match result {
+            Ok(_) => panic!("Expected error, got success"),
+            Err(error) => assert_eq!(
+                format!("{}", error)
+                    .split_once(" {")
+                    .map_or(format!("{}", error), |(prefix, _)| prefix.to_string()),
+                expected_error
+            ),
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Relates to #539 

This is an attempt to both add some additional test vectors and to create some headway on the tests deficiencies caught by cargo mutants ahead of time. 
Currently missing is the test for process_response which I was unable to make significant progress on as I was not able to parse what I anticipated as expected values for the ohttp encapsulation/decapsulation. Ideally we should have a test for that added so I have created a TODO there.

I have tried my best to keep the tests in accordance with the design laid out in #487 

Below is the cargo mutants output for `send/v2/mod.rs` as of df30f3b9da531427fa042dc9f5ed206169c21fa0

<details>

```
caught   payjoin/src/send/v2/mod.rs:203:5: replace serialize_v2_body -> Result<Vec<u8>, CreateRequestError> with Ok(vec![]) in 8.7s build + 1.1s test
caught   payjoin/src/send/v2/mod.rs:203:5: replace serialize_v2_body -> Result<Vec<u8>, CreateRequestError> with Ok(vec![1]) in 5.9s build + 1.1s test
***MISSED   payjoin/src/send/v2/mod.rs:146:45: replace > with == in Sender::extract_v2 in 10.2s build + 1.5s test
caught   payjoin/src/send/v2/mod.rs:203:5: replace serialize_v2_body -> Result<Vec<u8>, CreateRequestError> with Ok(vec![0]) in 8.5s build + 1.1s test
***MISSED   payjoin/src/send/v2/mod.rs:289:9: replace V2GetContext::process_response -> Result<Option<Psbt>, ResponseError> with Ok(None) in 8.6s build + 1.2s test
caught   payjoin/src/send/v2/mod.rs:146:45: replace > with < in Sender::extract_v2 in 66.0s build + 0.6s test
17 mutants tested in 1m 32s: 2 missed, 4 caught, 11 unviable
````

Note the 2 main improvements that can be made are for creating a test for `process_response` and catching the `test_extract_v2_fails_when_expired` slightly better

</details>