### PR TITLE
feat: add consolidation input selection strategy

### DIFF
--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -321,6 +321,8 @@ pub(crate) enum InternalSelectionError {
     UnsupportedOutputLength,
     /// No selection candidates improve privacy
     NotFound,
+    /// Fee rate too high for consolidation
+    FeeRateTooHighForConsolidation,
 }
 
 impl fmt::Display for SelectionError {
@@ -333,6 +335,8 @@ impl fmt::Display for SelectionError {
             ),
             InternalSelectionError::NotFound =>
                 write!(f, "No selection candidates improve privacy"),
+            InternalSelectionError::FeeRateTooHighForConsolidation =>
+                write!(f, "Fee rate too high for consolidation strategy"),
         }
     }
 }
@@ -345,6 +349,7 @@ impl error::Error for SelectionError {
             Empty => None,
             UnsupportedOutputLength => None,
             NotFound => None,
+            FeeRateTooHighForConsolidation => None,
         }
     }
 }


### PR DESCRIPTION
# Add Consolidation Input Selection Strategy

## Overview
This PR introduces a new input selection strategy for receivers that optimizes for UTXO consolidation. This enables receivers to use payjoins as an opportunity to consolidate their UTXOs efficiently, improving their wallet's long-term UTXO management.

## Features
- New `SelectionStrategy::Consolidate` option for receiver input selection
- Configurable parameters to control consolidation behavior:
  - `max_consolidation_fee_rate`: Only consolidate when fees are below this threshold
  - `max_inputs`: Limit the number of inputs to add
  - `target_value`: Optionally stop adding inputs after reaching a target amount
  - `dust_limit`: Minimum value for inputs to be considered

## Implementation Details
- Inputs are sorted by value (ascending) and added until reaching either max_inputs or target_value
- Consolidation only proceeds if current transaction fee rate is below the specified threshold
- Maintains compatibility with existing privacy-preserving selection strategy
- V2 receiver implementation delegates to V1 for actual consolidation logic

## Considerations
- Testing pending
- CLI changes pending to expose consolidation strategy and its parameters
- While providing numerous parameters could offer flexibility, it might also lead to unnecessary complexity. We need to strike the right balance between configurability and simplicity.

## Related Issues
#460