### PR TITLE
Add "Quick Start" minimal tutorial, "Configuration", and "Reference" to `payjoin-cli` README

### DIFF
--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -19,7 +19,7 @@ Independent audit is welcome.
 
 Here's a minimal payjoin example using `payjoin-cli` with the `v2` feature connected to `bitcoind` on [regtest](https://developer.bitcoin.org/examples/testing.html#regtest-mode). This example uses [`nigiri`](https://github.com/vulpemventures/nigiri) to setup a regtest environment. 
 
-Payjoin `v2` allows for transactions to be completed asynchronously. Thus the sender and receiver do not need to be online at the same time to payjoin. To make this work, we need a payjoin directory server and OHTTP relay. Learn more about how `v2` works [here](https://payjoin.org/docs/how-it-works/payjoin-v2-bip-77).
+Payjoin `v2` allows for transactions to be completed asynchronously. Thus the sender and receiver do not need to be online at the same time to payjoin. Learn more about how `v2` works [here](https://payjoin.org/docs/how-it-works/payjoin-v2-bip-77).
 
 To get started, install `nigiri`. Payjoin requires the sender and receiver each to have spendable [UTXOs](https://www.unchained.com/blog/what-is-a-utxo-bitcoin), so we'll create two wallets and fund each.
 

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -4,7 +4,7 @@
 
 `payjoin-cli` is the reference implementation for the payjoin protocol, written using the [Payjoin Dev Kit](https://payjoindevkit.org).
 
-It enables sending and receiving [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP Payjoin V2](https://github.com/bitcoin/bips/pull/1483) transactions via `bitcoind`. By default it supports Payjoin V1, and the `v2` feature sends and receives both since the protocol is backwards compatible.
+It enables sending and receiving [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP Payjoin V2](https://github.com/bitcoin/bips/pull/1483) (also known as Async Payjoin) transactions via `bitcoind`. By default it supports Payjoin V1, and the `v2` feature sends and receives both since the protocol is backwards compatible.
 
 While this code and design have had significant testing, it is still alpha-quality experimental software. Use at your own risk.
 
@@ -12,9 +12,11 @@ Independent audit is welcome.
 
 ## Quick Start
 
-Here's a minimal example using `payjoin-cli` with the `v2` feature connected to `bitcoind` on [regtest](https://developer.bitcoin.org/examples/testing.html#regtest-mode). This example uses [`nigiri`](https://github.com/vulpemventures/nigiri) to setup a regtest environment.
+Here's a minimal payjoin example using `payjoin-cli` with the `v2` feature connected to `bitcoind` on [regtest](https://developer.bitcoin.org/examples/testing.html#regtest-mode). This example uses [`nigiri`](https://github.com/vulpemventures/nigiri) to setup a regtest environment. 
 
-First, install `nigiri`. Payjoin requires the sender and receiver each to have spendable [UTXOs](https://www.unchained.com/blog/what-is-a-utxo-bitcoin), so we'll create two wallets and fund them each.
+Payjoin `v2` allows for transactions to be completed asynchronously. Thus the sender and receiver do not need to be online at the same time to payjoin. To make this work, we need a payjoin directory server and OHTTP relay. Learn more about how `v2` works [here](https://payjoin.org/docs/how-it-works/payjoin-v2-bip-77).
+
+To get started, install `nigiri`. Payjoin requires the sender and receiver each to have spendable [UTXOs](https://www.unchained.com/blog/what-is-a-utxo-bitcoin), so we'll create two wallets and fund each with spendable UTXOs.
 
 ```sh
 cargo install nigiri
@@ -27,7 +29,7 @@ nigiri rpc generatetoaddress $(nigiri rpc getnewaddress "sender") 101
 nigiri rpc generatetoaddress $(nigiri rpc getnewaddress "receiver") 101
 ```
 
-Great! Our wallets are setup, now let's do a payjoin.
+Great! Our wallets are setup, now let's do an async payjoin.
 
 ### Install `payjoin-cli`
 
@@ -88,87 +90,108 @@ Note that the session can be paused by pressing `Ctrl+C`. The receiver can come 
 
 ### Send a Payjoin
 
+Now, let's send the payjoin:
+
 ```sh
 sender/payjoin-cli send bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com --fee-rate 10
 ```
 
-Congratulations! You've completed a payjoin, and are on your way toward more efficient, private payments.
+Congratulations! You've completed a payjoin, and are on your way toward cheaper, more efficient, and more private payments. Additionally, because we're using `v2`, the sender and receiver don't need to be online at the same time to do the payjoin!
 
-Get a list of commands and options:
+## Configuration
 
-```console
-payjoin-cli --help
-```
+Config options can be passed from the command line, or manually edited in a `config.toml` file within the directory you run `payjoin-cli` from.
 
-Either pass config options from cli, or manually edit a `config.toml` file within directory you run `payjoin-cli` from.
-Configure it like so:
+Configure it like so (example for regtest):
 
 ```toml
 # config.toml
-bitcoind_cookie = "/tmp/regtest1/bitcoind/regtest/.cookie"
-# specify your wallet via rpchost connection string
-bitcoind_rpchost = "http://localhost:18443/wallet/boom"
- ```
+
+# Bitcoin Core RPC configuration
+bitcoind_rpchost = "http://localhost:18443/wallet/sender"  # RPC endpoint with wallet name
+bitcoind_rpcuser = "admin1"      # RPC username (if not using cookie auth)
+bitcoind_rpcpassword = "123"     # RPC password (if not using cookie auth)
+
+# Cookie authentication (alternative to username/password)
+# Default locations (mainnet):
+# Linux: ~/.bitcoin/.cookie
+# MacOS: ~/Library/Application Support/Bitcoin/.cookie
+# Windows: %APPDATA%\Bitcoin\.cookie
+bitcoind_cookie = "~/.bitcoin/regtest/.cookie"  # Path to Bitcoin Core cookie file
+
+# Default ports for bitcoind:
+# Mainnet: 8332
+# Testnet: 18332
+# Signet: 38332
+# Regtest: 18443
+
+# Database configuration
+db_path = "~/.local/share/payjoin/wallet.db"  # Custom path for the database
+
+# Payjoin v2 configuration
+pj_directory = "https://payjo.in"              # Payjoin directory server
+ohttp_relay = "https://pj.bobspacebkk.com"     # OHTTP relay service
+```
+
+## Usage
+
+Get a list of commands and options:
+
+```sh
+payjoin-cli --help
+```
+
+### CLI Reference
+
+#### Commands
+
+| Command  | Description |
+|----------|-------------|
+| `send`   | Send a payjoin transaction |
+| `receive`| Receive a payjoin transaction |
+| `help`   | Print this message or the help of the given subcommand(s) |
+
+#### Options
+
+| Option | Flag | Description |
+|--------|------|-------------|
+| `--rpchost` | `-r` | The port of the bitcoin node |
+| `--cookie-file` | `-c` | Path to the cookie file of the bitcoin node |
+| `--rpcuser` | | The username for the bitcoin node |
+| `--rpcpassword` | | The password for the bitcoin node |
+| `--db-path` | `-d` | Sets a custom database path |
+| `--help` | `-h` | Print help information |
+| `--version` | `-V` | Print version information |
 
 Your configuration details will vary, but you may use this as a template.
+
+#### Send Options
+
+| Argument/Option | Description |
+|----------------|-------------|
+| `<BIP21>` | The `bitcoin:...` payjoin uri to send to |
+| `--fee-rate <FEE_SAT_PER_VB>` | Fee rate in sat/vB |
+| `-h, --help` | Print help information |
+
+#### Receive Options
+
+| Argument/Option | Description |
+|----------------|-------------|
+| `<AMOUNT>` | The amount to receive in satoshis |
+| `-p, --port <port>` | The local port to listen on |
+| `-e, --pj-endpoint <pj_endpoint>` | The `pj=` endpoint to receive the payjoin request |
+| `-h, --help` | Print help information |
 
 ## Test Payjoin 2
 
 ### Install `payjoin-cli` with the V2 feature
 
-```console
-cargo install payjoin-cli --version $VERSION --features v2
-```
-
-### V2 Configuration
-
-In addition to the rpc configuration above, specify relevant ohttp and payjoin directory configuration as follows:
-
-```toml
-# config.toml
-...
-# a production payjoin directory server
-pj_directory="https://payjo.in"
-# payjo.in's ohttp_keys can now be fetched rather than configured ahead of time
- # an ohttp relay with ingress to payjo.in
-ohttp_relay="https://pj.bobspacebkk.com"
-```
 
 ### Asynchronous Operation
 
 Send and receiver state is saved to a database in the directory from which `payjoin-cli` is run. Once a send or receive session is started, it may resume using the `resume` argument if prior payjoin sessions have not yet complete.
 
-```console
-payjoin-cli resume
-```
 
-## Manual End to End Regtest Testing
-
-### Test Receive
-
-Set up 2 local regtest wallets and fund them. This example uses "boom" and "ocean"
-
-Determine the RPC port specified in your bitcoind's `bitcoin.conf`
-file. 18443 is the default. This can be set like so:
-
-```conf
-rpcport = 18443
-```
-
-From the directory you'll run `payjoin-cli`, assuming "boom" is the name of the receiving wallet, 18443 is the rpc port, and you wish to request 10,000 sats run:
-
-```console
-RUST_LOG=debug cargo run --features=_danger-local-https -- -r "http://localhost:18443/wallet/boom" receive 10000
-```
-
-The default configuration listens for payjoin requests at `http://localhost:3000` and expects you to relay https requests there.
-Payjoin requires a secure endpoint, either https and .onion are valid. In order to receive payjoin in a local testing environment one may enable the  `_danger-local-https` feature which will provision a self-signed certificate and host the `https://localhost:3000` endpoint. Emphasis on HTTP**S**.
-
-This will generate a payjoin capable bip21 URI with which to accept payjoin:
-
-```console
-BITCOIN:BCRT1QCJ4X75DUNY4X5NAWLM3CR8MALM9YAUYWWEWKWL?amount=0.00010&pj=https://localhost:3000
-```
 
 ### Test Send
 
@@ -181,7 +204,7 @@ Create another `config.toml` file in the directory the sender will run from  and
 Using the previously generated bip21 URI, run the following command
 from the sender directory:
 
-```console
+```sh
  RUST_LOG=debug cargo run --features=_danger-local-https -- send <BIP21> --fee-rate <FEE_SAT_PER_VB>
 ```
 

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -133,6 +133,10 @@ pj_directory = "https://payjo.in"              # Payjoin directory server
 ohttp_relay = "https://pj.bobspacebkk.com"     # OHTTP relay service
 ```
 
+### Asynchronous Operation
+
+Sender and receiver state is saved to a database in the directory from which `payjoin-cli` is run, called `payjoin.sled`. Once a send or receive session is started, it may resume using the `resume` argument if prior payjoin sessions have not yet complete.
+
 ## Usage
 
 Get a list of commands and options:
@@ -181,33 +185,3 @@ Your configuration details will vary, but you may use this as a template.
 | `-p, --port <port>` | The local port to listen on |
 | `-e, --pj-endpoint <pj_endpoint>` | The `pj=` endpoint to receive the payjoin request |
 | `-h, --help` | Print help information |
-
-## Test Payjoin 2
-
-### Install `payjoin-cli` with the V2 feature
-
-
-### Asynchronous Operation
-
-Send and receiver state is saved to a database in the directory from which `payjoin-cli` is run. Once a send or receive session is started, it may resume using the `resume` argument if prior payjoin sessions have not yet complete.
-
-
-
-### Test Send
-
-Create a "sender" directory within `payjoin-cli`. Open a new terminal window and navigate to this directory.
-
-Note: A wallet cannot payjoin with itself, one needs separate wallets.
-
-Create another `config.toml` file in the directory the sender will run from  and configure it as you did previously, except replace the receiver wallet name with the sender
-
-Using the previously generated bip21 URI, run the following command
-from the sender directory:
-
-```sh
- RUST_LOG=debug cargo run --features=_danger-local-https -- send <BIP21> --fee-rate <FEE_SAT_PER_VB>
-```
-
-You should see the payjoin transaction occur and be able to verify the Partially Signed Bitcoin Transaction (PSBT), inputs, and Unspent Transaction Outputs (UTXOs).
-
-Congrats, you've payjoined!

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -95,7 +95,7 @@ For example, to receive 10000 sats from our top-level directory:
 receiver/payjoin-cli receive 10000
 ```
 
-This will output a [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) URL containing the receiver's address, amount, payjoin directory, and OHTTP relay. For example:
+This will output a [bitcoin URI](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) containing the receiver's address, amount, payjoin directory, and other session information the client needs. For example:
 
 ```sh
 bitcoin:tb1qfttmt4z68cfyn2z25t3dusp03rq6gxrucfxs5a?amount=0.0001&pj=HTTPS://PAYJO.IN/EUQKYLU92GC6U%23RK1QFWVXS2LQ2VD4T6DUMQ0F4RZQ5NL9GM0EFWVHJZ9L796L20Z7SL3J+OH1QYP87E2AVMDKXDTU6R25WCPQ5ZUF02XHNPA65JMD8ZA2W4YRQN6UUWG+EX10T57UE```

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -16,7 +16,7 @@ Here's a minimal payjoin example using `payjoin-cli` with the `v2` feature conne
 
 Payjoin `v2` allows for transactions to be completed asynchronously. Thus the sender and receiver do not need to be online at the same time to payjoin. To make this work, we need a payjoin directory server and OHTTP relay. Learn more about how `v2` works [here](https://payjoin.org/docs/how-it-works/payjoin-v2-bip-77).
 
-To get started, install `nigiri`. Payjoin requires the sender and receiver each to have spendable [UTXOs](https://www.unchained.com/blog/what-is-a-utxo-bitcoin), so we'll create two wallets and fund each with spendable UTXOs.
+To get started, install `nigiri`. Payjoin requires the sender and receiver each to have spendable [UTXOs](https://www.unchained.com/blog/what-is-a-utxo-bitcoin), so we'll create two wallets and fund each.
 
 ```sh
 cargo install nigiri
@@ -46,7 +46,7 @@ mkdir sender receiver
 touch sender/config.toml receiver/config.toml
 ```
 
-Edit the `config.toml` files. Note that the `v2` feature requires a payjoin directory server and OHTTP relay. Learn more about them [here](https://payjoin.org/docs/how-it-works/payjoin-v2-bip-77).
+Edit the `config.toml` files. Note that the `v2` feature requires a payjoin directory server and OHTTP relay.
 
 ```toml
 # sender/config.toml
@@ -74,7 +74,13 @@ pj_directory = "https://payjo.in"
 ohttp_relay = "https://pj.bobspacebkk.com"
 ```
 
-Now, the receiver must generate an address to receive the payment:
+Now, the receiver must generate an address to receive the payment. The format is:
+
+```sh
+payjoin-cli receive <AMOUNT_SATS>
+```
+
+For example, to receive 10000 sats from our top-level directory:
 
 ```sh
 receiver/payjoin-cli receive 10000
@@ -90,13 +96,19 @@ Note that the session can be paused by pressing `Ctrl+C`. The receiver can come 
 
 ### Send a Payjoin
 
-Now, let's send the payjoin:
+Now, let's send the payjoin. Here is an example format:
 
 ```sh
-sender/payjoin-cli send bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com --fee-rate 10
+payjoin-cli send <BIP21> --fee-rate <FEE_SAT_PER_VB>
 ```
 
-Congratulations! You've completed a payjoin, and are on your way toward cheaper, more efficient, and more private payments. Additionally, because we're using `v2`, the sender and receiver don't need to be online at the same time to do the payjoin!
+Where `<BIP21>` is the BIP21 URL containing the receiver's address, amount, payjoin directory, and OHTTP relay. Using the example from above:
+
+```sh
+sender/payjoin-cli send bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com --fee-rate 2
+```
+
+Congratulations! You've completed a version 2 payjoin, which can be used for cheaper, more efficient, and more private on-chain payments. Additionally, because we're using `v2`, the sender and receiver don't need to be online at the same time to do the payjoin!
 
 ## Configuration
 
@@ -167,7 +179,6 @@ payjoin-cli --help
 | `--help` | `-h` | Print help information |
 | `--version` | `-V` | Print version information |
 
-Your configuration details will vary, but you may use this as a template.
 
 #### Send Options
 

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -4,7 +4,12 @@
 
 `payjoin-cli` is the reference implementation for the payjoin protocol, written using the [Payjoin Dev Kit](https://payjoindevkit.org).
 
-It enables sending and receiving [BIP 78 Payjoin (v1)](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/pull/1483) transactions via `bitcoind`. By default it supports Payjoin v2, which is backwards compatible with v1. Enable the `v1` feature to disable Payjoin v2 and sends and receives only v1 transactions.
+It enables sending and receiving [BIP 78 Payjoin
+(v1)](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft
+BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/pull/1483)
+transactions via `bitcoind`. By default it supports Payjoin v2, which is
+backwards compatible with v1. Enable the `v1` feature to disable Payjoin v2 to
+send and receive using only v1.
 
 While this code and design have had significant testing, it is still alpha-quality experimental software. Use at your own risk.
 
@@ -52,11 +57,13 @@ Edit the `config.toml` files. Note that the `v2` feature requires a payjoin dire
 # sender/config.toml
 
 # Nigiri uses the following RPC credentials
-bitcoind_rpcuser = "admin1"
-bitcoind_rpcpassword = "123"
-bitcoind_rpchost = "http://localhost:18443/wallet/sender"
+[bitcoind]
+rpcuser = "admin1"
+rpcpassword = "123"
+rpchost = "http://localhost:18443/wallet/sender"
 
 # For v2, our config also requires a payjoin directory server and OHTTP relay
+[v2]
 pj_directory = "https://payjo.in"
 ohttp_relay = "https://pj.bobspacebkk.com"
 ```
@@ -65,11 +72,13 @@ ohttp_relay = "https://pj.bobspacebkk.com"
 # receiver/config.toml
 
 # Nigiri uses the following RPC credentials
-bitcoind_rpcuser = "admin1"
-bitcoind_rpcpassword = "123"
-bitcoind_rpchost = "http://localhost:18443/wallet/receiver"
+[bitcoind]
+rpcuser = "admin1"
+rpcpassword = "123"
+rpchost = "http://localhost:18443/wallet/receiver"
 
 # For v2, our config also requires a payjoin directory server and OHTTP relay
+[v2]
 pj_directory = "https://payjo.in"
 ohttp_relay = "https://pj.bobspacebkk.com"
 ```
@@ -89,8 +98,7 @@ receiver/payjoin-cli receive 10000
 This will output a [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) URL containing the receiver's address, amount, payjoin directory, and OHTTP relay. For example:
 
 ```sh
-bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com
-```
+bitcoin:tb1qfttmt4z68cfyn2z25t3dusp03rq6gxrucfxs5a?amount=0.0001&pj=HTTPS://PAYJO.IN/EUQKYLU92GC6U%23RK1QFWVXS2LQ2VD4T6DUMQ0F4RZQ5NL9GM0EFWVHJZ9L796L20Z7SL3J+OH1QYP87E2AVMDKXDTU6R25WCPQ5ZUF02XHNPA65JMD8ZA2W4YRQN6UUWG+EX10T57UE```
 
 Note that the session can be paused by pressing `Ctrl+C`. The receiver can come back online and resume the session by running `payjoin-cli resume` again, and the sender may do a `send` against it while the receiver is offline.
 
@@ -105,45 +113,19 @@ payjoin-cli send <BIP21> --fee-rate <FEE_SAT_PER_VB>
 Where `<BIP21>` is the BIP21 URL containing the receiver's address, amount, payjoin directory, and OHTTP relay. Using the example from above:
 
 ```sh
-sender/payjoin-cli send bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com --fee-rate 2
+sender/payjoin-cli send "bitcoin:tb1qfttmt4z68cfyn2z25t3dusp03rq6gxrucfxs5a?amount=0.0001&pj=HTTPS://PAYJO.IN/EUQKYLU92GC6U%23RK1QFWVXS2LQ2VD4T6DUMQ0F4RZQ5NL9GM0EFWVHJZ9L796L20Z7SL3J+OH1QYP87E2AVMDKXDTU6R25WCPQ5ZUF02XHNPA65JMD8ZA2W4YRQN6UUWG+EX10T57UE" --fee-rate 1
 ```
 
-Congratulations! You've completed a version 2 payjoin, which can be used for cheaper, more efficient, and more private on-chain payments. Additionally, because we're using `v2`, the sender and receiver don't need to be online at the same time to do the payjoin!
+Congratulations! You've completed a version 2 payjoin, which can be used for cheaper, more efficient, and more private on-chain payments. Additionally, because we're using `v2`, the sender and receiver don't need to be online at the same time to do the payjoin.
 
 ## Configuration
 
 Config options can be passed from the command line, or manually edited in a `config.toml` file within the directory you run `payjoin-cli` from.
 
-Configure it like so (example for regtest):
+see the
+[example.config.toml](https://github.com/payjoin/rust-payjoin/blob/fde867b93ede767c9a50913432a73782a94ef40b/payjoin-cli/example.config.toml)
+for inspiration.
 
-```toml
-# config.toml
-
-# Bitcoin Core RPC configuration
-bitcoind_rpchost = "http://localhost:18443/wallet/sender"  # RPC endpoint with wallet name
-bitcoind_rpcuser = "admin1"      # RPC username (if not using cookie auth)
-bitcoind_rpcpassword = "123"     # RPC password (if not using cookie auth)
-
-# Cookie authentication (alternative to username/password)
-# Default locations (mainnet):
-# Linux: ~/.bitcoin/.cookie
-# MacOS: ~/Library/Application Support/Bitcoin/.cookie
-# Windows: %APPDATA%\Bitcoin\.cookie
-bitcoind_cookie = "~/.bitcoin/regtest/.cookie"  # Path to Bitcoin Core cookie file
-
-# Default ports for bitcoind:
-# Mainnet: 8332
-# Testnet: 18332
-# Signet: 38332
-# Regtest: 18443
-
-# Database configuration
-db_path = "~/.local/share/payjoin/wallet.db"  # Custom path for the database
-
-# Payjoin v2 configuration
-pj_directory = "https://payjo.in"              # Payjoin directory server
-ohttp_relay = "https://pj.bobspacebkk.com"     # OHTTP relay service
-```
 
 ### Asynchronous Operation
 
@@ -157,42 +139,8 @@ Get a list of commands and options:
 payjoin-cli --help
 ```
 
-### CLI Reference
+or with a subcommand e.g.
 
-#### Commands
-
-| Command  | Description |
-|----------|-------------|
-| `send`   | Send a payjoin transaction |
-| `receive`| Receive a payjoin transaction |
-| `help`   | Print this message or the help of the given subcommand(s) |
-
-#### Options
-
-| Option | Flag | Description |
-|--------|------|-------------|
-| `--rpchost` | `-r` | The port of the bitcoin node |
-| `--cookie-file` | `-c` | Path to the cookie file of the bitcoin node |
-| `--rpcuser` | | The username for the bitcoin node |
-| `--rpcpassword` | | The password for the bitcoin node |
-| `--db-path` | `-d` | Sets a custom database path |
-| `--help` | `-h` | Print help information |
-| `--version` | `-V` | Print version information |
-
-
-#### Send Options
-
-| Argument/Option | Description |
-|----------------|-------------|
-| `<BIP21>` | The `bitcoin:...` payjoin uri to send to |
-| `--fee-rate <FEE_SAT_PER_VB>` | Fee rate in sat/vB |
-| `-h, --help` | Print help information |
-
-#### Receive Options
-
-| Argument/Option | Description |
-|----------------|-------------|
-| `<AMOUNT>` | The amount to receive in satoshis |
-| `-p, --port <port>` | The local port to listen on |
-| `-e, --pj-endpoint <pj_endpoint>` | The `pj=` endpoint to receive the payjoin request |
-| `-h, --help` | Print help information |
+```sh
+payjoin-cli send --help
+```

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -4,7 +4,7 @@
 
 `payjoin-cli` is the reference implementation for the payjoin protocol, written using the [Payjoin Dev Kit](https://payjoindevkit.org).
 
-It enables sending and receiving [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP Payjoin V2](https://github.com/bitcoin/bips/pull/1483) (also known as Async Payjoin) transactions via `bitcoind`. By default it supports Payjoin V1, and the `v2` feature sends and receives both since the protocol is backwards compatible.
+It enables sending and receiving [BIP 78 Payjoin (v1)](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/pull/1483) transactions via `bitcoind`. By default it supports Payjoin v2, which is backwards compatible with v1. Enable the `v1` feature to disable Payjoin v2 and sends and receives only v1 transactions.
 
 While this code and design have had significant testing, it is still alpha-quality experimental software. Use at your own risk.
 

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -1,19 +1,98 @@
 # `payjoin-cli`
 
-## A command-line payjoin client for bitcoind in Rust
+## A command-line payjoin client for [Bitcoin Core](https://github.com/bitcoin/bitcoin?tab=readme-ov-file) in Rust.
 
-The `payjoin-cli` client enables sending and receiving of [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP Payjoin V2](https://github.com/bitcoin/bips/pull/1483) transactions. By default it supports Payjoin V1, and the `v2` feature sends and receives both since the protocol is backwards compatible. The implementation is built on [Payjoin Dev Kit](https://payjoindevkit.org).
+`payjoin-cli` is the reference implementation for the payjoin protocol, written using the [Payjoin Dev Kit](https://payjoindevkit.org).
 
-While this code and design has had significant testing, it is still alpha-quality experimental software. Use at your own risk.
+It enables sending and receiving [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft BIP Payjoin V2](https://github.com/bitcoin/bips/pull/1483) transactions via `bitcoind`. By default it supports Payjoin V1, and the `v2` feature sends and receives both since the protocol is backwards compatible.
+
+While this code and design have had significant testing, it is still alpha-quality experimental software. Use at your own risk.
+
 Independent audit is welcome.
 
-## Install `payjoin-cli`
+## Quick Start
 
-```console
-cargo install payjoin-cli --version $VERSION
+Here's a minimal example using `payjoin-cli` with the `v2` feature connected to `bitcoind` on [regtest](https://developer.bitcoin.org/examples/testing.html#regtest-mode). This example uses [`nigiri`](https://github.com/vulpemventures/nigiri) to setup a regtest environment.
+
+First, install `nigiri`. Payjoin requires the sender and receiver each to have spendable [UTXOs](https://www.unchained.com/blog/what-is-a-utxo-bitcoin), so we'll create two wallets and fund them each.
+
+```sh
+cargo install nigiri
+
+nigiri rpc createwallet "sender"
+nigiri rpc createwallet "receiver"
+
+# We need 101 blocks for the UTXOs to be spendable due to the coinbase maturity requirement.
+nigiri rpc generatetoaddress $(nigiri rpc getnewaddress "sender") 101
+nigiri rpc generatetoaddress $(nigiri rpc getnewaddress "receiver") 101
 ```
 
-where `$VERSION` is the [latest version](https://crates.io/crates/payjoin-cli) of the `payjoin-cli` you wish to install.
+Great! Our wallets are setup, now let's do a payjoin.
+
+### Install `payjoin-cli`
+
+```sh
+cargo install payjoin-cli --version $VERSION --features v2
+```
+
+where `$VERSION` is the [latest version](https://crates.io/crates/payjoin-cli).
+
+Next, create a directory for the sender & receiver and create a `config.toml` file for each:
+
+```sh
+mkdir sender receiver
+touch sender/config.toml receiver/config.toml
+```
+
+Edit the `config.toml` files. Note that the `v2` feature requires a payjoin directory server and OHTTP relay. Learn more about them [here](https://payjoin.org/docs/how-it-works/payjoin-v2-bip-77).
+
+```toml
+# sender/config.toml
+
+# Nigiri uses the following RPC credentials
+bitcoind_rpcuser = "admin1"
+bitcoind_rpcpassword = "123"
+bitcoind_rpchost = "http://localhost:18443/wallet/sender"
+
+# For v2, our config also requires a payjoin directory server and OHTTP relay
+pj_directory = "https://payjo.in"
+ohttp_relay = "https://pj.bobspacebkk.com"
+```
+
+```toml
+# receiver/config.toml
+
+# Nigiri uses the following RPC credentials
+bitcoind_rpcuser = "admin1"
+bitcoind_rpcpassword = "123"
+bitcoind_rpchost = "http://localhost:18443/wallet/receiver"
+
+# For v2, our config also requires a payjoin directory server and OHTTP relay
+pj_directory = "https://payjo.in"
+ohttp_relay = "https://pj.bobspacebkk.com"
+```
+
+Now, the receiver must generate an address to receive the payment:
+
+```sh
+receiver/payjoin-cli receive 10000
+```
+
+This will output a [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) URL containing the receiver's address, amount, payjoin directory, and OHTTP relay. For example:
+
+```sh
+bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com
+```
+
+Note that the session can be paused by pressing `Ctrl+C`. The receiver can come back online and resume the session by running `payjoin-cli resume` again, and the sender may do a `send` against it while the receiver is offline.
+
+### Send a Payjoin
+
+```sh
+sender/payjoin-cli send bitcoin:bcrt1qmdfqplpqy9jatyul6vtcvl26sp3u3vs89986w0?amount=0.0001&pj_directory=https://payjo.in&ohttp_relay=https://pj.bobspacebkk.com --fee-rate 10
+```
+
+Congratulations! You've completed a payjoin, and are on your way toward more efficient, private payments.
 
 Get a list of commands and options:
 

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -39,7 +39,7 @@ Great! Our wallets are setup, now let's do an async payjoin.
 ### Install `payjoin-cli`
 
 ```sh
-cargo install payjoin-cli --version $VERSION --features v2
+cargo install payjoin-cli --version $VERSION
 ```
 
 where `$VERSION` is the [latest version](https://crates.io/crates/payjoin-cli).


### PR DESCRIPTION
The `payjoin-cli` README is outdated and difficult to follow. This is an opinionated overwrite to make it easier to follow and make the documentation more comprehensive. Feel free to let me know if anything from the old documentation needs keeping or if something I put here doesn't belong.

It now also includes a full tutorial for using it, along with configuration instructions and a comprehensive reference of commands. Given the required length of this "quick start", it may be better to eventually package the environment setup in a Docker container for easy testing.

I wrote this by installing the latest version from crates.io as listed in the docs and using that, but since the current release version is incompatible with the payjoin directory in use (as mentioned in #623), I'm blocked on fully verifying the send/receive/resume flows work, and so am putting this in draft. I don't want to rewrite this based on the updates from the source build, however, since then these docs would be inaccurate and wouldn't make sense for anyone who isn't building from source. So I'm happy to leave this in draft until the new release and then update what's missing accordingly. Let me know your feedback!

Notes on major changes:
- [x] Reference its applicability to Bitcoin Core explicitly in the primary description, since that is the name of the overall software project people are used to hearing. `bitcoind` specifically is also referenced later for clarity.
- [x] I added a phrase about this being the reference implementation for payjoin, both to accurately identify its analogous purpose to `bitcoin-cli` and to add some gravitas.
- [x] A "Quick Start" section which is a complete and thorough set of instructions for how to setup an environment to use this from scratch. It uses [nigiri](https://nigiri.vulpem.com) for environment setup, which [fwict](https://x.com/i/grok?conversation=1907183389666587120) is one of the easiest to use to get a quick `bitcoind` regtest instance. People can just follow this (and click on links for concepts they may not know about) and without having to do any extra work.
- [x] "Configuration" and "Reference" sections.

A point of confusion and frustration for me with most bitcoin software has always been 1) lots of assumed knowledge and 2) ambiguous and incomplete examples/documentation. I try to ameliorate both here with this PR.