### PR TITLE
Instantiate `v2::Reciver` only after data persistence is complete

### DIFF
--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -7,11 +7,10 @@ use url::Url;
 use super::*;
 
 impl Database {
-    pub(crate) fn insert_recv_session(&self, session: Receiver) -> Result<()> {
+    pub(crate) fn insert_recv_session(&self, key: &[u8], session: Receiver) -> Result<()> {
         let recv_tree = self.0.open_tree("recv_sessions")?;
-        let key = &session.id();
         let value = serde_json::to_string(&session).map_err(Error::Serialize)?;
-        recv_tree.insert(key.as_slice(), IVec::from(value.as_str()))?;
+        recv_tree.insert(key, IVec::from(value.as_str()))?;
         recv_tree.flush()?;
         Ok(())
     }

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -33,10 +33,10 @@ impl Database {
         Ok(())
     }
 
-    pub(crate) fn insert_send_session(&self, session: &mut Sender, pj_url: &Url) -> Result<()> {
+    pub(crate) fn insert_send_session(&self, session: &mut Sender, key: &[u8]) -> Result<()> {
         let send_tree: Tree = self.0.open_tree("send_sessions")?;
         let value = serde_json::to_string(session).map_err(Error::Serialize)?;
-        send_tree.insert(pj_url.to_string(), IVec::from(value.as_str()))?;
+        send_tree.insert(key, IVec::from(value.as_str()))?;
         send_tree.flush()?;
         Ok(())
     }

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -61,9 +61,7 @@ pub struct Receiver {
 }
 
 /// A wrapper around the receiver session. The receiver session is accessible only after it has been persisted via [`EphemeralReceiver::persist`]
-pub struct EphemeralReceiver {
-    inner: Receiver,
-}
+pub struct EphemeralReceiver(Receiver);
 
 impl EphemeralReceiver {
     pub fn new(
@@ -72,9 +70,7 @@ impl EphemeralReceiver {
         ohttp_keys: OhttpKeys,
         expire_after: Option<Duration>,
     ) -> Result<EphemeralReceiver, IntoUrlError> {
-        Ok(EphemeralReceiver {
-            inner: Receiver::new(address, directory, ohttp_keys, expire_after)?,
-        })
+        Ok(EphemeralReceiver(Receiver::new(address, directory, ohttp_keys, expire_after)?))
     }
 
     /// Persist the receiver session to the database. Implementation details are left to the caller.
@@ -83,7 +79,7 @@ impl EphemeralReceiver {
         &self,
         persist: impl Fn(&[u8], &Receiver) -> Result<(), ImplementationError>,
     ) -> Result<Receiver, ReplyableError> {
-        let receiver = self.inner.clone();
+        let receiver = self.0.clone();
         let short_id = id(&receiver.context.s);
         let id = short_id.0.as_slice();
         persist(id, &receiver).map_err(ReplyableError::Implementation)?;

--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -24,7 +24,8 @@ impl<'a> SenderBuilder<'a> {
     pub fn new(psbt: Psbt, uri: PjUri<'a>) -> Self { Self(v2::SenderBuilder::new(psbt, uri)) }
     pub fn build_recommended(self, min_fee_rate: FeeRate) -> Result<Sender, BuildSenderError> {
         let v2 = v2::SenderBuilder::new(self.0 .0.psbt, self.0 .0.uri)
-            .build_recommended(min_fee_rate)?;
+            .build_recommended(min_fee_rate)?
+            .persist(|_id, _sender| Ok(()))?;
         Ok(Sender(v2))
     }
 }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -253,7 +253,8 @@ mod integration {
                 let psbt = build_original_psbt(&sender, &expired_receiver.pj_uri())?;
                 // Test that an expired pj_url errors
                 let expired_req_ctx = SenderBuilder::new(psbt, expired_receiver.pj_uri())
-                    .build_non_incentivizing(FeeRate::BROADCAST_MIN)?;
+                    .build_non_incentivizing(FeeRate::BROADCAST_MIN)?
+                    .persist(|_key, _sender| Ok(()))?;
                 match expired_req_ctx.extract_v2(directory.to_owned()) {
                     // Internal error types are private, so check against a string
                     Err(err) => assert!(err.to_string().contains("expired")),
@@ -316,7 +317,8 @@ mod integration {
                     .map_err(|e| e.to_string())?;
                 let psbt = build_sweep_psbt(&sender, &pj_uri)?;
                 let req_ctx = SenderBuilder::new(psbt.clone(), pj_uri.clone())
-                    .build_recommended(FeeRate::BROADCAST_MIN)?;
+                    .build_recommended(FeeRate::BROADCAST_MIN)?
+                    .persist(|_key, _sender| Ok(()))?;
                 let (Request { url, body, content_type, .. }, send_ctx) =
                     req_ctx.extract_v2(mock_ohttp_relay.to_owned())?;
                 let response = agent
@@ -406,7 +408,8 @@ mod integration {
                 .map_err(|e| e.to_string())?;
             let psbt = build_original_psbt(&sender, &pj_uri)?;
             let req_ctx = SenderBuilder::new(psbt.clone(), pj_uri.clone())
-                .build_recommended(FeeRate::BROADCAST_MIN)?;
+                .build_recommended(FeeRate::BROADCAST_MIN)?
+                .persist(|_key, _sender| Ok(()))?;
             let (req, ctx) = req_ctx.extract_v1()?;
             let headers = HeaderMock::new(&req.body, req.content_type);
 
@@ -476,6 +479,7 @@ mod integration {
                             FeeRate::ZERO,
                             false,
                         )?
+                        .persist(|_key, _sender| Ok(()))?
                         .extract_v1()?;
                 log::info!("send fallback v1 to offline receiver fail");
                 let res = agent


### PR DESCRIPTION
In order to ensure the application has persisted the reciver session before they can use it to handle an proposal we first wrap the reciver in a `EphemeralReciver` struct. Indicating to the application that data will be lost unless it it properly persited via `EphemeralReciver::persist()`.

This work is meant to supersedes https://github.com/payjoin/rust-payjoin/pull/552. But I wanted to open a second Pr so we can compare implementation details. 


Issue: https://github.com/payjoin/rust-payjoin/issues/336