### PR TITLE
Ignore mutants.out* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ target
 *payjoin.sled
 Cargo.lock
 .vscode
-mutants.out
+mutants.out*


### PR DESCRIPTION
On each run, any existing mutants.out is renamed to mutants.out.old, and any existing mutants.out.old is deleted. This change ensures that mutants.out.old is also ignored.