### PR TITLE
Add issue write permissions to mutants cron job workflow

### DIFF
--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   cargo-mutants:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
Our current default workflow permisssions do not allow for writing issues but I had made a workflow that already had this in place so we just had a failed workflow that did not properly create the issue as expected. This change is in lieu of changing the global workflow permissions.