### PR TITLE
Remove redundant `UrlExt` import

### DIFF
--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -281,7 +281,6 @@ impl V2GetContext {
         &self,
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, ohttp::ClientResponse), CreateRequestError> {
-        use crate::uri::UrlExt;
         let base_url = self.endpoint.clone();
 
         // TODO unify with receiver's fn subdir_path_from_pubkey


### PR DESCRIPTION
`UrlExt` is already imported at the top of `Send::v2::mod.rs:L36`.