### PR TITLE
chore: fix unnecessary usage of `()` in Redis commands

### DIFF
--- a/payjoin-directory/src/db.rs
+++ b/payjoin-directory/src/db.rs
@@ -79,8 +79,8 @@ impl DbPool {
     ) -> Result<()> {
         let mut conn = self.client.get_async_connection().await?;
         let key = channel_name(subdirectory_id, channel_type);
-        () = conn.set(&key, data.clone()).await?;
-        () = conn.publish(&key, "updated").await?;
+        conn.set(&key, data.clone()).await?;
+        conn.publish(&key, "updated").await?;
         Ok(())
     }
 


### PR DESCRIPTION
I found an issue where `()` was incorrectly used in the following lines:

```rust
() = conn.set(&key, data.clone()).await?;
```

and

```rust
() = conn.publish(&key, "updated").await?;
```

This usage of `()` was not needed, as it doesn't serve any purpose here. The code has been corrected to simply call the methods without the unnecessary assignment:

```rust
conn.set(&key, data.clone()).await?;
```

and

```rust
conn.publish(&key, "updated").await?;
```

These changes ensure that the Redis commands are executed correctly.