### PR TITLE
Create clear command in payjoin-cli

### DIFF
--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -63,6 +63,12 @@ Send and receiver state is saved to a database in the directory from which `payj
 payjoin-cli resume
 ```
 
+If too many sessions are going at once it can be overwhelming to keep track of the active sessions no longer wanted. Clear active sessions using the `clear` argument if some or all prior payjoin sessions are stale or no longer wanted.
+
+```console
+payjoin-cli clear <BIP21>
+```
+
 ## Manual End to End Regtest Testing
 
 ### Test Receive

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -268,6 +268,8 @@ fn handle_subcommands(builder: Builder, matches: &ArgMatches) -> Result<Builder,
         }
         #[cfg(feature = "v2")]
         Some(("resume", _)) => Ok(builder),
+        #[cfg(feature = "v2")]
+        Some(("clear", _)) => Ok(builder),
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
 }

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -31,6 +31,8 @@ pub trait App: Send + Sync {
     async fn receive_payjoin(&self, amount: Amount) -> Result<()>;
     #[cfg(feature = "v2")]
     async fn resume_payjoins(&self) -> Result<()>;
+    #[cfg(feature = "v2")]
+    async fn clear_payjoins(&self, bip21: Option<&str>) -> Result<()>;
 
     fn create_original_psbt(&self, uri: &PjUri, fee_rate: FeeRate) -> Result<Psbt> {
         let amount = uri.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -123,6 +123,11 @@ impl AppTrait for App {
     async fn resume_payjoins(&self) -> Result<()> {
         unimplemented!("resume_payjoins not implemented for v1");
     }
+
+    #[cfg(feature = "v2")]
+    async fn clear_payjoins(&self, _bip_21: Option<&str>) -> Result<()> {
+        unimplemented!("clear_payjoins not implemented for v1");
+    }
 }
 
 impl App {


### PR DESCRIPTION
In testing there can be a lot of inactive and stale sessions when experimenting in the cli, I think it would be useful to have a method to clear those sessions out manually and not have to complete a payjoin to clear out the sessions.

I understand this may not be something we want to add to the cli as a manual clear is not really a pattern we would expect to see in wallets in the wild.