### PR TITLE
Reduce visibility of receiver error

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -25,7 +25,7 @@ use crate::receive::{parse_payload, InputPair};
 use crate::uri::ShortId;
 use crate::{IntoUrl, IntoUrlError, Request};
 
-pub(crate) mod error;
+mod error;
 
 const SUPPORTED_VERSIONS: &[usize] = &[1, 2];
 


### PR DESCRIPTION
Relevant errors are exported at the top of this file. The error submodule file doesnt need to be exported to the entire crate.