### PR TITLE
Make feature = "v2" ⇒ `pub send::V1Context`

### DIFF
--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -35,6 +35,8 @@ pub(crate) mod v1;
 #[cfg(feature = "v2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "v2")))]
 pub mod v2;
+#[cfg(all(feature = "v2", not(feature = "v1")))]
+pub use v1::V1Context;
 
 #[cfg(feature = "_multiparty")]
 pub mod multiparty;


### PR DESCRIPTION
`v2::Sender::extract_v1(..) -> (.. v1::V1Context)`, so this type must have public visibility in order for bindings to implement this `extract_v1` function.

I decided not to make the v1 module public only with respect to this V1Context type under exclusive v2 feature configuration because that would introduce far more complexity. View code for exact semantics, since `send::v1::V1Context` is still the path when the `v1` feature is enabled.

Fix #599