### PR TITLE
Fix Payjoin directory docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Target directory (compiled binaries)
+target/
+
+# Rust's incremental compilation and debug info
+**/incremental/
+**/debug/
+**/release/
+**/deps/
+**/examples/
+**/bench/
+
+# Hidden system files
+.DS_Store
+Thumbs.db
+
+# IDE & Editor settings
+.idea/
+.vscode/
+*.iml
+
+# Logs and temporary files
+logs/
+*.log
+*.tmp
+*.swp
+*.swo
+*.swn
+
+# Git files
+.git/
+.gitignore
+
+# Docker files (optional)
+.dockerignore
+Dockerfile

--- a/payjoin-directory/Dockerfile
+++ b/payjoin-directory/Dockerfile
@@ -20,12 +20,11 @@ ENV AR_x86_64_unknown_linux_musl=ar
 # Add the x86_64-unknown-linux-musl target
 RUN rustup target add x86_64-unknown-linux-musl
 
-# Copy the manifest and source code
-COPY payjoin-directory/Cargo.toml ./
-COPY payjoin-directory/src/ ./src/
+# Copy the workspace manifest and source code
+COPY . .
 
 # Build the binary
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --bin payjoin-directory --release --target x86_64-unknown-linux-musl
 
 # Create final minimal image
 FROM --platform=linux/amd64 alpine:latest


### PR DESCRIPTION
Running into 
```
 => ERROR [builder 7/7] RUN cargo build --release --target x86_64-unknown-linux-musl                                                                                                  4.3s
------
 > [builder 7/7] RUN cargo build --release --target x86_64-unknown-linux-musl:
0.228     Updating crates.io index
4.306 error: failed to select a version for `payjoin`.
4.306     ... required by package `payjoin-directory v0.0.1 (/usr/src/payjoin-directory)`
4.306 versions that meet the requirements `^0.22.0` are: 0.22.0
4.306
4.306 the package `payjoin-directory` depends on `payjoin`, with features: `directory` but `payjoin` does not have these features.
4.306
4.306
4.306 failed to select a version for `payjoin` which could resolve this conflict

```

Which can be resolved by building the directory from the workspace. In order to do that we need to copy the workspace manifest and all the source code. I introduced a dockerignore file to ignore build files and other non-source code files in the first commit 


Tested using: 

```bash
 docker buildx build --no-cache -f payjoin-directory/Dockerfile . -t payjoin-directory:0.0.1-rc2 --load
```