### PR TITLE
Propagate sub-config parsing error

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -142,12 +142,13 @@ impl Config {
             1 => {
                 #[cfg(feature = "v1")]
                 {
-                    if let Ok(v1) = built_config.get::<V1Config>("v1") {
-                        config.version = Some(VersionConfig::V1(v1));
-                    } else {
-                        return Err(ConfigError::Message(
-                            "V1 configuration is required for BIP78 mode".to_string(),
-                        ));
+                    match built_config.get::<V1Config>("v1") {
+                        Ok(v1) => config.version = Some(VersionConfig::V1(v1)),
+                        Err(e) =>
+                            return Err(ConfigError::Message(format!(
+                                "Valid V1 configuration is required for BIP78 mode: {}",
+                                e
+                            ))),
                     }
                 }
                 #[cfg(not(feature = "v1"))]
@@ -158,12 +159,13 @@ impl Config {
             2 => {
                 #[cfg(feature = "v2")]
                 {
-                    if let Ok(v2) = built_config.get::<V2Config>("v2") {
-                        config.version = Some(VersionConfig::V2(v2));
-                    } else {
-                        return Err(ConfigError::Message(
-                            "V2 configuration is required for BIP77 mode".to_string(),
-                        ));
+                    match built_config.get::<V2Config>("v2") {
+                        Ok(v2) => config.version = Some(VersionConfig::V2(v2)),
+                        Err(e) =>
+                            return Err(ConfigError::Message(format!(
+                                "Valid V2 configuration is required for BIP77 mode: {}",
+                                e
+                            ))),
                     }
                 }
                 #[cfg(not(feature = "v2"))]


### PR DESCRIPTION
For example, if the [v2] field had a pj_directory config field defined, but the URL parsing failed, the error would be swallowed before this change.

This now propagates that error to the CLI.

---

The error propagation still isn't perfect, and some config errors get swallowed without complete context, but this is progress.