### PR TITLE
Move shared response processing code to ohttp.rs

### DIFF
--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -3,7 +3,7 @@ use std::error;
 
 use super::Error::V2;
 use crate::hpke::HpkeError;
-use crate::ohttp::OhttpEncapsulationError;
+use crate::ohttp::{DirectoryResponseError, OhttpEncapsulationError};
 use crate::receive::error::Error;
 
 /// Error that may occur during a v2 session typestate change
@@ -19,6 +19,24 @@ impl From<InternalSessionError> for SessionError {
 
 impl From<InternalSessionError> for Error {
     fn from(e: InternalSessionError) -> Self { V2(e.into()) }
+}
+
+impl From<DirectoryResponseError> for SessionError {
+    fn from(value: DirectoryResponseError) -> Self {
+        match value {
+            DirectoryResponseError::InvalidSize(e) =>
+                InternalSessionError::UnexpectedResponseSize(e),
+            DirectoryResponseError::OhttpDecapsulation(e) =>
+                InternalSessionError::OhttpEncapsulation(e),
+            DirectoryResponseError::UnexpectedStatusCode(e) =>
+                InternalSessionError::UnexpectedStatusCode(e),
+        }
+        .into()
+    }
+}
+
+impl From<DirectoryResponseError> for Error {
+    fn from(value: DirectoryResponseError) -> Self { V2(value.into()) }
 }
 
 #[derive(Debug)]

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -182,7 +182,9 @@ impl Receiver<WithContext> {
         body: &[u8],
         context: ohttp::ClientResponse,
     ) -> Result<Option<Receiver<UncheckedProposal>>, Error> {
-        let body = match process_get_res(body, context)? {
+        let body = match process_get_res(body, context)
+            .map_err(InternalSessionError::DirectoryResponse)?
+        {
             Some(body) => body,
             None => return Ok(None),
         };
@@ -344,7 +346,8 @@ impl Receiver<UncheckedProposal> {
         body: &[u8],
         context: ohttp::ClientResponse,
     ) -> Result<(), SessionError> {
-        process_post_res(body, context).map_err(Into::into)
+        process_post_res(body, context)
+            .map_err(|e| InternalSessionError::DirectoryResponse(e).into())
     }
 }
 
@@ -633,7 +636,8 @@ impl Receiver<PayjoinProposal> {
         res: &[u8],
         ohttp_context: ohttp::ClientResponse,
     ) -> Result<(), Error> {
-        process_post_res(res, ohttp_context).map_err(Into::into)
+        process_post_res(res, ohttp_context)
+            .map_err(|e| InternalSessionError::DirectoryResponse(e).into())
     }
 }
 

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 
+use super::ResponseError;
+use crate::ohttp::DirectoryResponseError;
 use crate::uri::url_ext::ParseReceiverPubkeyParamError;
 
 /// Error returned when request could not be created.
@@ -116,6 +118,26 @@ impl From<InternalEncapsulationError> for EncapsulationError {
 impl From<InternalEncapsulationError> for super::ResponseError {
     fn from(value: InternalEncapsulationError) -> Self {
         super::ResponseError::Validation(
+            super::InternalValidationError::V2Encapsulation(value.into()).into(),
+        )
+    }
+}
+
+impl From<DirectoryResponseError> for EncapsulationError {
+    fn from(value: DirectoryResponseError) -> Self {
+        match value {
+            DirectoryResponseError::InvalidSize(e) => InternalEncapsulationError::InvalidSize(e),
+            DirectoryResponseError::OhttpDecapsulation(e) => InternalEncapsulationError::Ohttp(e),
+            DirectoryResponseError::UnexpectedStatusCode(e) =>
+                InternalEncapsulationError::UnexpectedStatusCode(e),
+        }
+        .into()
+    }
+}
+
+impl From<DirectoryResponseError> for ResponseError {
+    fn from(value: DirectoryResponseError) -> Self {
+        ResponseError::Validation(
             super::InternalValidationError::V2Encapsulation(value.into()).into(),
         )
     }

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -325,7 +325,8 @@ impl Sender<V2PostContext> {
         self,
         response: &[u8],
     ) -> Result<Sender<V2GetContext>, EncapsulationError> {
-        process_post_res(response, self.state.ohttp_ctx)?;
+        process_post_res(response, self.state.ohttp_ctx)
+            .map_err(InternalEncapsulationError::DirectoryResponse)?;
         Ok(Sender {
             state: V2GetContext {
                 endpoint: self.state.endpoint,
@@ -394,7 +395,9 @@ impl Sender<V2GetContext> {
         response: &[u8],
         ohttp_ctx: ohttp::ClientResponse,
     ) -> Result<Option<Psbt>, ResponseError> {
-        let body = match process_get_res(response, ohttp_ctx)? {
+        let body = match process_get_res(response, ohttp_ctx)
+            .map_err(InternalEncapsulationError::DirectoryResponse)?
+        {
             Some(body) => body,
             None => return Ok(None),
         };

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -32,7 +32,7 @@ use url::Url;
 use super::error::BuildSenderError;
 use super::*;
 use crate::hpke::{decrypt_message_b, encrypt_message_a, HpkeSecretKey};
-use crate::ohttp::{ohttp_decapsulate, ohttp_encapsulate};
+use crate::ohttp::{ohttp_encapsulate, process_get_res, process_post_res};
 use crate::persist::Persister;
 use crate::send::v1;
 use crate::uri::{ShortId, UrlExt};
@@ -325,24 +325,14 @@ impl Sender<V2PostContext> {
         self,
         response: &[u8],
     ) -> Result<Sender<V2GetContext>, EncapsulationError> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] = response
-            .try_into()
-            .map_err(|_| InternalEncapsulationError::InvalidSize(response.len()))?;
-        let response = ohttp_decapsulate(self.state.ohttp_ctx, response_array)
-            .map_err(InternalEncapsulationError::Ohttp)?;
-        match response.status() {
-            http::StatusCode::OK => {
-                // return OK with new Typestate
-                Ok(Sender {
-                    state: V2GetContext {
-                        endpoint: self.state.endpoint,
-                        psbt_ctx: self.state.psbt_ctx,
-                        hpke_ctx: self.state.hpke_ctx,
-                    },
-                })
-            }
-            _ => Err(InternalEncapsulationError::UnexpectedStatusCode(response.status()))?,
-        }
+        process_post_res(response, self.state.ohttp_ctx)?;
+        Ok(Sender {
+            state: V2GetContext {
+                endpoint: self.state.endpoint,
+                psbt_ctx: self.state.psbt_ctx,
+                hpke_ctx: self.state.hpke_ctx,
+            },
+        })
     }
 }
 
@@ -404,16 +394,9 @@ impl Sender<V2GetContext> {
         response: &[u8],
         ohttp_ctx: ohttp::ClientResponse,
     ) -> Result<Option<Psbt>, ResponseError> {
-        let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] = response
-            .try_into()
-            .map_err(|_| InternalEncapsulationError::InvalidSize(response.len()))?;
-
-        let response = ohttp_decapsulate(ohttp_ctx, response_array)
-            .map_err(InternalEncapsulationError::Ohttp)?;
-        let body = match response.status() {
-            http::StatusCode::OK => response.body().to_vec(),
-            http::StatusCode::ACCEPTED => return Ok(None),
-            _ => return Err(InternalEncapsulationError::UnexpectedStatusCode(response.status()))?,
+        let body = match process_get_res(response, ohttp_ctx)? {
+            Some(body) => body,
+            None => return Ok(None),
         };
         let psbt = decrypt_message_b(
             &body,


### PR DESCRIPTION
The `process_res` methods across send and receive have a lot of shared code that can be extracted into reusable functions. `process_get_res` and `process_post_res` essentially do the same thing, and could conceivably be combined into one function. They were kept separate because "202 Accepted" is not a valid response for POST requests.