### PR TITLE
Fix replacement_outputs type in v2 WantsOutputs

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -405,7 +405,7 @@ impl WantsOutputs {
     /// receiver needs to pay for additional miner fees (e.g. in the case of adding many outputs).
     pub fn replace_receiver_outputs(
         self,
-        replacement_outputs: impl Iterator<Item = TxOut>,
+        replacement_outputs: impl IntoIterator<Item = TxOut>,
         drain_script: &Script,
     ) -> Result<Self, OutputSubstitutionError> {
         let inner = self.v1.replace_receiver_outputs(replacement_outputs, drain_script)?;


### PR DESCRIPTION
This was missed in #529, the inner v1 type takes a IntoIterator and so should the v2 wrapper type.