### PR TITLE
Use explicit error conversion where there might be ambiguity

### DIFF
--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -41,10 +41,6 @@ impl From<crate::into_url::Error> for SessionError {
     fn from(e: crate::into_url::Error) -> Self { InternalSessionError::ParseUrl(e).into() }
 }
 
-impl From<std::time::SystemTime> for Error {
-    fn from(e: std::time::SystemTime) -> Self { InternalSessionError::Expired(e).into() }
-}
-
 impl From<OhttpEncapsulationError> for Error {
     fn from(e: OhttpEncapsulationError) -> Self {
         InternalSessionError::OhttpEncapsulation(e).into()


### PR DESCRIPTION
https://github.com/payjoin/rust-payjoin/pull/570#discussion_r1996461780

The SystemTime Expired variant is explicitly constructed.

I want to check how the ParseUrl errors are converted too before this goes in.