### PR TITLE
[WIP] include std::log output in tracing output

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "url",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "url",
 ]

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -26,3 +26,4 @@ tokio = { version = "1.12.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.2.2"
+tracing-log = "0.2.0"

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -21,6 +21,7 @@ use rustls::RootCertStore;
 use testcontainers::{clients, Container};
 use testcontainers_modules::redis::{Redis, REDIS_PORT};
 use tokio::task::JoinHandle;
+use tracing_log::LogTracer;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 use url::Url;
 
@@ -31,6 +32,8 @@ static INIT_TRACING: OnceCell<()> = OnceCell::new();
 
 pub fn init_tracing() {
     INIT_TRACING.get_or_init(|| {
+        LogTracer::init().expect("failed to initialize log tracersetting up log tracer");
+
         let subscriber = FmtSubscriber::builder()
             .with_env_filter(EnvFilter::from_default_env())
             .with_test_writer()


### PR DESCRIPTION
with the default options, which we use, the tracing-subscriber crate already includes tracing-log as a dependency, so might as well enable the std::log event bridge

opening as a draft primarily to document how this can be done at least crudely. afaict it would be better to have init_tracing return a guard per thread instead of a setting the global in a `Once`, and use the `SubscriberInitExt` extension trait's `set_default`, which would make our tests do `let _guard = init_tracing()` everywhere.

that's kind of what actually wanted which is to use the tracing-chrome crate so i can look at spans more graphically, still trying to figure out how to save these only if tests fail, or as an alternative set one up for all tests somehow and maybe use `#instrument` to add a span for per test, or just record them all but only if some env var is set (I would like to have them as downloadable artifacts in github CI jobs)