### PR TITLE
Use actual ohttp-relay in integration tests

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -408,9 +408,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
@@ -1473,8 +1473,7 @@ dependencies = [
 [[package]]
 name = "ohttp-relay"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8e8aef13b8327b680aaaca807aa11ba5979fc5858203e7b77c68128ede61a2"
+source = "git+https://github.com/payjoin/ohttp-relay.git?rev=b8153e5c290560be58e1395a8e50ea610e146f6d#b8153e5c290560be58e1395a8e50ea610e146f6d"
 dependencies = [
  "futures",
  "http",
@@ -1483,7 +1482,6 @@ dependencies = [
  "hyper-rustls",
  "hyper-tungstenite",
  "hyper-util",
- "once_cell",
  "rustls 0.22.4",
  "tokio",
  "tokio-tungstenite",
@@ -1686,6 +1684,7 @@ dependencies = [
  "payjoin-directory",
  "rcgen",
  "reqwest",
+ "rustls 0.22.4",
  "testcontainers",
  "testcontainers-modules",
  "tokio",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -408,9 +408,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
@@ -1473,8 +1473,7 @@ dependencies = [
 [[package]]
 name = "ohttp-relay"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8e8aef13b8327b680aaaca807aa11ba5979fc5858203e7b77c68128ede61a2"
+source = "git+https://github.com/payjoin/ohttp-relay.git?rev=b8153e5c290560be58e1395a8e50ea610e146f6d#b8153e5c290560be58e1395a8e50ea610e146f6d"
 dependencies = [
  "futures",
  "http",
@@ -1483,7 +1482,6 @@ dependencies = [
  "hyper-rustls",
  "hyper-tungstenite",
  "hyper-util",
- "once_cell",
  "rustls 0.22.4",
  "tokio",
  "tokio-tungstenite",
@@ -1686,6 +1684,7 @@ dependencies = [
  "payjoin-directory",
  "rcgen",
  "reqwest",
+ "rustls 0.22.4",
  "testcontainers",
  "testcontainers-modules",
  "tokio",

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -201,8 +201,7 @@ mod e2e {
             let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
 
             let directory = &services.directory_url().to_string();
-            // Mock ohttp_relay since the ohttp_relay's http client doesn't have the certificate for the directory
-            let mock_ohttp_relay = &services.ohttp_gateway_url().to_string();
+            let ohttp_relay = &services.ohttp_relay_url().to_string();
 
             let cli_receive_initiator = Command::new(payjoin_cli)
                 .arg("--rpchost")
@@ -212,7 +211,7 @@ mod e2e {
                 .arg("--db-path")
                 .arg(&receiver_db_path)
                 .arg("--ohttp-relay")
-                .arg(mock_ohttp_relay)
+                .arg(ohttp_relay)
                 .arg("receive")
                 .arg(RECEIVE_SATS)
                 .arg("--pj-directory")
@@ -232,7 +231,7 @@ mod e2e {
                 .arg("--db-path")
                 .arg(&sender_db_path)
                 .arg("--ohttp-relay")
-                .arg(mock_ohttp_relay)
+                .arg(ohttp_relay)
                 .arg("send")
                 .arg(&bip21)
                 .arg("--fee-rate")
@@ -251,7 +250,7 @@ mod e2e {
                 .arg("--db-path")
                 .arg(&receiver_db_path)
                 .arg("--ohttp-relay")
-                .arg(mock_ohttp_relay)
+                .arg(ohttp_relay)
                 .arg("resume")
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
@@ -267,7 +266,7 @@ mod e2e {
                 .arg("--db-path")
                 .arg(&sender_db_path)
                 .arg("--ohttp-relay")
-                .arg(mock_ohttp_relay)
+                .arg(ohttp_relay)
                 .arg("send")
                 .arg(&bip21)
                 .arg("--fee-rate")

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -13,11 +13,12 @@ bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
 log = "0.4.7"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
-ohttp-relay = { version = "0.0.9", features = ["_test-util"] }
+ohttp-relay = { git = "https://github.com/payjoin/ohttp-relay.git", rev = "b8153e5c290560be58e1395a8e50ea610e146f6d", version = "0.0.9", features = ["_test-util"] }
 once_cell = "1"
 payjoin = { path = "../payjoin", features = ["io", "_danger-local-https"] }
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }
 rcgen = "0.11"
+rustls = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.3.7", features = ["redis"] }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -206,7 +206,13 @@ mod integration {
                 let mut bad_initializer =
                     Receiver::new(mock_address, directory, bad_ohttp_keys, None)?;
                 let (req, _ctx) = bad_initializer.extract_req(&mock_ohttp_relay)?;
-                agent.post(req.url).body(req.body).send().await.map_err(|e| e.into())
+                agent
+                    .post(req.url)
+                    .header("Content-Type", req.content_type)
+                    .body(req.body)
+                    .send()
+                    .await
+                    .map_err(|e| e.into())
             }
 
             Ok(())
@@ -292,7 +298,12 @@ mod integration {
                 // Poll receive request
                 let mock_ohttp_relay = services.ohttp_gateway_url();
                 let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
-                let response = agent.post(req.url).body(req.body).send().await?;
+                let response = agent
+                    .post(req.url)
+                    .header("Content-Type", req.content_type)
+                    .body(req.body)
+                    .send()
+                    .await?;
                 assert!(response.status().is_success(), "error response: {}", response.status());
                 let response_body =
                     session.process_res(response.bytes().await?.to_vec().as_slice(), ctx)?;
@@ -328,7 +339,12 @@ mod integration {
 
                 // GET fallback psbt
                 let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
-                let response = agent.post(req.url).body(req.body).send().await?;
+                let response = agent
+                    .post(req.url)
+                    .header("Content-Type", req.content_type)
+                    .body(req.body)
+                    .send()
+                    .await?;
                 // POST payjoin
                 let proposal = session
                     .process_res(response.bytes().await?.to_vec().as_slice(), ctx)?
@@ -488,7 +504,12 @@ mod integration {
                     let agent_clone = agent_clone.clone();
                     let proposal = loop {
                         let (req, ctx) = session.extract_req(&mock_ohttp_relay)?;
-                        let response = agent_clone.post(req.url).body(req.body).send().await?;
+                        let response = agent_clone
+                            .post(req.url)
+                            .header("Content-Type", req.content_type)
+                            .body(req.body)
+                            .send()
+                            .await?;
 
                         if response.status() == 200 {
                             if let Some(proposal) = session
@@ -512,7 +533,12 @@ mod integration {
                     // Respond with payjoin psbt within the time window the sender is willing to wait
                     // this response would be returned as http response to the sender
                     let (req, ctx) = payjoin_proposal.extract_v2_req(&mock_ohttp_relay)?;
-                    let response = agent_clone.post(req.url).body(req.body).send().await?;
+                    let response = agent_clone
+                        .post(req.url)
+                        .header("Content-Type", req.content_type)
+                        .body(req.body)
+                        .send()
+                        .await?;
                     payjoin_proposal
                         .process_res(&response.bytes().await?, ctx)
                         .map_err(|e| e.to_string())?;
@@ -747,7 +773,12 @@ mod integration {
                 for sender_sesssion in inner_sender_test_sessions.iter() {
                     let mut receiver_session = sender_sesssion.receiver_session.clone();
                     let (req, reciever_ctx) = receiver_session.extract_req(&directory)?;
-                    let response = agent.post(req.url).body(req.body).send().await?;
+                    let response = agent
+                        .post(req.url)
+                        .header("Content-Type", req.content_type)
+                        .body(req.body)
+                        .send()
+                        .await?;
                     assert!(response.status().is_success());
                     let res = response.bytes().await?.to_vec();
                     let proposal = receiver_session
@@ -816,7 +847,12 @@ mod integration {
                 for sender_sesssion in inner_sender_test_sessions.iter() {
                     let mut receiver_session = sender_sesssion.receiver_session.clone();
                     let (req, reciever_ctx) = receiver_session.extract_req(&directory)?;
-                    let response = agent.post(req.url).body(req.body).send().await?;
+                    let response = agent
+                        .post(req.url)
+                        .header("Content-Type", req.content_type)
+                        .body(req.body)
+                        .send()
+                        .await?;
                     assert!(response.status().is_success());
 
                     let finalized_response = receiver_session


### PR DESCRIPTION
Instead of submitting OHTTP requests directly to the directory's OHTTP gateway, give the OHTTP gateway's self signed certificate to the relay so it can connect to it, and exercise the relay in the integration tests.

This change updates`payjoin-test-util`'s `Cargo.toml` to use a git origin for the merge commit of payjoin/ohttp-relay#63, as such it needs to be followed up with a commit that specifies an updated version before release.

Depends on 
- payjoin/ohttp-relay#63
- #571 

(edit by Dan, when you put dependencies in a list the render pretty)