### PR TITLE
Limit response sizes for v1

### DIFF
--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -267,7 +267,6 @@ pub const KEM: Kem = Kem::K256Sha256;
 pub const SYMMETRIC: &[SymmetricSuite] =
     &[ohttp::SymmetricSuite::new(Kdf::HkdfSha256, Aead::ChaCha20Poly1305)];
 
-// OriginalPSBT Test Vector from BIP 78
 // https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#user-content-span_idtestvectorsspanTest_vectors
 // | InputScriptType | Original PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|
 // |-----------------|-----------------------|------------------------------|-------------------------|

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -76,3 +76,7 @@ pub(crate) mod error_codes;
 pub use crate::core::error::ImplementationError;
 #[cfg(feature = "_core")]
 pub(crate) use crate::core::version::Version;
+
+/// 4M block size limit with base64 encoding overhead => maximum reasonable size of content-length
+/// 4_000_000 * 4 / 3 fits in u32
+pub const MAX_CONTENT_LENGTH: usize = 4_000_000 * 4 / 3;

--- a/payjoin/src/receive/v1/exclusive/mod.rs
+++ b/payjoin/src/receive/v1/exclusive/mod.rs
@@ -4,10 +4,8 @@ pub use error::RequestError;
 
 use super::*;
 use crate::into_url::IntoUrl;
-use crate::Version;
+use crate::{Version, MAX_CONTENT_LENGTH};
 
-/// 4_000_000 * 4 / 3 fits in u32
-const MAX_CONTENT_LENGTH: usize = 4_000_000 * 4 / 3;
 const SUPPORTED_VERSIONS: &[Version] = &[Version::One];
 
 pub trait Headers {

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -6,6 +6,7 @@ use bitcoin::transaction::Version;
 use bitcoin::Sequence;
 
 use crate::error_codes::ErrorCode;
+use crate::MAX_CONTENT_LENGTH;
 
 /// Error building a Sender from a SenderBuilder.
 ///
@@ -95,6 +96,7 @@ pub struct ValidationError(InternalValidationError);
 pub(crate) enum InternalValidationError {
     Parse,
     Io(std::io::Error),
+    ContentTooLarge,
     Proposal(InternalProposalError),
     #[cfg(feature = "v2")]
     V2Encapsulation(crate::send::v2::EncapsulationError),
@@ -119,6 +121,7 @@ impl fmt::Display for ValidationError {
         match &self.0 {
             Parse => write!(f, "couldn't decode as PSBT or JSON",),
             Io(e) => write!(f, "couldn't read PSBT: {e}"),
+            ContentTooLarge => write!(f, "content is larger than {MAX_CONTENT_LENGTH} bytes"),
             Proposal(e) => write!(f, "proposal PSBT error: {e}"),
             #[cfg(feature = "v2")]
             V2Encapsulation(e) => write!(f, "v2 encapsulation error: {e}"),
@@ -133,6 +136,7 @@ impl std::error::Error for ValidationError {
         match &self.0 {
             Parse => None,
             Io(error) => Some(error),
+            ContentTooLarge => None,
             Proposal(e) => Some(e),
             #[cfg(feature = "v2")]
             V2Encapsulation(e) => Some(e),

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -295,7 +295,7 @@ impl V1Context {
 #[cfg(test)]
 mod test {
     use bitcoin::FeeRate;
-    use payjoin_test_utils::{BoxError, PARSED_ORIGINAL_PSBT};
+    use payjoin_test_utils::{BoxError, INVALID_PSBT, PARSED_ORIGINAL_PSBT, PAYJOIN_PROPOSAL};
 
     use super::*;
     use crate::error_codes::ErrorCode;
@@ -305,12 +305,6 @@ mod test {
 
     const PJ_URI: &str =
         "bitcoin:2N47mmrWXsNBvQR6k78hWJoTji57zXwNcU7?amount=0.02&pjos=0&pj=HTTPS://EXAMPLE.COM/";
-
-    /// From the BIP-174 test vector
-    const INVALID_PSBT: &str = "AgAAAAEmgXE3Ht/yhek3re6ks3t4AAwFZsuzrWRkFxPKQhcb9gAAAABqRzBEAiBwsiRRI+a/R01gxbUMBD1MaRpdJDXwmjSnZiqdwlF5CgIgATKcqdrPKAvfMHQOwDkEIkIsgctFg5RXrrdvwS7dlbMBIQJlfRGNM1e44PTCzUbbezn22cONmnCry5st5dyNv+TOMf7///8C09/1BQAAAAAZdqkU0MWZA8W6woaHYOkP1SGkZlqnZSCIrADh9QUAAAAAF6kUNUXm4zuDLEcFDyTT7rk8nAOUi8eHsy4TAA&#61;&#61;";
-
-    /// From the BIP-78 test vector
-    const PJ_PROPOSAL_PSBT: &str = "cHNidP8BAJwCAAAAAo8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////jye60aAl3JgZdaIERvjkeh72VYZuTGH/ps2I4l0IO4MBAAAAAP7///8CJpW4BQAAAAAXqRQd6EnwadJ0FQ46/q6NcutaawlEMIcACT0AAAAAABepFHdAltvPSGdDwi9DR+m0af6+i2d6h9MAAAAAAQEgqBvXBQAAAAAXqRTeTh6QYcpZE1sDWtXm1HmQRUNU0IcAAQEggIQeAAAAAAAXqRTI8sv5ymFHLIjkZNRrNXSEXZHY1YcBBxcWABRfgGZV5ZJMkgTC1RvlOU9L+e2iEAEIawJHMEQCIGe7e0DfJaVPRYEKWxddL2Pr0G37BoKz0lyNa02O2/tWAiB7ZVgBoF4s8MHocYWWmo4Q1cyV2wl7MX0azlqa8NBENAEhAmXWPPW0G3yE3HajBOb7gO7iKzHSmZ0o0w0iONowcV+tAAAA";
 
     fn create_v1_context() -> super::V1Context {
         let psbt_context = create_psbt_context().expect("failed to create context");
@@ -362,7 +356,7 @@ mod test {
 
     #[test]
     fn process_response_valid() {
-        let mut cursor = std::io::Cursor::new(PJ_PROPOSAL_PSBT.as_bytes());
+        let mut cursor = std::io::Cursor::new(PAYJOIN_PROPOSAL.as_bytes());
 
         let ctx = create_v1_context();
         let response = ctx.process_response(&mut cursor);


### PR DESCRIPTION
Add content length checks in v1 send and payjoin-cli.

Fixes #483 