### PR TITLE
Remove redundant sender imports

### DIFF
--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -254,8 +254,6 @@ pub(crate) fn extract_request(
     receiver_pubkey: HpkePublicKey,
     ohttp_keys: &mut OhttpKeys,
 ) -> Result<(Request, ClientResponse), CreateRequestError> {
-    use crate::hpke::encrypt_message_a;
-    use crate::ohttp::ohttp_encapsulate;
     let hpke_ctx = HpkeContext::new(receiver_pubkey, &reply_key);
     let body = encrypt_message_a(
         body,


### PR DESCRIPTION
Both `encrypt_message_a` and `ohttp_encapsulate` are imported at the top of this file.

Clippy doesnt point these our which is odd. Noticed a warning in CI [here](https://github.com/payjoin/rust-payjoin/actions/runs/14219933836/job/39845219852?pr=624#step:5:250)