### PR TITLE
Make WellKnownError public

### DIFF
--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -364,6 +364,7 @@ impl fmt::Debug for ResponseError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum WellKnownError {
     Unavailable(String),
     NotEnoughMoney(String),

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 use bitcoin::psbt::Psbt;
 use bitcoin::{Amount, FeeRate, Script, ScriptBuf, TxOut, Weight};
-pub use error::{BuildSenderError, ResponseError, ValidationError};
+pub use error::{BuildSenderError, ResponseError, ValidationError, WellKnownError};
 pub(crate) use error::{InternalBuildSenderError, InternalProposalError, InternalValidationError};
 use url::Url;
 


### PR DESCRIPTION
Well known errors are required for ffi bindings and should be public