### PR TITLE
Update directory Docker rustc version to 1.81

### DIFF
--- a/payjoin-directory/Dockerfile
+++ b/payjoin-directory/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Rust image as the builder
-FROM --platform=linux/amd64 rust:1.75-slim as builder
+FROM --platform=linux/amd64 rust:1.81-slim as builder
 
 WORKDIR /usr/src/payjoin-directory
 


### PR DESCRIPTION
Running docker build errors out with
```
46.56 error: package `litemap v0.7.5` cannot be built because it
   requires rustc 1.81 or newer, while the currently active rustc
version is 1.75.0
46.56 Either upgrade to rustc 1.81 or newer, or use
46.56 cargo update litemap@0.7.5 --precise ver
46.56 where `ver` is the latest version of `litemap` supporting rustc
   1.75.0

```

Updating to 1.81 fixes this