### PR TITLE
Remove duplicate cli required_else_help method

### DIFF
--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -147,7 +147,6 @@ fn cli() -> ArgMatches {
         Command::new("send")
             .arg_required_else_help(true)
             .arg(arg!(<BIP21> "The `bitcoin:...` payjoin uri to send to"))
-            .arg_required_else_help(true)
             .arg(
                 Arg::new("fee_rate")
                     .long("fee-rate")
@@ -159,8 +158,7 @@ fn cli() -> ArgMatches {
 
     let mut receive_cmd = Command::new("receive")
         .arg_required_else_help(true)
-        .arg(arg!(<AMOUNT> "The amount to receive in satoshis").value_parser(parse_amount_in_sat))
-        .arg_required_else_help(true);
+        .arg(arg!(<AMOUNT> "The amount to receive in satoshis").value_parser(parse_amount_in_sat));
 
     #[cfg(feature = "v2")]
     let mut cmd = cmd.subcommand(Command::new("resume"));


### PR DESCRIPTION
The payjoin-cli expects some args else it lists a help message for users as a walk through for creating a new payjoin. There were some duplicate functions that were causing some dev confusion so the duplicates were removed.

I don't think we can get rid of all 4 instances of this method as we still want the help command to show up if a user doesn't add any arg to receive or send, just that these methods already don't work with `--fee-rate` for example, just a warning is given.

This simply removes the unecessary methods, if we want to display the help command if say `--fee-rate` is ommited we would need to restructure the commands to allow for this.

closes #636 