### PR TITLE
Add derive macros to cli config

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -130,14 +130,14 @@ pub struct RawV1Config {
     pub pj_endpoint: Option<Url>,
 }
 
-
+#[cfg(feature = "v1")]
 #[derive(Debug, Clone, Deserialize)]
 pub struct V1Config {
     pub port: u16,
     pub pj_endpoint: Url,
 }
 
-
+#[cfg(feature = "v2")]
 #[derive(Debug, Clone, Deserialize)]
 pub struct V2Config {
     #[serde(deserialize_with = "deserialize_ohttp_keys_from_path")]
@@ -247,8 +247,8 @@ fn add_bitcoind_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigEr
     if let Some(bitcoind) = &cli.config.bitcoind {
         let rpchost = bitcoind.rpchost.as_ref().map(|s| s.as_str());
         let cookie = bitcoind.cookie.as_ref().map(|p| p.to_string_lossy().into_owned());
-        let rpcuser = bitcoind.rpcuser.as_ref().map(|s| s.as_str());
-        let rpcpassword = bitcoind.rpcpassword.as_ref().map(|s| s.as_str());
+        let rpcuser = bitcoind.rpcuser.as_deref();
+        let rpcpassword = bitcoind.rpcpassword.as_deref();
 
         config
             .set_override_option("bitcoind.rpchost", rpchost)?

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -10,6 +10,9 @@ use url::Url;
 
 use crate::db;
 
+
+type Builder = config::builder::ConfigBuilder<DefaultState>;
+
 #[derive(Debug, Parser)]
 #[command(
     version = env!("CARGO_PKG_VERSION"),
@@ -74,7 +77,6 @@ pub enum Commands {
     Resume,
 }
 
-type Builder = config::builder::ConfigBuilder<DefaultState>;
 
 #[derive(Debug, Clone, Deserialize, Parser)]
 pub struct Flags {
@@ -106,6 +108,15 @@ pub struct RawBitcoindConfig {
     pub rpcpassword: Option<String>,
 }
 
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BitcoindConfig {
+    pub rpchost: Url,
+    pub cookie: Option<PathBuf>,
+    pub rpcuser: String,
+    pub rpcpassword: String,
+}
+
 #[cfg(feature = "v1")]
 #[derive(Debug, Clone, Deserialize, Parser)]
 pub struct RawV1Config {
@@ -117,6 +128,22 @@ pub struct RawV1Config {
         help = "The URL endpoint of the payjoin V1 server, e.g. https://localhost:3000"
     )]
     pub pj_endpoint: Option<Url>,
+}
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct V1Config {
+    pub port: u16,
+    pub pj_endpoint: Url,
+}
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct V2Config {
+    #[serde(deserialize_with = "deserialize_ohttp_keys_from_path")]
+    pub ohttp_keys: Option<payjoin::OhttpKeys>,
+    pub ohttp_relay: Url,
+    pub pj_directory: Url,
 }
 
 #[cfg(feature = "v2")]
@@ -152,13 +179,6 @@ pub struct RawConfig {
     pub v2: Option<RawV2Config>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct BitcoindConfig {
-    pub rpchost: Url,
-    pub cookie: Option<PathBuf>,
-    pub rpcuser: String,
-    pub rpcpassword: String,
-}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ValidatedConfig {
@@ -176,19 +196,7 @@ pub struct ValidatedConfig {
     pub v2: V2Config,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct V1Config {
-    pub port: u16,
-    pub pj_endpoint: Url,
-}
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct V2Config {
-    #[serde(deserialize_with = "deserialize_ohttp_keys_from_path")]
-    pub ohttp_keys: Option<payjoin::OhttpKeys>,
-    pub ohttp_relay: Url,
-    pub pj_directory: Url,
-}
 
 impl ValidatedConfig {
     pub(crate) fn new(cli: &Cli) -> Result<Self, ConfigError> {

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -85,12 +85,15 @@ pub struct Config {
         help = "Sets a custom database path. Defaults to ~/.config/payjoin-cli"
     )]
     pub db_path: PathBuf,
+
     #[arg(long = "max-fee-rate", short = 'f', help = "The maximum fee rate to accept in sat/vB")]
     pub max_fee_rate: Option<FeeRate>,
-    #[clap(flatten)]
+
+    #[command(flatten)]
     pub bitcoind: BitcoindConfig,
-    #[clap(flatten)]
+
     #[serde(skip)]
+    #[arg(skip)]
     pub version: Option<VersionConfig>,
 }
 

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -208,7 +208,6 @@ impl ValidatedConfig {
             #[cfg(feature = "v1")]
             {
                 config_builder = add_v1_defaults(config_builder)?;
-                config_builder = config_builder.set_default("bip78", true)?;
             }
             #[cfg(not(feature = "v1"))]
             {
@@ -220,7 +219,6 @@ impl ValidatedConfig {
             #[cfg(feature = "v2")]
             {
                 config_builder = add_v2_defaults(config_builder)?;
-                config_builder = config_builder.set_default("bip77", true)?;
             }
             #[cfg(not(feature = "v2"))]
             {
@@ -231,6 +229,7 @@ impl ValidatedConfig {
         }
 
         config_builder = handle_subcommands(config_builder, cli)?;
+
         let config = config_builder.build()?.try_deserialize()?;
 
         Ok(config)
@@ -239,7 +238,10 @@ impl ValidatedConfig {
 
 /// Set up config -> cli overrides -> defaults for Bitcoin RPC connection settings
 fn add_bitcoind_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
-    // FIXME: unwrap shouldn't be used?
+    // Set defaults
+    let config = config.set_default("bitcoind.rpchost", "http://localhost:18443")?
+        .set_default("bitcoind.rpcuser", "bitcoin")?
+        .set_default("bitcoind.rpcpassword", "")?;
 
     // Override config values with command line arguments if applicable
     if let Some(bitcoind) = &cli.config.bitcoind {
@@ -267,13 +269,19 @@ fn add_common_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigErro
 /// Set up default values for v1-specific settings when v2 is not enabled
 #[cfg(feature = "v1")]
 fn add_v1_defaults(config: Builder) -> Result<Builder, ConfigError> {
-    config.set_default("v1.port", 3000_u16)?.set_default("v1.pj_endpoint", "https://localhost:3000")
+    config
+        .set_default("bip78", true)?
+        .set_default("bip77", false)?
+        .set_default("v1.port", 3000_u16)?
+        .set_default("v1.pj_endpoint", "https://localhost:3000")
 }
 
 /// Set up default values and CLI overrides for v2-specific settings
 #[cfg(feature = "v2")]
 fn add_v2_defaults(config: Builder) -> Result<Builder, ConfigError> {
     config
+        .set_default("bip77", true)?
+        .set_default("bip78", false)?
         .set_default("v2.ohttp_relay", "https://pj.bobspacebkk.com")?
         .set_default("v2.pj_directory", "https://payjo.in")?
         .set_default("v2.ohttp_keys", None::<String>)

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -182,240 +182,192 @@ pub struct ValidatedConfig {
     pub version: Option<VersionConfig>,
 }
 
-impl ValidatedConfig {
-    /// Version flags in order of precedence (newest to oldest)
-    const VERSION_FLAGS: &'static [(&'static str, u8)] = &[("bip77", 2), ("bip78", 1)];
-
-    /// Check for multiple version flags and return the highest precedence version
-    fn determine_version(cli: &Cli) -> Result<u8, ConfigError> {
-        let mut selected_version = None;
-        for _ in Self::VERSION_FLAGS.iter() {
-            #[cfg(feature = "v2")]
-            if cli.config.bip77.is_some() {
-                if selected_version.is_some() {
-                    return Err(ConfigError::Message(
-                            "Multiple version flags specified. Please use only one of: --bip77, --bip78"
-                            .to_string()
-                        ));
-                }
-                selected_version = Some(2);
-            }
-
-            #[cfg(feature = "v1")]
-            if cli.config.bip78.is_some() {
-                if selected_version.is_some() {
-                    return Err(ConfigError::Message(
-                            "Multiple version flags specified. Please use only one of: --bip77, --bip78"
-                            .to_string()
-                        ));
-                }
-                selected_version = Some(1);
-            }
-        }
-
-        if let Some(version) = selected_version {
-            return Ok(version);
-        }
-
-        #[cfg(feature = "v2")]
-        return Ok(2);
-        #[cfg(all(feature = "v1", not(feature = "v2")))]
-        return Ok(1);
-
-        #[cfg(not(any(feature = "v1", feature = "v2")))]
-        return Err(ConfigError::Message(
-            "No valid version available - must compile with v1 or v2 feature".to_string(),
-        ));
-    }
-
-    pub(crate) fn new(cli: &Cli) -> Result<Self, ConfigError> {
-        let mut config = config::Config::builder();
-
-        // Validate bitcoind settings
-        // 1. override config values with command line arguments where applicable
-        // 2. if neither command line or config values are set, use default values where applicable
-        // 3. for those that should not have default values because there's no
-        //    standard, return an error
-
-        config = add_bitcoind_defaults(config, cli)?;
-        config = add_common_defaults(config, cli)?;
-        let version = Self::determine_version(cli)?;
-
-        match version {
-            1 => {
-                #[cfg(feature = "v1")]
-                {
-                    config = add_v1_defaults(config)?;
-                }
-                #[cfg(not(feature = "v1"))]
-                return Err(ConfigError::Message(
-                    "BIP78 (v1) selected but v1 feature not enabled".to_string(),
-                ));
-            }
-            2 => {
-                #[cfg(feature = "v2")]
-                {
-                    config = add_v2_defaults(config)?;
-                }
-                #[cfg(not(feature = "v2"))]
-                return Err(ConfigError::Message(
-                    "BIP77 (v2) selected but v2 feature not enabled".to_string(),
-                ));
-            }
-            _ => unreachable!("determine_version() should only return 1 or 2"),
-        }
-
-        config = handle_subcommands(config, cli)?;
-        config = config.add_source(File::new("config.toml", FileFormat::Toml).required(false));
-
-        let built_config = config.build()?;
-
-        let mut config = ValidatedConfig {
-            db_path: built_config.get("db_path")?,
-            max_fee_rate: built_config.get("max_fee_rate").ok(),
-            bitcoind: built_config.get("bitcoind")?,
-            version: None,
-            bip77: built_config.get("bip77")?,
-            bip78: built_config.get("bip78")?,
-        };
-
-        match version {
-            1 => {
-                #[cfg(feature = "v1")]
-                {
-                    match built_config.get::<RawV1Config>("v1") {
-                        Ok(v1) => config.version = Some(VersionConfig::V1(v1)),
-                        Err(e) => {
-                            return Err(ConfigError::Message(format!(
-                                "Valid V1 configuration is required for BIP78 mode: {e}"
-                            )))
-                        }
-                    }
-                }
-                #[cfg(not(feature = "v1"))]
-                return Err(ConfigError::Message(
-                    "BIP78 (v1) selected but v1 feature not enabled".to_string(),
-                ));
-            }
-            2 => {
-                #[cfg(feature = "v2")]
-                {
-                    match built_config.get::<RawV2Config>("v2") {
-                        Ok(v2) => config.version = Some(VersionConfig::V2(v2)),
-                        Err(e) => {
-                            return Err(ConfigError::Message(format!(
-                                "Valid V2 configuration is required for BIP77 mode: {e}"
-                            )))
-                        }
-                    }
-                }
-                #[cfg(not(feature = "v2"))]
-                return Err(ConfigError::Message(
-                    "BIP77 (v2) selected but v2 feature not enabled".to_string(),
-                ));
-            }
-            _ => unreachable!("determine_version() should only return 1 or 2"),
-        }
-
-        if config.version.is_none() {
-            return Err(ConfigError::Message(
-                "No valid version configuration found for the specified mode".to_string(),
-            ));
-        }
-
-        log::debug!("App config: {config:?}");
-        Ok(config)
-    }
-
-    #[cfg(feature = "v1")]
-    pub fn v1(&self) -> Result<&RawV1Config, anyhow::Error> {
-        match &self.version {
-            Some(VersionConfig::V1(v1_config)) => Ok(v1_config),
-            #[allow(unreachable_patterns)]
-            _ => Err(anyhow::anyhow!("V1 configuration is required for BIP78 mode")),
-        }
-    }
-
-    #[cfg(feature = "v2")]
-    pub fn v2(&self) -> Result<&RawV2Config, anyhow::Error> {
-        match &self.version {
-            Some(VersionConfig::V2(v2_config)) => Ok(v2_config),
-            #[allow(unreachable_patterns)]
-            _ => Err(anyhow::anyhow!("V2 configuration is required for v2 mode")),
-        }
-    }
+pub fn load_config() -> Result<RawConfig, ConfigError> {
+    let mut config = config::Config::builder();
+    // let config.add_source(File::with_name("config").format(FileFormat::Toml).required(false)).build()?;
+    config = config.add_source(File::with_name("config").format(FileFormat::Toml).required(false));
+    config.build()?.try_deserialize()
 }
+//
+// impl ValidatedConfig {
+//     /// Version flags in order of precedence (newest to oldest)
+//     const VERSION_FLAGS: &'static [(&'static str, u8)] = &[("bip77", 2), ("bip78", 1)];
+//
+//     /// Check for multiple version flags and return the highest precedence version
+//     fn determine_version(cli: &Cli) -> Result<u8, ConfigError> {
+//         let mut selected_version = None;
+//         for _ in Self::VERSION_FLAGS.iter() {
+//             #[cfg(feature = "v2")]
+//             if cli.config.bip77.is_some() {
+//                 if selected_version.is_some() {
+//                     return Err(ConfigError::Message(
+//                             "Multiple version flags specified. Please use only one of: --bip77, --bip78"
+//                             .to_string()
+//                         ));
+//                 }
+//                 selected_version = Some(2);
+//             }
+//
+//             #[cfg(feature = "v1")]
+//             if cli.config.bip78.is_some() {
+//                 if selected_version.is_some() {
+//                     return Err(ConfigError::Message(
+//                             "Multiple version flags specified. Please use only one of: --bip77, --bip78"
+//                             .to_string()
+//                         ));
+//                 }
+//                 selected_version = Some(1);
+//             }
+//         }
+//
+//         if let Some(version) = selected_version {
+//             return Ok(version);
+//         }
+//
+//         #[cfg(feature = "v2")]
+//         return Ok(2);
+//         #[cfg(all(feature = "v1", not(feature = "v2")))]
+//         return Ok(1);
+//
+//         #[cfg(not(any(feature = "v1", feature = "v2")))]
+//         return Err(ConfigError::Message(
+//             "No valid version available - must compile with v1 or v2 feature".to_string(),
+//         ));
+//     }
+//
+// pub(crate) fn new(cli: &Cli) -> Result<Self, ConfigError> {
 
+// Validate bitcoind settings
+// 1. override config values with command line arguments where applicable
+// 2. if neither command line or config values are set, use default values where applicable
+// 3. for those that should not have default values because there's no
+//    standard, return an error
+
+//     config = add_bitcoind_defaults(config, cli)?;
+//     config = add_common_defaults(config, cli)?;
+//     let version = Self::determine_version(cli)?;
+//
+//     match version {
+//         1 => {
+//             #[cfg(feature = "v1")]
+//             {
+//                 config = add_v1_defaults(config)?;
+//             }
+//             #[cfg(not(feature = "v1"))]
+//             return Err(ConfigError::Message(
+//                 "BIP78 (v1) selected but v1 feature not enabled".to_string(),
+//             ));
+//         }
+//         2 => {
+//             #[cfg(feature = "v2")]
+//             {
+//                 config = add_v2_defaults(config)?;
+//             }
+//             #[cfg(not(feature = "v2"))]
+//             return Err(ConfigError::Message(
+//                 "BIP77 (v2) selected but v2 feature not enabled".to_string(),
+//             ));
+//         }
+//         _ => unreachable!("determine_version() should only return 1 or 2"),
+//     }
+//
+//     config = handle_subcommands(config, cli)?;
+// }
+//
+// #[cfg(feature = "v1")]
+// pub fn v1(&self) -> Result<&RawV1Config, anyhow::Error> {
+//     match &self.version {
+//         Some(VersionConfig::V1(v1_config)) => Ok(v1_config),
+//         #[allow(unreachable_patterns)]
+//         _ => Err(anyhow::anyhow!("V1 configuration is required for BIP78 mode")),
+//     }
+// }
+//
+// #[cfg(feature = "v2")]
+// pub fn v2(&self) -> Result<&RawV2Config, anyhow::Error> {
+//     match &self.version {
+//         Some(VersionConfig::V2(v2_config)) => Ok(v2_config),
+//         #[allow(unreachable_patterns)]
+//         _ => Err(anyhow::anyhow!("V2 configuration is required for v2 mode")),
+//     }
+// }
+// }
+//
 /// Set up config -> cli overrides -> defaults for Bitcoin RPC connection settings
-fn add_bitcoind_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
-    let mut config = config;
-
-    if let Some(bitcoind) = &cli.config.bitcoind {
-        config = config.set_override_option(
-            "bitcoind.rpchost",
-            bitcoind.rpchost.as_ref().map(|s| s.as_str()),
-        )?;
-        config = config.set_override_option(
-            "bitcoind.cookie",
-            bitcoind.cookie.as_ref().map(|p| p.to_string_lossy().into_owned()),
-        )?;
-        config = config.set_override_option(
-            "bitcoind.rpcuser",
-            bitcoind.rpcuser.as_ref().map(|s| s.as_str()),
-        )?;
-        config = config.set_override_option(
-            "bitcoind.rpcpassword",
-            bitcoind.rpcpassword.as_ref().map(|s| s.as_str()),
-        )?;
-    };
-
-    // if !bitcoind.rpcuser.
-    //     config = config.set_override_option("bitcoind.rpcuser", Some(&bitcoind.rpcuser))?;
-    // }
-    // if !bitcoind.rpcpassword.is_empty() {
-    //     config =
-    //         config.set_override_option("bitcoind.rpcpassword", Some(&bitcoind.rpcpassword))?;
-    // }
-
-    // config
-    //     .set_override_option("bitcoind.rpchost", cli.config.bitcoind.rpchost.to_owned().as_str())?
-    //     .set_override_option(
-    //         "bitcoind.cookie",
-    //         cli.config.bitcoind.cookie.as_ref().map(|p| p.to_string_lossy().into_owned()),
-    //     )?
-    //     .set_override_option(
-    //         "bitcoind.rpcuser",
-    //         Some(cli.config.bitcoind.rpcuser.to_owned().as_str()),
-    //     )?
-    //     .set_override_option(
-    //         "bitcoind.rpcpassword",
-    //         Some(cli.config.bitcoind.rpcpassword.to_owned().as_str()),
-    //     )
-    Ok(config)
-}
+// fn add_bitcoind_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+//
+//
+//     if let Some(config_file_bitcoind) = &cli.config.bitcoind {
+//         if let Some(cli_bitcoind) = &cli.config.bitcoind {
+//
+//         }
+//         if config_file_bitcoind.rpchost.is_none() && cli.config.bitcoind.rpchost.is_none() {
+//             return Err(ConfigError::Message("bitcoind.rpchost is required".to_string()));
+//         }
+//         config = config.set_override_option(
+//             "bitcoind.rpchost",
+//             bitcoind.rpchost.as_ref().map(|s| s.as_str()),
+//         )?;
+//         config = config.set_override_option(
+//             "bitcoind.cookie",
+//             bitcoind.cookie.as_ref().map(|p| p.to_string_lossy().into_owned()),
+//         )?;
+//         config = config.set_override_option(
+//             "bitcoind.rpcuser",
+//             bitcoind.rpcuser.as_ref().map(|s| s.as_str()),
+//         )?;
+//         config = config.set_override_option(
+//             "bitcoind.rpcpassword",
+//             bitcoind.rpcpassword.as_ref().map(|s| s.as_str()),
+//         )?;
+//     };
+//
+//     // if !bitcoind.rpcuser.
+//     //     config = config.set_override_option("bitcoind.rpcuser", Some(&bitcoind.rpcuser))?;
+//     // }
+//     // if !bitcoind.rpcpassword.is_empty() {
+//     //     config =
+//     //         config.set_override_option("bitcoind.rpcpassword", Some(&bitcoind.rpcpassword))?;
+//     // }
+//
+//     // config
+//     //     .set_override_option("bitcoind.rpchost", cli.config.bitcoind.rpchost.to_owned().as_str())?
+//     //     .set_override_option(
+//     //         "bitcoind.cookie",
+//     //         cli.config.bitcoind.cookie.as_ref().map(|p| p.to_string_lossy().into_owned()),
+//     //     )?
+//     //     .set_override_option(
+//     //         "bitcoind.rpcuser",
+//     //         Some(cli.config.bitcoind.rpcuser.to_owned().as_str()),
+//     //     )?
+//     //     .set_override_option(
+//     //         "bitcoind.rpcpassword",
+//     //         Some(cli.config.bitcoind.rpcpassword.to_owned().as_str()),
+//     //     )
+//     Ok(config)
+// }
 
 /// Set up default values and CLI overrides for common settings shared between v1 and v2
-fn add_common_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
-    config.set_default("db_path", db::DB_PATH)?.set_override_option(
-        "db_path",
-        cli.config.db_path.as_ref().map(|p| p.to_string_lossy().into_owned()),
-    )
-}
-
-/// Set up default values for v1-specific settings when v2 is not enabled
-#[cfg(feature = "v1")]
-fn add_v1_defaults(config: Builder) -> Result<Builder, ConfigError> {
-    config.set_default("v1.port", 3000_u16)?.set_default("v1.pj_endpoint", "https://localhost:3000")
-}
-
-/// Set up default values and CLI overrides for v2-specific settings
-#[cfg(feature = "v2")]
-fn add_v2_defaults(config: Builder) -> Result<Builder, ConfigError> {
-    config
-        .set_default("v2.ohttp_relay", "https://pj.bobspacebkk.com")?
-        .set_default("v2.pj_directory", "https://payjo.in")?
-        .set_default("v2.ohttp_keys", None::<String>)
-}
+// fn add_common_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+//     config
+//         .set_default("db_path", db::DB_PATH)?
+//         .set_override_option("db_path", cli.config.db_path.to_str())
+// }
+//
+// /// Set up default values for v1-specific settings when v2 is not enabled
+// #[cfg(feature = "v1")]
+// fn add_v1_defaults(config: Builder) -> Result<Builder, ConfigError> {
+//     config.set_default("v1.port", 3000_u16)?.set_default("v1.pj_endpoint", "https://localhost:3000")
+// }
+//
+// /// Set up default values and CLI overrides for v2-specific settings
+// #[cfg(feature = "v2")]
+// fn add_v2_defaults(config: Builder) -> Result<Builder, ConfigError> {
+//     config
+//         .set_default("v2.ohttp_relay", "https://pj.bobspacebkk.com")?
+//         .set_default("v2.pj_directory", "https://payjo.in")?
+//         .set_default("v2.ohttp_keys", None::<String>)
+// }
 
 /// Handles configuration overrides based on CLI subcommands
 fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
@@ -481,3 +433,4 @@ fn parse_fee_rate_in_sat_per_vb(s: &str) -> Result<FeeRate, std::num::ParseFloat
     let fee_rate_sat_per_kwu = fee_rate_sat_per_vb * 250.0_f32;
     Ok(FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64))
 }
+

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -10,7 +10,7 @@ use tokio::sync::watch;
 
 pub mod config;
 pub mod wallet;
-use crate::app::config::Config;
+use crate::app::config::RawConfig;
 use crate::app::wallet::BitcoindWallet;
 
 #[cfg(feature = "v1")]
@@ -23,7 +23,7 @@ pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 #[async_trait::async_trait]
 pub trait App: Send + Sync {
-    fn new(config: Config) -> Result<Self>
+    fn new(config: RawConfig) -> Result<Self>
     where
         Self: Sized;
     fn wallet(&self) -> BitcoindWallet;

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use bitcoincore_rpc::bitcoin::Amount;
+use config::ValidatedConfig;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::FeeRate;
 use payjoin::{bitcoin, PjUri};
@@ -10,7 +11,6 @@ use tokio::sync::watch;
 
 pub mod config;
 pub mod wallet;
-use crate::app::config::RawConfig;
 use crate::app::wallet::BitcoindWallet;
 
 #[cfg(feature = "v1")]
@@ -23,7 +23,7 @@ pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 #[async_trait::async_trait]
 pub trait App: Send + Sync {
-    fn new(config: RawConfig) -> Result<Self>
+    fn new(config: ValidatedConfig) -> Result<Self>
     where
         Self: Sized;
     fn wallet(&self) -> BitcoindWallet;

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -56,10 +56,14 @@ pub trait App: Send + Sync {
 }
 
 #[cfg(feature = "_danger-local-https")]
-fn http_agent() -> Result<reqwest::Client> { Ok(http_agent_builder()?.build()?) }
+fn http_agent() -> Result<reqwest::Client> {
+    Ok(http_agent_builder()?.build()?)
+}
 
 #[cfg(not(feature = "_danger-local-https"))]
-fn http_agent() -> Result<reqwest::Client> { Ok(reqwest::Client::new()) }
+fn http_agent() -> Result<reqwest::Client> {
+    Ok(reqwest::Client::new())
+}
 
 #[cfg(feature = "_danger-local-https")]
 fn http_agent_builder() -> Result<reqwest::ClientBuilder> {

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -23,10 +23,11 @@ pub struct BitcoindWallet {
 impl BitcoindWallet {
     pub fn new(config: &crate::app::config::BitcoindConfig) -> Result<Self> {
         let client = match &config.cookie {
-            Some(cookie) if cookie.as_os_str().is_empty() =>
+            Some(cookie) if cookie.as_os_str().is_empty() => {
                 return Err(anyhow!(
                     "Cookie authentication enabled but no cookie path provided in config.toml"
-                )),
+                ))
+            }
             Some(cookie) => Client::new(config.rpchost.as_str(), Auth::CookieFile(cookie.into())),
             None => Client::new(
                 config.rpchost.as_str(),

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
         }
         #[cfg(all(feature = "v1", not(feature = "v2")))]
         {
-            Box::new(crate::app::v1::App::new(config)?)
+            Box::new(crate::app::v1::App::new(validated_config)?)
         }
         #[cfg(not(any(feature = "v1", feature = "v2")))]
         {

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use app::config::{Cli, Commands, Config};
+use app::config::{Cli, Commands, RawConfig};
 use app::App as AppTrait;
 use clap::Parser;
 use payjoin::bitcoin::FeeRate;
@@ -15,7 +15,9 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let cli = Cli::parse();
-    let config = Config::new(&cli)?;
+    let config = load_config();
+
+    // validate
 
     #[allow(clippy::if_same_then_else)]
     let app: Box<dyn AppTrait> = if config.bip78 {

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,8 +1,8 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use app::config::{Cli, Commands, Config};
 use app::App as AppTrait;
 use clap::Parser;
-use payjoin::bitcoin::{Amount, FeeRate};
+use payjoin::bitcoin::FeeRate;
 
 mod app;
 mod db;
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     let config = Config::new(&cli)?;
 
     #[allow(clippy::if_same_then_else)]
-    let app: Box<dyn AppTrait> = if cli.config.bip78 {
+    let app: Box<dyn AppTrait> = if config.bip78 {
         #[cfg(feature = "v1")]
         {
             Box::new(crate::app::v1::App::new(config)?)

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use app::config::{Cli, Commands, RawConfig};
+use app::config::{load_config, Cli, Commands, RawConfig};
 use app::App as AppTrait;
 use clap::Parser;
 use payjoin::bitcoin::FeeRate;

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,10 +1,8 @@
 use anyhow::{Context, Result};
-use app::config::Config;
+use app::config::{Cli, Commands, Config};
 use app::App as AppTrait;
-use clap::{arg, value_parser, Arg, ArgMatches, Command};
-use payjoin::bitcoin::amount::ParseAmountError;
+use clap::Parser;
 use payjoin::bitcoin::{Amount, FeeRate};
-use url::Url;
 
 mod app;
 mod db;
@@ -16,11 +14,11 @@ compile_error!("At least one of the features ['v1', 'v2'] must be enabled");
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let matches = cli();
-    let config = Config::new(&matches)?;
+    let cli = Cli::parse();
+    let config = Config::new(&cli)?;
 
     #[allow(clippy::if_same_then_else)]
-    let app: Box<dyn AppTrait> = if matches.get_flag("bip78") {
+    let app: Box<dyn AppTrait> = if cli.config.bip78 {
         #[cfg(feature = "v1")]
         {
             Box::new(crate::app::v1::App::new(config)?)
@@ -31,7 +29,7 @@ async fn main() -> Result<()> {
                 "BIP78 (v1) support is not enabled in this build. Recompile with --features v1"
             )
         }
-    } else if matches.get_flag("bip77") {
+    } else if cli.config.bip77 {
         #[cfg(feature = "v2")]
         {
             Box::new(crate::app::v2::App::new(config)?)
@@ -57,26 +55,35 @@ async fn main() -> Result<()> {
         }
     };
 
-    match matches.subcommand() {
-        Some(("send", sub_matches)) => {
-            let bip21 = sub_matches.get_one::<String>("BIP21").context("Missing BIP21 argument")?;
-            let fee_rate = sub_matches
-                .get_one::<FeeRate>("fee_rate")
-                .context("Missing --fee-rate argument")?;
-            app.send_payjoin(bip21, *fee_rate).await?;
+    match &cli.command {
+        // Some(("send", sub_matches)) => {
+        //     let bip21 = sub_matches.get_one::<String>("BIP21").context("Missing BIP21 argument")?;
+        //     let fee_rate = sub_matches
+        //         .get_one::<FeeRate>("fee_rate")
+        //         .context("Missing --fee-rate argument")?;
+        //     app.send_payjoin(bip21, *fee_rate).await?;
+        // }
+        // Some(("receive", sub_matches)) => {
+        //     let amount =
+        //         sub_matches.get_one::<Amount>("AMOUNT").context("Missing AMOUNT argument")?;
+        //     app.receive_payjoin(*amount).await?;
+        // }
+        // #[cfg(feature = "v2")]
+        // Some(("resume", _)) => {
+        //     if matches.get_flag("bip78") {
+        //         anyhow::bail!("Resume command is only available with BIP77 (v2)");
+        //     }
+        //     println!("resume");
+        //     app.resume_payjoins().await?;
+        // }
+        Commands::Send { bip21, fee_rate } => {
+            //
+            let fee = fee_rate
+                .unwrap_or_else(|| FeeRate::from_sat_per_vb(2).unwrap_or(FeeRate::BROADCAST_MIN));
+            app.send_payjoin(bip21, fee).await?;
         }
-        Some(("receive", sub_matches)) => {
-            let amount =
-                sub_matches.get_one::<Amount>("AMOUNT").context("Missing AMOUNT argument")?;
+        Commands::Receive { amount, .. } => {
             app.receive_payjoin(*amount).await?;
-        }
-        #[cfg(feature = "v2")]
-        Some(("resume", _)) => {
-            if matches.get_flag("bip78") {
-                anyhow::bail!("Resume command is only available with BIP77 (v2)");
-            }
-            println!("resume");
-            app.resume_payjoins().await?;
         }
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
@@ -84,135 +91,125 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn cli() -> ArgMatches {
-    let mut cmd = Command::new("payjoin")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("Payjoin - bitcoin scaling, savings, and privacy by default")
-        .arg(
-            Arg::new("bip77")
-                .long("bip77")
-                .help("Use BIP77 (v2) protocol (default)")
-                .conflicts_with("bip78")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("bip78")
-                .long("bip78")
-                .help("Use BIP78 (v1) protocol")
-                .conflicts_with("bip77")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("rpchost")
-                .long("rpchost")
-                .short('r')
-                .num_args(1)
-                .help("The port of the bitcoin node")
-                .value_parser(value_parser!(Url)),
-        )
-        .arg(
-            Arg::new("cookie_file")
-                .long("cookie-file")
-                .short('c')
-                .num_args(1)
-                .help("Path to the cookie file of the bitcoin node"),
-        )
-        .arg(
-            Arg::new("rpcuser")
-                .long("rpcuser")
-                .num_args(1)
-                .help("The username for the bitcoin node"),
-        )
-        .arg(
-            Arg::new("rpcpassword")
-                .long("rpcpassword")
-                .num_args(1)
-                .help("The password for the bitcoin node"),
-        )
-        .arg(Arg::new("db_path").short('d').long("db-path").help("Sets a custom database path"))
-        .subcommand_required(true);
-
-    // Conditional arguments based on features
-    #[cfg(feature = "v2")]
-    {
-        cmd = cmd.arg(
-            Arg::new("ohttp_relay")
-                .long("ohttp-relay")
-                .help("The ohttp relay url")
-                .value_parser(value_parser!(Url)),
-        );
-    }
-
-    cmd = cmd.subcommand(
-        Command::new("send")
-            .arg_required_else_help(true)
-            .arg(arg!(<BIP21> "The `bitcoin:...` payjoin uri to send to"))
-            .arg(
-                Arg::new("fee_rate")
-                    .long("fee-rate")
-                    .value_name("FEE_SAT_PER_VB")
-                    .help("Fee rate in sat/vB")
-                    .value_parser(parse_fee_rate_in_sat_per_vb),
-            ),
-    );
-
-    let mut receive_cmd = Command::new("receive")
-        .arg_required_else_help(true)
-        .arg(arg!(<AMOUNT> "The amount to receive in satoshis").value_parser(parse_amount_in_sat));
-
-    #[cfg(feature = "v2")]
-    let mut cmd = cmd.subcommand(Command::new("resume"));
-
-    // Conditional arguments based on features for the receive subcommand
-    receive_cmd = receive_cmd.arg(
-        Arg::new("max_fee_rate")
-            .long("max-fee-rate")
-            .num_args(1)
-            .help("The maximum effective fee rate the receiver is willing to pay (in sat/vB)")
-            .value_parser(parse_fee_rate_in_sat_per_vb),
-    );
-    #[cfg(feature = "v1")]
-    {
-        receive_cmd = receive_cmd.arg(
-            Arg::new("port")
-                .long("port")
-                .short('p')
-                .num_args(1)
-                .help("The local port to listen on"),
-        );
-        receive_cmd = receive_cmd.arg(
-            Arg::new("pj_endpoint")
-                .long("pj-endpoint")
-                .short('e')
-                .num_args(1)
-                .help("The `pj=` endpoint to receive the payjoin request")
-                .value_parser(value_parser!(Url)),
-        );
-    }
-
-    #[cfg(feature = "v2")]
-    {
-        receive_cmd = receive_cmd.arg(
-            Arg::new("pj_directory")
-                .long("pj-directory")
-                .num_args(1)
-                .help("The directory to store payjoin requests")
-                .value_parser(value_parser!(Url)),
-        );
-        receive_cmd = receive_cmd
-            .arg(Arg::new("ohttp_keys").long("ohttp-keys").help("The ohttp key config file path"));
-    }
-
-    cmd = cmd.subcommand(receive_cmd);
-    cmd.get_matches()
-}
-
-fn parse_amount_in_sat(s: &str) -> Result<Amount, ParseAmountError> {
-    Amount::from_str_in(s, payjoin::bitcoin::Denomination::Satoshi)
-}
-
-fn parse_fee_rate_in_sat_per_vb(s: &str) -> Result<FeeRate, std::num::ParseFloatError> {
-    let fee_rate_sat_per_vb: f32 = s.parse()?;
-    let fee_rate_sat_per_kwu = fee_rate_sat_per_vb * 250.0_f32;
-    Ok(FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64))
-}
+// fn cli() -> ArgMatches {
+// let mut cmd = Command::new("payjoin")
+//     .version(env!("CARGO_PKG_VERSION"))
+//     .about("Payjoin - bitcoin scaling, savings, and privacy by default")
+//     .arg(
+//         Arg::new("bip77")
+//             .long("bip77")
+//             .help("Use BIP77 (v2) protocol (default)")
+//             .conflicts_with("bip78")
+//             .action(clap::ArgAction::SetTrue),
+//     )
+//     .arg(
+//         Arg::new("bip78")
+//             .long("bip78")
+//             .help("Use BIP78 (v1) protocol")
+//             .conflicts_with("bip77")
+//             .action(clap::ArgAction::SetTrue),
+//     )
+//     .arg(
+//         Arg::new("rpchost")
+//             .long("rpchost")
+//             .short('r')
+//             .num_args(1)
+//             .help("The port of the bitcoin node")
+//             .value_parser(value_parser!(Url)),
+//     )
+//     .arg(
+//         Arg::new("cookie_file")
+//             .long("cookie-file")
+//             .short('c')
+//             .num_args(1)
+//             .help("Path to the cookie file of the bitcoin node"),
+//     )
+//     .arg(
+//         Arg::new("rpcuser")
+//             .long("rpcuser")
+//             .num_args(1)
+//             .help("The username for the bitcoin node"),
+//     )
+//     .arg(
+//         Arg::new("rpcpassword")
+//             .long("rpcpassword")
+//             .num_args(1)
+//             .help("The password for the bitcoin node"),
+//     )
+//     .arg(Arg::new("db_path").short('d').long("db-path").help("Sets a custom database path"))
+//     .subcommand_required(true);
+//
+// // Conditional arguments based on features
+// #[cfg(feature = "v2")]
+// {
+//     cmd = cmd.arg(
+//         Arg::new("ohttp_relay")
+//             .long("ohttp-relay")
+//             .help("The ohttp relay url")
+//             .value_parser(value_parser!(Url)),
+//     );
+// }
+//
+// cmd = cmd.subcommand(
+//     Command::new("send")
+//         .arg_required_else_help(true)
+//         .arg(arg!(<BIP21> "The `bitcoin:...` payjoin uri to send to"))
+//         .arg(
+//             Arg::new("fee_rate")
+//                 .long("fee-rate")
+//                 .value_name("FEE_SAT_PER_VB")
+//                 .help("Fee rate in sat/vB")
+//                 .value_parser(parse_fee_rate_in_sat_per_vb),
+//         ),
+// );
+//
+// let mut receive_cmd = Command::new("receive")
+//     .arg_required_else_help(true)
+//     .arg(arg!(<AMOUNT> "The amount to receive in satoshis").value_parser(parse_amount_in_sat));
+//
+// #[cfg(feature = "v2")]
+// let mut cmd = cmd.subcommand(Command::new("resume"));
+//
+// // Conditional arguments based on features for the receive subcommand
+// receive_cmd = receive_cmd.arg(
+//     Arg::new("max_fee_rate")
+//         .long("max-fee-rate")
+//         .num_args(1)
+//         .help("The maximum effective fee rate the receiver is willing to pay (in sat/vB)")
+//         .value_parser(parse_fee_rate_in_sat_per_vb),
+// );
+// #[cfg(feature = "v1")]
+// {
+//     receive_cmd = receive_cmd.arg(
+//         Arg::new("port")
+//             .long("port")
+//             .short('p')
+//             .num_args(1)
+//             .help("The local port to listen on"),
+//     );
+//     receive_cmd = receive_cmd.arg(
+//         Arg::new("pj_endpoint")
+//             .long("pj-endpoint")
+//             .short('e')
+//             .num_args(1)
+//             .help("The `pj=` endpoint to receive the payjoin request")
+//             .value_parser(value_parser!(Url)),
+//     );
+// }
+//
+// #[cfg(feature = "v2")]
+// {
+//     receive_cmd = receive_cmd.arg(
+//         Arg::new("pj_directory")
+//             .long("pj-directory")
+//             .num_args(1)
+//             .help("The directory to store payjoin requests")
+//             .value_parser(value_parser!(Url)),
+//     );
+//     receive_cmd = receive_cmd
+//         .arg(Arg::new("ohttp_keys").long("ohttp-keys").help("The ohttp key config file path"));
+// }
+//
+// cmd.get_catches()
+// }
+//


### PR DESCRIPTION
This WIP commit begins refactoring to use the [derive](https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html) macros provided by clap to replace the [builder](https://docs.rs/clap/latest/clap/_tutorial/index.html) we are currently using. This is essentially a sample of how I intend to refactor this code if we are in agreement.

Clap [appears](https://grok.com/share/c2hhcmQtMg%3D%3D_11c4ff55-a750-48e5-9a58-85ae6a25596f) to recommend using derive when a lot of flexibility isn't needed. See [FAQ](https://docs.rs/clap/latest/clap/_faq/index.html#when-should-i-use-the-builder-vs-derive-apis). I believe this would allow us to simplify the logic, make the code DRYer, make the code more readable and maintainable, and conform to `clap` recommendations.

There may barrier or complexity I'm failing to see here, but it seems like this refactor would make things much more maintainable and easier to build on moving forward. Also, if we find ourselves needing the lower-level API's provided by the builder method, we can still use it on an as-needed basis