### PR TITLE
Expose shortid method for SessionContext

### DIFF
--- a/payjoin/src/receive/multiparty/mod.rs
+++ b/payjoin/src/receive/multiparty/mod.rs
@@ -44,8 +44,8 @@ impl UncheckedProposalBuilder {
         {
             return Err(InternalMultipartyError::IdenticalProposals(
                 IdenticalProposalError::IdenticalContexts(
-                    Box::new(duplicate_context.id()),
-                    Box::new(proposal.id()),
+                    Box::new(duplicate_context.context.id()),
+                    Box::new(proposal.context.id()),
                 ),
             )
             .into());
@@ -249,8 +249,8 @@ impl FinalizedProposal {
         {
             return Err(InternalMultipartyError::IdenticalProposals(
                 IdenticalProposalError::IdenticalContexts(
-                    Box::new(duplicate_context.id()),
-                    Box::new(proposal.id()),
+                    Box::new(duplicate_context.context.id()),
+                    Box::new(proposal.context.id()),
                 ),
             )
             .into());
@@ -366,8 +366,8 @@ mod test {
                 e.to_string(),
                 MultipartyError::from(InternalMultipartyError::IdenticalProposals(
                     IdenticalProposalError::IdenticalContexts(
-                        Box::new(proposal_one.id()),
-                        Box::new(proposal_two.id())
+                        Box::new(proposal_one.context.id()),
+                        Box::new(proposal_two.context.id())
                     )
                 ))
                 .to_string()

--- a/payjoin/src/receive/v2/persist.rs
+++ b/payjoin/src/receive/v2/persist.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::{id, Receiver};
+use super::Receiver;
 use crate::persist::{self};
 use crate::uri::ShortId;
 
@@ -13,7 +13,7 @@ impl Display for ReceiverToken {
 }
 
 impl From<Receiver> for ReceiverToken {
-    fn from(receiver: Receiver) -> Self { ReceiverToken(id(&receiver.context.s)) }
+    fn from(receiver: Receiver) -> Self { ReceiverToken(receiver.context.id()) }
 }
 
 impl AsRef<[u8]> for ReceiverToken {
@@ -23,5 +23,5 @@ impl AsRef<[u8]> for ReceiverToken {
 impl persist::Value for Receiver {
     type Key = ReceiverToken;
 
-    fn key(&self) -> Self::Key { ReceiverToken(id(&self.context.s)) }
+    fn key(&self) -> Self::Key { ReceiverToken(self.context.id()) }
 }


### PR DESCRIPTION
By exposing the shortid method for SessionContext it allows us to be able to track the id across all psbt intermediate steps and allows us to not need this method duplicated in every step of the process.