### PR TITLE
Catch new match arm cargo mutants

### DIFF
--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -1,7 +1,7 @@
 use url::ParseError;
 
 #[derive(Debug)]
-pub struct PjParseError(InternalPjParseError);
+pub struct PjParseError(pub(crate) InternalPjParseError);
 
 #[derive(Debug)]
 pub(crate) enum InternalPjParseError {

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -316,6 +316,31 @@ mod tests {
     }
 
     #[test]
+    fn test_pj_duplicate_params() {
+        let uri =
+            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pjos=1&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let pjuri = Uri::try_from(uri);
+        assert!(matches!(
+            pjuri,
+            Err(bitcoin_uri::de::Error::Extras(PjParseError(
+                InternalPjParseError::DuplicateParams("pjos")
+            )))
+        ));
+        let uri =
+            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let pjuri = Uri::try_from(uri);
+        assert!(matches!(
+            pjuri,
+            Err(bitcoin_uri::de::Error::Extras(PjParseError(
+                InternalPjParseError::DuplicateParams("pj")
+            )))
+        ));
+    }
+
+    #[test]
     fn test_serialize_pjos() {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=HTTPS://EXAMPLE.COM/%23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
         let expected_is_disabled = "pjos=0";


### PR DESCRIPTION
The newest version of cargo mutants v25.0.1 added a new type of mutation that attempts to delete entire match arms.

Mutants passing on 7b3ea49a9e45806496e80589c0f7114b6798cb71

`259 mutants tested in 8m 49s: 163 caught, 96 unviable`

Closes #671