### PR TITLE
Specify the versions for deps more precisely in the cargo toml

### DIFF
--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -12,11 +12,11 @@ license = "MIT"
 bitcoin = { version = "0.32.5", features = ["base64"] }
 bitcoincore-rpc = "0.19.0"
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
-http = "1"
+http = "1.1.0"
 log = "0.4.7"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 ohttp-relay = { version = "0.0.10", features = ["_test-util"] }
-once_cell = "1"
+once_cell = "1.19.0"
 payjoin = { version = "0.23.0", features = ["io", "_danger-local-https"] }
 payjoin-directory = { version = "0.0.2", features = ["_danger-local-https"] }
 rcgen = "0.11"

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -32,7 +32,7 @@ bitcoin = { version = "0.32.5", features = ["base64"] }
 bitcoin_uri = { version = "0.1.0", optional = true }
 hpke = { package = "bitcoin-hpke", version = "0.13.0", optional = true }
 log = { version = "0.4.14"}
-http = { version = "1", optional = true }
+http = { version = "1.1.0", optional = true }
 bhttp = { version = "=0.5.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 serde = { version = "1.0.186", default-features = false, optional = true }
@@ -44,7 +44,7 @@ serde_json = { version = "1.0.108", optional = true }
 [dev-dependencies]
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 payjoin-test-utils = { path = "../payjoin-test-utils" }
-once_cell = "1"
+once_cell = "1.19.0"
 tokio = { version = "1.38.1", features = ["full"] }
 tracing = "0.1.40"
 


### PR DESCRIPTION
We had 2 dependency versions that were on less specific version numbers and in adding these deps to other crates there is/was some confusion around which version to use.

By adding specific versions for these deps when other crates need or want to add these deps we can prevent dep tree mismatches. I am confident that these versions should be pinned as there are several downstream deps that rely on `1.1.0` for http and `1.19.0` for once_cell.

_These versions are what already exist in the cargo tree and by including these specific versions we are not actually changing any versions, just what devs can refer back to when looking for exact dependency versions._