### PR TITLE
Extend tests for rest of receive module

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 additional_cargo_args = ["--all-features"]
-examine_globs = ["payjoin/src/uri/*.rs", "payjoin/src/receive/v1/**/*.rs"]
+examine_globs = ["payjoin/src/uri/*.rs", "payjoin/src/receive/**/*.rs"]
 exclude_globs = []
 exclude_re = [
 	"impl Debug",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { version = "0.12", default-features = false }
 rustls = { version = "0.22.4", optional = true }
 serde = { version = "1.0.160", features = ["derive"] }
 sled = "0.34"
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { version = "1.38.1", features = ["full"] }
 tokio-rustls = { version = "0.25", features = ["ring"], default-features = false, optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -22,7 +22,7 @@ rustls = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.3.7", features = ["redis"] }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { version = "1.38.1", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.2.2"

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = { version = "1.0.108", optional = true }
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 payjoin-test-utils = { path = "../payjoin-test-utils" }
 once_cell = "1"
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { version = "1.38.1", features = ["full"] }
 tracing = "0.1.40"
 
 [package.metadata.docs.rs]

--- a/payjoin/src/receive/optional_parameters.rs
+++ b/payjoin/src/receive/optional_parameters.rs
@@ -133,3 +133,25 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
+
+#[cfg(test)]
+pub(crate) mod test {
+    use bitcoin::Amount;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_params() {
+        use bitcoin::FeeRate;
+
+        let pairs = url::form_urlencoded::parse(b"maxadditionalfeecontribution=182&additionalfeeoutputindex=0&minfeerate=1&disableoutputsubstitution=true&optimisticmerge=true");
+        let params =
+            Params::from_query_pairs(pairs, &[1]).expect("Could not parse params from query pairs");
+        assert_eq!(params.v, 1);
+        assert_eq!(params.output_substitution, OutputSubstitution::Disabled);
+        assert_eq!(params.additional_fee_contribution, Some((Amount::from_sat(182), 0)));
+        assert_eq!(params.min_fee_rate, FeeRate::BROADCAST_MIN);
+        #[cfg(feature = "_multiparty")]
+        assert!(params.optimistic_merge)
+    }
+}


### PR DESCRIPTION
This expands the mutant  coverage for the rest of the receive module and expands the mutant job coverage over the entire receive module.

Unfortunately the `SHARED_CONTEXT` cannot reasonably be moved into test_utils as the external nature of this struct would then cause errors as the type would be of `payjoin::SessionContext` not `SessionContext`