### PR TITLE
Handle bad key configuration

### DIFF
--- a/payjoin/src/ohttp.rs
+++ b/payjoin/src/ohttp.rs
@@ -50,6 +50,48 @@ pub fn ohttp_encapsulate(
     Ok((buffer, ohttp_ctx))
 }
 
+pub enum DirectoryResponseError {
+    InvalidSize(usize),
+    OhttpDecapsulation(OhttpEncapsulationError),
+    UnexpectedStatusCode(http::StatusCode),
+}
+
+pub fn process_get_res(
+    res: &[u8],
+    ohttp_context: ohttp::ClientResponse,
+) -> Result<Option<Vec<u8>>, DirectoryResponseError> {
+    let response = process_ohttp_res(res, ohttp_context)?;
+    let body = match response.status() {
+        http::StatusCode::OK => response.body().to_vec(),
+        http::StatusCode::ACCEPTED => return Ok(None),
+        _ => return Err(DirectoryResponseError::UnexpectedStatusCode(response.status())),
+    };
+    Ok(Some(body))
+}
+
+pub fn process_post_res(
+    res: &[u8],
+    ohttp_context: ohttp::ClientResponse,
+) -> Result<(), DirectoryResponseError> {
+    let response = process_ohttp_res(res, ohttp_context)?;
+    match response.status() {
+        http::StatusCode::OK => return Ok(()),
+        _ => return Err(DirectoryResponseError::UnexpectedStatusCode(response.status())),
+    };
+}
+
+fn process_ohttp_res(
+    res: &[u8],
+    ohttp_context: ohttp::ClientResponse,
+) -> Result<http::Response<Vec<u8>>, DirectoryResponseError> {
+    let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
+        res.try_into().map_err(|_| DirectoryResponseError::InvalidSize(res.len()))?;
+    log::trace!("decapsulating directory response");
+    let res = ohttp_decapsulate(ohttp_context, response_array)
+        .map_err(DirectoryResponseError::OhttpDecapsulation)?;
+    Ok(res)
+}
+
 /// decapsulate ohttp, bhttp response and return http response body and status code
 pub fn ohttp_decapsulate(
     res_ctx: ohttp::ClientResponse,

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -30,6 +30,7 @@ impl From<DirectoryResponseError> for SessionError {
                 InternalSessionError::OhttpEncapsulation(e),
             DirectoryResponseError::UnexpectedStatusCode(e) =>
                 InternalSessionError::UnexpectedStatusCode(e),
+            DirectoryResponseError::OhttpKeyRejected => todo!(),
         }
         .into()
     }

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -3,7 +3,7 @@ use std::error;
 
 use super::Error::V2;
 use crate::hpke::HpkeError;
-use crate::ohttp::OhttpEncapsulationError;
+use crate::ohttp::{DirectoryResponseError, OhttpEncapsulationError};
 use crate::receive::error::Error;
 
 /// Error that may occur during a v2 session typestate change
@@ -19,6 +19,24 @@ impl From<InternalSessionError> for SessionError {
 
 impl From<InternalSessionError> for Error {
     fn from(e: InternalSessionError) -> Self { V2(e.into()) }
+}
+
+impl From<DirectoryResponseError> for SessionError {
+    fn from(value: DirectoryResponseError) -> Self {
+        match value {
+            DirectoryResponseError::InvalidSize(e) =>
+                InternalSessionError::UnexpectedResponseSize(e),
+            DirectoryResponseError::OhttpDecapsulation(e) =>
+                InternalSessionError::OhttpEncapsulation(e),
+            DirectoryResponseError::UnexpectedStatusCode(e) =>
+                InternalSessionError::UnexpectedStatusCode(e),
+        }
+        .into()
+    }
+}
+
+impl From<DirectoryResponseError> for Error {
+    fn from(value: DirectoryResponseError) -> Self { V2(value.into()) }
 }
 
 #[derive(Debug)]

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -18,7 +18,9 @@ use super::{
     ReplyableError, SelectionError,
 };
 use crate::hpke::{decrypt_message_a, encrypt_message_b, HpkeKeyPair, HpkePublicKey};
-use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate, OhttpEncapsulationError, OhttpKeys};
+use crate::ohttp::{
+    ohttp_encapsulate, process_get_res, process_post_res, OhttpEncapsulationError, OhttpKeys,
+};
 use crate::output_substitution::OutputSubstitution;
 use crate::persist::{self, Persister};
 use crate::receive::{parse_payload, InputPair};
@@ -177,21 +179,15 @@ impl Receiver {
         body: &[u8],
         context: ohttp::ClientResponse,
     ) -> Result<Option<UncheckedProposal>, Error> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
-            body.try_into()
-                .map_err(|_| InternalSessionError::UnexpectedResponseSize(body.len()))?;
-        log::trace!("decapsulating directory response");
-        let response = ohttp_decapsulate(context, response_array)
-            .map_err(InternalSessionError::OhttpEncapsulation)?;
-        if response.body().is_empty() {
-            log::debug!("response is empty");
-            return Ok(None);
-        }
-        match String::from_utf8(response.body().to_vec()) {
+        let body = match process_get_res(body, context)? {
+            Some(body) => body,
+            None => return Ok(None),
+        };
+        match String::from_utf8(body.clone()) {
             // V1 response bodies are utf8 plaintext
             Ok(response) => Ok(Some(self.extract_proposal_from_v1(response)?)),
             // V2 response bodies are encrypted binary
-            Err(_) => Ok(Some(self.extract_proposal_from_v2(response.body().to_vec())?)),
+            Err(_) => Ok(Some(self.extract_proposal_from_v2(body)?)),
         }
     }
 
@@ -346,16 +342,7 @@ impl UncheckedProposal {
         body: &[u8],
         context: ohttp::ClientResponse,
     ) -> Result<(), SessionError> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
-            body.try_into()
-                .map_err(|_| InternalSessionError::UnexpectedResponseSize(body.len()))?;
-        let response = ohttp_decapsulate(context, response_array)
-            .map_err(InternalSessionError::OhttpEncapsulation)?;
-
-        match response.status() {
-            http::StatusCode::OK => Ok(()),
-            _ => Err(InternalSessionError::UnexpectedStatusCode(response.status()).into()),
-        }
+        process_post_res(body, context).map_err(Into::into)
     }
 }
 
@@ -606,15 +593,7 @@ impl PayjoinProposal {
         res: &[u8],
         ohttp_context: ohttp::ClientResponse,
     ) -> Result<(), Error> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
-            res.try_into().map_err(|_| InternalSessionError::UnexpectedResponseSize(res.len()))?;
-        let res = ohttp_decapsulate(ohttp_context, response_array)
-            .map_err(InternalSessionError::OhttpEncapsulation)?;
-        if res.status().is_success() {
-            Ok(())
-        } else {
-            Err(InternalSessionError::UnexpectedStatusCode(res.status()).into())
-        }
+        process_post_res(res, ohttp_context).map_err(Into::into)
     }
 }
 

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -594,7 +594,6 @@ impl PayjoinProposal {
         Ok((req, ctx))
     }
 
-    #[cfg(feature = "v2")]
     /// Processes the response for the final POST message from the receiver client in the v2 Payjoin protocol.
     ///
     /// This function decapsulates the response using the provided OHTTP context. If the response status is successful,

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -131,6 +131,7 @@ impl From<DirectoryResponseError> for EncapsulationError {
             DirectoryResponseError::OhttpDecapsulation(e) => InternalEncapsulationError::Ohttp(e),
             DirectoryResponseError::UnexpectedStatusCode(e) =>
                 InternalEncapsulationError::UnexpectedStatusCode(e),
+            DirectoryResponseError::OhttpKeyRejected => todo!(),
         }
         .into()
     }

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 
+use super::ResponseError;
+use crate::ohttp::DirectoryResponseError;
 use crate::uri::url_ext::ParseReceiverPubkeyParamError;
 
 pub type ImplementationError = Box<dyn std::error::Error + Send + Sync>;
@@ -117,6 +119,26 @@ impl From<InternalEncapsulationError> for EncapsulationError {
 impl From<InternalEncapsulationError> for super::ResponseError {
     fn from(value: InternalEncapsulationError) -> Self {
         super::ResponseError::Validation(
+            super::InternalValidationError::V2Encapsulation(value.into()).into(),
+        )
+    }
+}
+
+impl From<DirectoryResponseError> for EncapsulationError {
+    fn from(value: DirectoryResponseError) -> Self {
+        match value {
+            DirectoryResponseError::InvalidSize(e) => InternalEncapsulationError::InvalidSize(e),
+            DirectoryResponseError::OhttpDecapsulation(e) => InternalEncapsulationError::Ohttp(e),
+            DirectoryResponseError::UnexpectedStatusCode(e) =>
+                InternalEncapsulationError::UnexpectedStatusCode(e),
+        }
+        .into()
+    }
+}
+
+impl From<DirectoryResponseError> for ResponseError {
+    fn from(value: DirectoryResponseError) -> Self {
+        ResponseError::Validation(
             super::InternalValidationError::V2Encapsulation(value.into()).into(),
         )
     }

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -33,7 +33,7 @@ use url::Url;
 use super::error::BuildSenderError;
 use super::*;
 use crate::hpke::{decrypt_message_b, encrypt_message_a, HpkeSecretKey};
-use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate};
+use crate::ohttp::{ohttp_encapsulate, process_get_res, process_post_res};
 use crate::persist::{Persister, Value};
 use crate::send::v1;
 use crate::uri::{ShortId, UrlExt};
@@ -299,22 +299,13 @@ pub struct V2PostContext {
 
 impl V2PostContext {
     pub fn process_response(self, response: &[u8]) -> Result<V2GetContext, EncapsulationError> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] = response
-            .try_into()
-            .map_err(|_| InternalEncapsulationError::InvalidSize(response.len()))?;
-        let response = ohttp_decapsulate(self.ohttp_ctx, response_array)
-            .map_err(InternalEncapsulationError::Ohttp)?;
-        match response.status() {
-            http::StatusCode::OK => {
-                // return OK with new Typestate
-                Ok(V2GetContext {
-                    endpoint: self.endpoint,
-                    psbt_ctx: self.psbt_ctx,
-                    hpke_ctx: self.hpke_ctx,
-                })
-            }
-            _ => Err(InternalEncapsulationError::UnexpectedStatusCode(response.status()))?,
-        }
+        process_post_res(response, self.ohttp_ctx)?;
+        // return OK with new Typestate
+        Ok(V2GetContext {
+            endpoint: self.endpoint,
+            psbt_ctx: self.psbt_ctx,
+            hpke_ctx: self.hpke_ctx,
+        })
     }
 }
 
@@ -359,16 +350,9 @@ impl V2GetContext {
         response: &[u8],
         ohttp_ctx: ohttp::ClientResponse,
     ) -> Result<Option<Psbt>, ResponseError> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] = response
-            .try_into()
-            .map_err(|_| InternalEncapsulationError::InvalidSize(response.len()))?;
-
-        let response = ohttp_decapsulate(ohttp_ctx, response_array)
-            .map_err(InternalEncapsulationError::Ohttp)?;
-        let body = match response.status() {
-            http::StatusCode::OK => response.body().to_vec(),
-            http::StatusCode::ACCEPTED => return Ok(None),
-            _ => return Err(InternalEncapsulationError::UnexpectedStatusCode(response.status()))?,
+        let body = match process_get_res(response, ohttp_ctx)? {
+            Some(body) => body,
+            None => return Ok(None),
         };
         let psbt = decrypt_message_b(
             &body,


### PR DESCRIPTION
This is still a draft because I noticed some related issues that must be addressed first:

- `process_response` methods return inconsistent error types when POSTing vs. GETting, specifically: `EncapsulationError` vs. `ResponseError` for send and `SessionError` vs. `Error` for receive.
- Those error types are currently opaque, so the caller can't switch on specific variants.
- There are four duplicated variants between `InternalEncapsulationError` and `InternalSessionError`.
  - Also, `EncapsulationError` is a misnomer since it afaict it's exclusively raised when *de*capsulating responses.
  - The `Hpke` variant has nothing to do with en/decapsulation.
