### PR TITLE
Fix cli conf: cookie and db

### DIFF
--- a/payjoin-cli/example.config.toml
+++ b/payjoin-cli/example.config.toml
@@ -6,7 +6,7 @@
 # --------------
 
 # The path to the database file
-db_path = "payjoin.db"
+db_path = "payjoin.sled"
 
 # The maximum fee rate that the receiver is willing to pay (in sat/vB)
 max_fee_rate = 2.0
@@ -29,7 +29,7 @@ rpchost = "http://localhost:18443/wallet/sender"
 # 	MacOS: ~/Library/Application Support/Bitcoin/<NETWORK>/.cookie
 # 	Windows Vista and later: C:\Users\YourUserName\AppData\Roaming\Bitcoin\<NETWORK>\.cookie
 # 	Windows XP: C:\Documents and Settings\YourUserName\Application Data\Bitcoin\<NETWORK>\.cookie
-cookie = ""
+# cookie = ""
 
 # The rpcuser to connect to (specified in bitcoin.conf).
 rpcuser = "user"

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -23,6 +23,10 @@ pub struct BitcoindWallet {
 impl BitcoindWallet {
     pub fn new(config: &crate::app::config::BitcoindConfig) -> Result<Self> {
         let client = match &config.cookie {
+            Some(cookie) if cookie.as_os_str().is_empty() =>
+                return Err(anyhow!(
+                    "Cookie authentication enabled but no cookie path provided in config.toml"
+                )),
             Some(cookie) => Client::new(config.rpchost.as_str(), Auth::CookieFile(cookie.into())),
             None => Client::new(
                 config.rpchost.as_str(),


### PR DESCRIPTION
The cookie was set to an empty string by default,
this caused a cryptic I/O error that took a while to track down.

The db file path was set as .db by default,
.gitignore assumes a .sled file.