### PR TITLE
Alter receiver session as_ref assert and persist::Value import for ReceiverToken

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -639,9 +639,9 @@ pub mod test {
 
     use once_cell::sync::Lazy;
     use payjoin_test_utils::{BoxError, EXAMPLE_URL, KEM, KEY_ID, SYMMETRIC};
-    use persist::Value;
 
     use super::*;
+    use crate::persist::Value;
 
     pub(crate) static SHARED_CONTEXT: Lazy<SessionContext> = Lazy::new(|| SessionContext {
         address: Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")
@@ -708,7 +708,8 @@ pub mod test {
     #[test]
     fn receiver_ser_de_roundtrip() -> Result<(), serde_json::Error> {
         let session = Receiver { context: SHARED_CONTEXT.clone() };
-        assert_eq!(session.key().as_ref(), session.key().0.as_bytes());
+        let short_id = id(&session.context.s);
+        assert_eq!(session.key().as_ref(), short_id.as_bytes());
         let serialized = serde_json::to_string(&session)?;
         let deserialized: Receiver = serde_json::from_str(&serialized)?;
         assert_eq!(session, deserialized);


### PR DESCRIPTION
After moving the `as_ref` method for the `RecieverToken` in #638 we needed to change the imports for an assert that prevented a mutant from cropping up. This was missed prior to push and caused some failing lints.

Mutants pass on 6c465ddaffdb77f743ba5bbc2210876b287f4ad9