### PR TITLE
Make serialize_url and extract_v1 infallible

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -70,7 +70,7 @@ impl AppTrait for App {
         let (req, ctx) = SenderBuilder::new(psbt, uri.clone())
             .build_recommended(fee_rate)
             .with_context(|| "Failed to build payjoin request")?
-            .extract_v1()?;
+            .extract_v1();
         let http = http_agent()?;
         let body = String::from_utf8(req.body.clone()).unwrap();
         println!("Sending fallback request to {}", &req.url);

--- a/payjoin-cli/src/app/v2.rs
+++ b/payjoin-cli/src/app/v2.rs
@@ -206,7 +206,7 @@ impl App {
                 }
             }
             Err(_) => {
-                let (req, v1_ctx) = req_ctx.extract_v1()?;
+                let (req, v1_ctx) = req_ctx.extract_v1();
                 println!("Posting Original PSBT Payload request...");
                 let response = post_request(req).await?;
                 println!("Sent fallback transaction");

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -418,7 +418,7 @@ fn serialize_url(
     fee_contribution: Option<AdditionalFeeContribution>,
     min_fee_rate: FeeRate,
     version: &str,
-) -> Result<Url, url::ParseError> {
+) -> Url {
     let mut url = endpoint;
     url.query_pairs_mut().append_pair("v", version);
     if disable_output_substitution {
@@ -434,7 +434,7 @@ fn serialize_url(
         let float_fee_rate = min_fee_rate.to_sat_per_kwu() as f32 / 250.0_f32;
         url.query_pairs_mut().append_pair("minfeerate", &float_fee_rate.to_string());
     }
-    Ok(url)
+    url
 }
 
 #[cfg(test)]
@@ -641,12 +641,10 @@ mod test {
 
     #[test]
     fn test_disable_output_substitution_query_param() -> Result<(), BoxError> {
-        let url = serialize_url(Url::parse("http://localhost")?, true, None, FeeRate::ZERO, "2")
-            .expect("Failed to serialize url");
+        let url = serialize_url(Url::parse("http://localhost")?, true, None, FeeRate::ZERO, "2");
         assert_eq!(url, Url::parse("http://localhost?v=2&disableoutputsubstitution=true")?);
 
-        let url = serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2")
-            .expect("Failed to serialize url");
+        let url = serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2");
         assert_eq!(url, Url::parse("http://localhost?v=2")?);
         Ok(())
     }

--- a/payjoin/src/send/multiparty/error.rs
+++ b/payjoin/src/send/multiparty/error.rs
@@ -17,7 +17,6 @@ pub(crate) enum InternalCreateRequestError {
     Expired(std::time::SystemTime),
     MissingOhttpConfig,
     ParseReceiverPubkeyParam(ParseReceiverPubkeyParamError),
-    Url(url::ParseError),
     V2CreateRequest(crate::send::v2::CreateRequestError),
 }
 
@@ -35,7 +34,6 @@ impl std::error::Error for CreateRequestError {
             InternalCreateRequestError::Expired(_) => None,
             InternalCreateRequestError::MissingOhttpConfig => None,
             InternalCreateRequestError::ParseReceiverPubkeyParam(e) => Some(e),
-            InternalCreateRequestError::Url(e) => Some(e),
             InternalCreateRequestError::V2CreateRequest(e) => Some(e),
         }
     }

--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -89,8 +89,7 @@ fn serialize_v2_body(
         fee_contribution,
         min_fee_rate,
         "2",
-    )
-    .map_err(InternalCreateRequestError::Url)?;
+    );
     append_optimisitic_merge_query_param(&mut url);
     let base64 = psbt.to_string();
     Ok(format!("{}\n{}", base64, url.query().unwrap_or_default()).into_bytes())
@@ -244,11 +243,11 @@ mod test {
     #[test]
     fn test_optimistic_merge_query_param() -> Result<(), BoxError> {
         let mut url =
-            serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2")?;
+            serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2");
         append_optimisitic_merge_query_param(&mut url);
         assert_eq!(url, Url::parse("http://localhost?v=2&optimisticmerge=true")?);
 
-        let url = serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2")?;
+        let url = serialize_url(Url::parse("http://localhost")?, false, None, FeeRate::ZERO, "2");
         assert_eq!(url, Url::parse("http://localhost?v=2")?);
 
         Ok(())

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -227,7 +227,7 @@ pub struct Sender {
 
 impl Sender {
     /// Extract serialized V1 Request and Context from a Payjoin Proposal
-    pub fn extract_v1(&self) -> Result<(Request, V1Context), url::ParseError> {
+    pub fn extract_v1(&self) -> (Request, V1Context) {
         let url = serialize_url(
             self.endpoint.clone(),
             self.disable_output_substitution,
@@ -236,7 +236,7 @@ impl Sender {
             "1", // payjoin version
         );
         let body = self.psbt.to_string().as_bytes().to_vec();
-        Ok((
+        (
             Request::new_v1(&url, &body),
             V1Context {
                 psbt_context: PsbtContext {
@@ -247,7 +247,7 @@ impl Sender {
                     min_fee_rate: self.min_fee_rate,
                 },
             },
-        ))
+        )
     }
 
     pub fn endpoint(&self) -> &Url { &self.endpoint }

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -234,7 +234,7 @@ impl Sender {
             self.fee_contribution,
             self.min_fee_rate,
             "1", // payjoin version
-        )?;
+        );
         let body = self.psbt.to_string().as_bytes().to_vec();
         Ok((
             Request::new_v1(&url, &body),

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -127,9 +127,7 @@ pub struct Sender {
 
 impl Sender {
     /// Extract serialized V1 Request and Context from a Payjoin Proposal
-    pub fn extract_v1(&self) -> Result<(Request, v1::V1Context), url::ParseError> {
-        self.v1.extract_v1()
-    }
+    pub fn extract_v1(&self) -> (Request, v1::V1Context) { self.v1.extract_v1() }
 
     /// Extract serialized Request and Context from a Payjoin Proposal.
     ///

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -231,8 +231,7 @@ pub(crate) fn serialize_v2_body(
         fee_contribution,
         min_fee_rate,
         "2", // payjoin version
-    )
-    .map_err(|e| InternalCreateRequestError::Url(e.into()))?;
+    );
     let query_params = placeholder_url.query().unwrap_or_default();
     let base64 = psbt.to_string();
     Ok(format!("{}\n{}", base64, query_params).into_bytes())

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -87,7 +87,7 @@ mod integration {
             debug!("Original psbt: {:#?}", psbt);
             let (req, ctx) = SenderBuilder::new(psbt, uri)
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
-                .extract_v1()?;
+                .extract_v1();
             let headers = HeaderMock::new(&req.body, req.content_type);
 
             // **********************
@@ -151,7 +151,7 @@ mod integration {
             debug!("Original psbt: {:#?}", psbt);
             let (req, _ctx) = SenderBuilder::new(psbt, uri)
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
-                .extract_v1()?;
+                .extract_v1();
             let headers = HeaderMock::new(&req.body, req.content_type);
 
             // **********************
@@ -400,7 +400,7 @@ mod integration {
             let psbt = build_original_psbt(&sender, &pj_uri)?;
             let req_ctx = SenderBuilder::new(psbt.clone(), pj_uri.clone())
                 .build_recommended(FeeRate::BROADCAST_MIN)?;
-            let (req, ctx) = req_ctx.extract_v1()?;
+            let (req, ctx) = req_ctx.extract_v1();
             let headers = HeaderMock::new(&req.body, req.content_type);
 
             // **********************
@@ -468,7 +468,7 @@ mod integration {
                             FeeRate::ZERO,
                             false,
                         )?
-                        .extract_v1()?;
+                        .extract_v1();
                 log::info!("send fallback v1 to offline receiver fail");
                 let res = agent
                     .post(url.clone())
@@ -967,7 +967,7 @@ mod integration {
             let max_additional_fee = Amount::from_sat(1000);
             let (req, ctx) = SenderBuilder::new(psbt.clone(), uri)
                 .build_with_additional_fee(max_additional_fee, None, FeeRate::ZERO, false)?
-                .extract_v1()?;
+                .extract_v1();
             let headers = HeaderMock::new(&req.body, req.content_type);
 
             // **********************
@@ -1043,7 +1043,7 @@ mod integration {
             log::debug!("Original psbt: {:#?}", psbt);
             let (req, ctx) = SenderBuilder::new(psbt.clone(), uri)
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
-                .extract_v1()?;
+                .extract_v1();
             let headers = HeaderMock::new(&req.body, req.content_type);
 
             // **********************


### PR DESCRIPTION
I noticed that `serialize_url` returns a `Result<Url, url::ParseError>` but never actually returns an `Err`, so it can simply return a `Url` instead. The first commit addresses this.

By extension, `Sender::extract_v1` no longer needs to return a `Result` either. The second commit addresses this. However, that one is a breaking change so I can remove this commit if that's undesired.