### PR TITLE
Use `IntoUrl` for `ohttp_relay` argument

### DIFF
--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -13,7 +13,7 @@ use crate::ohttp::ohttp_decapsulate;
 use crate::output_substitution::OutputSubstitution;
 use crate::send::v2::{ImplementationError, V2PostContext};
 use crate::uri::UrlExt;
-use crate::{PjUri, Request};
+use crate::{IntoUrl, PjUri, Request};
 
 mod error;
 mod persist;
@@ -117,7 +117,7 @@ impl GetContext {
     /// Extract the GET request that will give us the psbt to be finalized
     pub fn extract_req(
         &self,
-        ohttp_relay: Url,
+        ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, ohttp::ClientResponse), crate::send::v2::CreateRequestError> {
         self.0.extract_req(ohttp_relay)
     }
@@ -175,7 +175,7 @@ pub struct FinalizeContext {
 impl FinalizeContext {
     pub fn extract_req(
         &self,
-        ohttp_relay: Url,
+        ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, ohttp::ClientResponse), CreateRequestError> {
         let reply_key = self.hpke_ctx.reply_pair.secret_key();
         let body = serialize_v2_body(

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -169,7 +169,7 @@ impl Sender {
     /// and has no fallback to v1.
     pub fn extract_v2(
         &self,
-        ohttp_relay: Url,
+        ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, V2PostContext), CreateRequestError> {
         if let Ok(expiry) = self.v1.endpoint.exp() {
             if std::time::SystemTime::now() > expiry {
@@ -225,13 +225,14 @@ impl Sender {
 }
 
 pub(crate) fn extract_request(
-    ohttp_relay: Url,
+    ohttp_relay: impl IntoUrl,
     reply_key: HpkeSecretKey,
     body: Vec<u8>,
     url: Url,
     receiver_pubkey: HpkePublicKey,
     ohttp_keys: &mut OhttpKeys,
 ) -> Result<(Request, ClientResponse), CreateRequestError> {
+    let ohttp_relay = ohttp_relay.into_url()?;
     let hpke_ctx = HpkeContext::new(receiver_pubkey, &reply_key);
     let body = encrypt_message_a(
         body,


### PR DESCRIPTION
Switching to `IntoUrl` makes the function more ergonomic by allowing a broader range of URL-like inputs. This also simplifies bindings, as strings can be passed directly without extra conversion.