### PR TITLE
Fix confusing and incorrect test condition

### DIFF
--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -499,7 +499,6 @@ mod integration {
                                 log::info!(
                                     "No response yet for POST payjoin request, retrying some seconds"
                                 );
-                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                             }
                         } else {
                             log::error!("Unexpected response status: {}", response.status());


### PR DESCRIPTION
The v1_to_v2 test checks the v2 receiver's polling behavior, and the directory's backwards compatible handling of that.

However, as the following diff demonstrates when applied, it's actually the first request, the one which receives a 503 response whose data makes it to the receiver, and the 202 status check in the test never triggers even when that initial sender's proposal is withheld to force the directory to respond with 202, instead triggering `.expect("proposal should exist")`:

```diff
diff --git a/payjoin/tests/integration.rs b/payjoin/tests/integration.rs
index c500af4..3827b45 100644
--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -469,14 +469,14 @@ mod integration {
                             false,
                         )?
                         .extract_v1()?;
-                log::info!("send fallback v1 to offline receiver fail");
-                let res = agent
-                    .post(url.clone())
-                    .header("Content-Type", content_type)
-                    .body(body.clone())
-                    .send()
-                    .await;
-                assert!(res?.status() == StatusCode::SERVICE_UNAVAILABLE);
+                // log::info!("send fallback v1 to offline receiver fail");
+                // let res = agent
+                //     .post(url.clone())
+                //     .header("Content-Type", content_type)
+                //     .body(body.clone())
+                //     .send()
+                //     .await;
+                // assert!(res?.status() == StatusCode::SERVICE_UNAVAILABLE);

                 // **********************
                 // Inside the Receiver:
@@ -497,6 +497,7 @@ mod integration {
                                 "No response yet for POST payjoin request, retrying some seconds"
                             );
                             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                            panic!("not expecting 202");
                         } else {
                             log::error!("Unexpected response status: {}", response.status());
                             panic!("Unexpected response status: {}", response.status())
@@ -519,6 +520,10 @@ mod integration {
                     Ok::<_, BoxSendSyncError>(())
                 });

+                // test services configures a timeout of 2 seconds for the
+                // directory before it returns 202 status responses
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
                 // **********************
                 // send fallback v1 to online receiver
                 log::info!("send fallback v1 to online receiver should succeed");
```