### PR TITLE
Add additional tests for uri module

### DIFF
--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -253,7 +253,7 @@ pub async fn wait_for_service_ready(
 }
 
 pub static EXAMPLE_URL: Lazy<Url> =
-    Lazy::new(|| Url::parse("https://relay.com").expect("invalid URL"));
+    Lazy::new(|| Url::parse("https://example.com").expect("invalid URL"));
 
 pub const KEY_ID: KeyId = 1;
 pub const KEM: Kem = Kem::K256Sha256;


### PR DESCRIPTION
This expands the test coverage for the uri module covering all mutants that currently exist.

This will likely become the narrowest scope of my mutant ci coverage so that we can start with full coverage and expand the scope out as we catch more mutants.

Here is the mutants out for `payjoin/src/uri/*.rs` as of c1cc48786615343caaa17b34b579fcb6b4a5bb2d

<details>

```
caught   payjoin/src/uri/mod.rs:190:25: replace && with || in <impl DeserializationState for DeserializationState>::finalize in 12.4s build + 1.2s test
caught   payjoin/src/uri/mod.rs:188:38: replace == with != in <impl DeserializationState for DeserializationState>::finalize in 9.6s build + 1.3s test
caught   payjoin/src/uri/url_ext.rs:116:5: replace get_param -> Option<T> with None in 9.3s build + 1.1s test
caught   payjoin/src/uri/url_ext.rs:32:16: replace != with == in <impl UrlExt for Url>::receiver_pubkey in 10.4s build + 1.2s test
caught   payjoin/src/uri/mod.rs:25:9: replace MaybePayjoinExtras::pj_is_supported -> bool with false in 10.7s build + 1.3s test
caught   payjoin/src/uri/url_ext.rs:130:80: replace + with - in set_param in 11.1s build + 1.0s test
caught   payjoin/src/uri/mod.rs:189:21: replace || with && in <impl DeserializationState for DeserializationState>::finalize in 73.7s build + 0.9s test
caught   payjoin/src/uri/url_ext.rs:60:49: replace <impl UrlExt for Url>::set_ohttp with () in 4.0s build + 0.8s test
caught   payjoin/src/uri/mod.rs:141:53: replace <impl DeserializationState for DeserializationState>::is_param_known -> bool with false in 3.2s build + 0.7s test
caught   payjoin/src/uri/url_ext.rs:42:9: replace <impl UrlExt for Url>::set_receiver_pubkey with () in 4.1s build + 1.0s test
caught   payjoin/src/uri/url_ext.rs:137:8: delete ! in set_param in 4.0s build + 0.9s test
caught   payjoin/src/uri/url_ext.rs:127:5: replace set_param with () in 83.5s build + 0.7s test
caught   payjoin/src/uri/url_ext.rs:84:9: replace <impl UrlExt for Url>::set_exp with () in 3.2s build + 0.8s test
caught   payjoin/src/uri/mod.rs:25:9: replace MaybePayjoinExtras::pj_is_supported -> bool with true in 84.6s build + 0.8s test
caught   payjoin/src/uri/mod.rs:84:61: replace PayjoinExtras::is_output_substitution_disabled -> bool with true in 2.7s build + 0.8s test
caught   payjoin/src/uri/url_ext.rs:130:80: replace + with * in set_param in 3.0s build + 0.7s test
caught   payjoin/src/uri/mod.rs:141:53: replace <impl DeserializationState for DeserializationState>::is_param_known -> bool with true in 3.3s build + 0.8s test
caught   payjoin/src/uri/url_ext.rs:77:39: replace + with - in <impl UrlExt for Url>::exp in 3.3s build + 0.9s test
caught   payjoin/src/uri/mod.rs:189:42: replace == with != in <impl DeserializationState for DeserializationState>::finalize in 3.0s build + 0.8s test
caught   payjoin/src/uri/mod.rs:84:61: replace PayjoinExtras::is_output_substitution_disabled -> bool with false in 2.8s build + 0.7s test
caught   payjoin/src/uri/url_ext.rs:71:16: replace != with == in <impl UrlExt for Url>::exp in 2.6s build + 0.6s test
25 mutants tested in 2m 14s: 21 caught, 4 unviable

```

Note, this is with the `mutants.toml`exclusions from #573 in place

</details>
