### PR TITLE
Make InputContributionError public

### DIFF
--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -14,8 +14,8 @@ use std::str::FromStr;
 use bitcoin::{psbt, AddressType, Psbt, TxIn, TxOut};
 pub(crate) use error::InternalPayloadError;
 pub use error::{
-    Error, ImplementationError, JsonError, OutputSubstitutionError, PayloadError, ReplyableError,
-    SelectionError,
+    Error, ImplementationError, InputContributionError, JsonError, OutputSubstitutionError,
+    PayloadError, ReplyableError, SelectionError,
 };
 use optional_parameters::Params;
 


### PR DESCRIPTION
It was previously added to the public errors in 0af90e6, but removed (erroneously I believe) in f6f1281.