### PR TITLE
Update ohttp-relay to 0.0.10

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1472,8 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "ohttp-relay"
-version = "0.0.9"
-source = "git+https://github.com/payjoin/ohttp-relay.git?rev=c1a4bfd489a69170b4107317fd99aabc87796bab#c1a4bfd489a69170b4107317fd99aabc87796bab"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e766a4a358e64f0ea35b79eae3333052b8164ffc20f538ffb7c6861250bbb101"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1472,8 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "ohttp-relay"
-version = "0.0.9"
-source = "git+https://github.com/payjoin/ohttp-relay.git?rev=c1a4bfd489a69170b4107317fd99aabc87796bab#c1a4bfd489a69170b4107317fd99aabc87796bab"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e766a4a358e64f0ea35b79eae3333052b8164ffc20f538ffb7c6861250bbb101"
 dependencies = [
  "byteorder",
  "bytes",

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -13,7 +13,7 @@ bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 http = "1"
 log = "0.4.7"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
-ohttp-relay = { git = "https://github.com/payjoin/ohttp-relay.git", rev = "c1a4bfd489a69170b4107317fd99aabc87796bab", version = "0.0.9", features = ["_test-util"] }
+ohttp-relay = { version = "0.0.10", features = ["_test-util"] }
 once_cell = "1"
 payjoin = { path = "../payjoin", features = ["io", "_danger-local-https"] }
 payjoin-directory = { path = "../payjoin-directory", features = ["_danger-local-https"] }


### PR DESCRIPTION
Crates.io must be used for release, not commit hash.