### PR TITLE
Propagate DbError as Internal

### DIFF
--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -399,7 +399,7 @@ async fn post_subdir(
 
     match pool.push_default(&id, req.into()).await {
         Ok(_) => Ok(none_response),
-        Err(e) => Err(HandlerError::BadRequest(e.into())),
+        Err(e) => Err(HandlerError::InternalServerError(e.into())),
     }
 }
 


### PR DESCRIPTION
Errors arising from a validated request being pushed to DB are internal 500 errors in nature.