### PR TITLE
Add fetch-keys subcommand to cli

### DIFF
--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -109,3 +109,18 @@ from the sender directory:
 You should see the payjoin transaction occur and be able to verify the Partially Signed Bitcoin Transaction (PSBT), inputs, and Unspent Transaction Outputs (UTXOs).
 
 Congrats, you've payjoined!
+
+
+## Miscelaneous
+
+If you want to fetch ohttp keys for the default gateway there is a convenience method provided:
+
+```sh
+payjoin-cli fetch-keys
+```
+
+or locally from the payjoin-cli directory:
+
+```sh
+cargo run --features v2 -- fetch-keys
+```

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -266,6 +266,7 @@ fn handle_subcommands(builder: Builder, matches: &ArgMatches) -> Result<Builder,
         }
         #[cfg(feature = "v2")]
         Some(("resume", _)) => Ok(builder),
+        Some(("fetch-keys", _)) => Ok(builder),
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
 }

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -39,7 +39,10 @@ impl PayjoinExtras {
     pub fn endpoint(&self) -> &Url { &self.endpoint }
 }
 
+/// A bip21 compliant uri type with parsing.
 pub type Uri<'a, NetworkValidation> = bitcoin_uri::Uri<'a, NetworkValidation, MaybePayjoinExtras>;
+
+/// A bip77 compliant uri type.
 pub type PjUri<'a> = bitcoin_uri::Uri<'a, NetworkChecked, PayjoinExtras>;
 
 mod sealed {


### PR DESCRIPTION
This adds a subcommand to fetch ohttp keys for the default gateway.

Current use case is for WASM bindings POC, WASM doesn't support TLS.