### PR TITLE
Refactor config to use proc macros over builder

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -79,19 +79,19 @@ impl Config {
             selected_version = Some(Version::One);
         }
 
-        // If no version explicitly selected, use default based on available features
-        if selected_version.is_none() {
-            #[cfg(feature = "v2")]
-            return Ok(Version::Two);
-            #[cfg(all(feature = "v1", not(feature = "v2")))]
-            return Ok(Version::One);
-            #[cfg(not(any(feature = "v1", feature = "v2")))]
-            return Err(ConfigError::Message(
-                "No valid version available - must compile with v1 or v2 feature".to_string(),
-            ));
-        }
+        if let Some(version) = selected_version {
+            return Ok(version);
+        };
 
-        Ok(selected_version.unwrap())
+        // If no version explicitly selected, use default based on available features
+        #[cfg(feature = "v2")]
+        return Ok(Version::Two);
+        #[cfg(all(feature = "v1", not(feature = "v2")))]
+        return Ok(Version::One);
+        #[cfg(not(any(feature = "v1", feature = "v2")))]
+        return Err(ConfigError::Message(
+            "No valid version available - must compile with v1 or v2 feature".to_string(),
+        ));
     }
 
     pub(crate) fn new(cli: &Cli) -> Result<Self, ConfigError> {

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -1,0 +1,135 @@
+use std::path::PathBuf;
+
+use clap::{value_parser, Parser, Subcommand};
+use payjoin::bitcoin::amount::ParseAmountError;
+use payjoin::bitcoin::{Amount, FeeRate};
+use serde::Deserialize;
+use url::Url;
+
+#[derive(Debug, Clone, Deserialize, Parser)]
+pub struct Flags {
+    #[arg(long = "bip77", help = "Use BIP77 (v2) protocol (default)", action = clap::ArgAction::SetTrue)]
+    pub bip77: Option<bool>,
+    #[arg(long = "bip78", help = "Use BIP78 (v1) protocol", action = clap::ArgAction::SetTrue)]
+    pub bip78: Option<bool>,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    version = env!("CARGO_PKG_VERSION"),
+    about = "Payjoin - bitcoin scaling, savings, and privacy by default",
+    long_about = None,
+    subcommand_required = true
+)]
+pub struct Cli {
+    #[command(flatten)]
+    pub flags: Flags,
+
+    #[command(subcommand)]
+    pub command: Commands,
+
+    #[arg(long, short = 'd', help = "Sets a custom database path")]
+    pub db_path: Option<PathBuf>,
+
+    #[arg(long = "max-fee-rate", short = 'f', help = "The maximum fee rate to accept in sat/vB")]
+    pub max_fee_rate: Option<FeeRate>,
+
+    #[arg(
+        long,
+        short = 'r',
+        num_args(1),
+        help = "The URL of the Bitcoin RPC host, e.g. regtest default is http://localhost:18443"
+    )]
+    pub rpchost: Option<Url>,
+
+    #[arg(
+        long = "cookie-file",
+        short = 'c',
+        num_args(1),
+        help = "Path to the cookie file of the bitcoin node"
+    )]
+    pub cookie_file: Option<PathBuf>,
+
+    #[arg(long = "rpcuser", num_args(1), help = "The username for the bitcoin node")]
+    pub rpcuser: Option<String>,
+
+    #[arg(long = "rpcpassword", num_args(1), help = "The password for the bitcoin node")]
+    pub rpcpassword: Option<String>,
+
+    #[cfg(feature = "v1")]
+    #[arg(long = "port", help = "The local port to listen on")]
+    pub port: Option<u16>,
+
+    #[cfg(feature = "v1")]
+    #[arg(long = "pj-endpoint", help = "The `pj=` endpoint to receive the payjoin request", value_parser = value_parser!(Url))]
+    pub pj_endpoint: Option<Url>,
+
+    #[cfg(feature = "v2")]
+    #[arg(long = "ohttp-relays", help = "One or more ohttp relay URLs, comma-separated", value_parser = value_parser!(Url))]
+    pub ohttp_relays: Option<Vec<Url>>,
+
+    #[cfg(feature = "v2")]
+    #[arg(long = "ohttp-keys", help = "The ohttp key config file path", value_parser = value_parser!(PathBuf))]
+    pub ohttp_keys: Option<PathBuf>,
+
+    #[cfg(feature = "v2")]
+    #[arg(long = "pj-directory", help = "The directory to store payjoin requests", value_parser = value_parser!(Url))]
+    pub pj_directory: Option<Url>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Send a payjoin payment
+    Send {
+        /// The `bitcoin:...` payjoin uri to send to
+        #[arg(required = true)]
+        bip21: String,
+
+        /// Fee rate in sat/vB
+        #[arg(short, long = "fee-rate", value_parser = parse_fee_rate_in_sat_per_vb)]
+        fee_rate: Option<FeeRate>,
+    },
+    /// Receive a payjoin payment
+    Receive {
+        /// The amount to receive in satoshis
+        #[arg(required = true, value_parser = parse_amount_in_sat)]
+        amount: Amount,
+
+        /// The maximum effective fee rate the receiver is willing to pay (in sat/vB)
+        #[arg(short, long = "max-fee-rate", value_parser = parse_fee_rate_in_sat_per_vb)]
+        max_fee_rate: Option<FeeRate>,
+
+        #[cfg(feature = "v1")]
+        /// The local port to listen on
+        #[arg(short, long = "port")]
+        port: Option<u16>,
+
+        #[cfg(feature = "v1")]
+        /// The `pj=` endpoint to receive the payjoin request
+        #[arg(long = "pj-endpoint", value_parser = value_parser!(Url))]
+        pj_endpoint: Option<Url>,
+
+        #[cfg(feature = "v2")]
+        /// The directory to store payjoin requests
+        #[arg(long = "pj-directory", value_parser = value_parser!(Url))]
+        pj_directory: Option<Url>,
+
+        #[cfg(feature = "v2")]
+        /// The path to the ohttp keys file
+        #[arg(long = "ohttp-keys", value_parser = value_parser!(PathBuf))]
+        ohttp_keys: Option<PathBuf>,
+    },
+    /// Resume pending payjoins (BIP77/v2 only)
+    #[cfg(feature = "v2")]
+    Resume,
+}
+
+pub fn parse_amount_in_sat(s: &str) -> Result<Amount, ParseAmountError> {
+    Amount::from_str_in(s, payjoin::bitcoin::Denomination::Satoshi)
+}
+
+pub fn parse_fee_rate_in_sat_per_vb(s: &str) -> Result<FeeRate, std::num::ParseFloatError> {
+    let fee_rate_sat_per_vb: f32 = s.parse()?;
+    let fee_rate_sat_per_kwu = fee_rate_sat_per_vb * 250.0_f32;
+    Ok(FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64))
+}

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -65,7 +65,7 @@ pub struct Cli {
     pub pj_endpoint: Option<Url>,
 
     #[cfg(feature = "v2")]
-    #[arg(long = "ohttp-relays", help = "One or more ohttp relay URLs, comma-separated", value_parser = value_parser!(Url))]
+    #[arg(long = "ohttp-relays", help = "One or more ohttp relay URLs, comma-separated", value_parser = value_parser!(Url), value_delimiter = ',', action = clap::ArgAction::Append)]
     pub ohttp_relays: Option<Vec<Url>>,
 
     #[cfg(feature = "v2")]

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -86,8 +86,8 @@ pub enum Commands {
         bip21: String,
 
         /// Fee rate in sat/vB
-        #[arg(short, long = "fee-rate", value_parser = parse_fee_rate_in_sat_per_vb)]
-        fee_rate: Option<FeeRate>,
+        #[arg(required = true, short, long = "fee-rate", value_parser = parse_fee_rate_in_sat_per_vb)]
+        fee_rate: FeeRate,
     },
     /// Receive a payjoin payment
     Receive {

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -3,7 +3,6 @@ use app::config::Config;
 use app::App as AppTrait;
 use clap::Parser;
 use cli::{Cli, Commands};
-use payjoin::bitcoin::FeeRate;
 
 mod app;
 mod cli;
@@ -59,9 +58,7 @@ async fn main() -> Result<()> {
 
     match &cli.command {
         Commands::Send { bip21, fee_rate } => {
-            let fee = fee_rate
-                .unwrap_or_else(|| FeeRate::from_sat_per_vb(2).unwrap_or(FeeRate::BROADCAST_MIN));
-            app.send_payjoin(bip21, fee).await?;
+            app.send_payjoin(bip21, *fee_rate).await?;
         }
         Commands::Receive { amount, .. } => {
             app.receive_payjoin(*amount).await?;

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,12 +1,12 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use app::config::Config;
 use app::App as AppTrait;
-use clap::{arg, value_parser, Arg, ArgMatches, Command};
-use payjoin::bitcoin::amount::ParseAmountError;
-use payjoin::bitcoin::{Amount, FeeRate};
-use url::Url;
+use clap::Parser;
+use cli::{Cli, Commands};
+use payjoin::bitcoin::FeeRate;
 
 mod app;
+mod cli;
 mod db;
 
 #[cfg(not(any(feature = "v1", feature = "v2")))]
@@ -16,11 +16,11 @@ compile_error!("At least one of the features ['v1', 'v2'] must be enabled");
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let matches = cli();
-    let config = Config::new(&matches)?;
+    let cli = Cli::parse();
+    let config = Config::new(&cli)?;
 
     #[allow(clippy::if_same_then_else)]
-    let app: Box<dyn AppTrait> = if matches.get_flag("bip78") {
+    let app: Box<dyn AppTrait> = if cli.flags.bip78.unwrap_or(false) {
         #[cfg(feature = "v1")]
         {
             Box::new(crate::app::v1::App::new(config)?)
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
                 "BIP78 (v1) support is not enabled in this build. Recompile with --features v1"
             )
         }
-    } else if matches.get_flag("bip77") {
+    } else if cli.flags.bip77.unwrap_or(false) {
         #[cfg(feature = "v2")]
         {
             Box::new(crate::app::v2::App::new(config)?)
@@ -57,164 +57,20 @@ async fn main() -> Result<()> {
         }
     };
 
-    match matches.subcommand() {
-        Some(("send", sub_matches)) => {
-            let bip21 = sub_matches.get_one::<String>("BIP21").context("Missing BIP21 argument")?;
-            let fee_rate = sub_matches
-                .get_one::<FeeRate>("fee_rate")
-                .context("Missing --fee-rate argument")?;
-            app.send_payjoin(bip21, *fee_rate).await?;
+    match &cli.command {
+        Commands::Send { bip21, fee_rate } => {
+            let fee = fee_rate
+                .unwrap_or_else(|| FeeRate::from_sat_per_vb(2).unwrap_or(FeeRate::BROADCAST_MIN));
+            app.send_payjoin(bip21, fee).await?;
         }
-        Some(("receive", sub_matches)) => {
-            let amount =
-                sub_matches.get_one::<Amount>("AMOUNT").context("Missing AMOUNT argument")?;
+        Commands::Receive { amount, .. } => {
             app.receive_payjoin(*amount).await?;
         }
         #[cfg(feature = "v2")]
-        Some(("resume", _)) => {
-            if matches.get_flag("bip78") {
-                anyhow::bail!("Resume command is only available with BIP77 (v2)");
-            }
-            println!("resume");
+        Commands::Resume => {
             app.resume_payjoins().await?;
         }
-        _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
-    }
+    };
 
     Ok(())
-}
-
-fn cli() -> ArgMatches {
-    let mut cmd = Command::new("payjoin")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("Payjoin - bitcoin scaling, savings, and privacy by default")
-        .arg(
-            Arg::new("bip77")
-                .long("bip77")
-                .help("Use BIP77 (v2) protocol (default)")
-                .conflicts_with("bip78")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("bip78")
-                .long("bip78")
-                .help("Use BIP78 (v1) protocol")
-                .conflicts_with("bip77")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("rpchost")
-                .long("rpchost")
-                .short('r')
-                .num_args(1)
-                .help("The port of the bitcoin node")
-                .value_parser(value_parser!(Url)),
-        )
-        .arg(
-            Arg::new("cookie_file")
-                .long("cookie-file")
-                .short('c')
-                .num_args(1)
-                .help("Path to the cookie file of the bitcoin node"),
-        )
-        .arg(
-            Arg::new("rpcuser")
-                .long("rpcuser")
-                .num_args(1)
-                .help("The username for the bitcoin node"),
-        )
-        .arg(
-            Arg::new("rpcpassword")
-                .long("rpcpassword")
-                .num_args(1)
-                .help("The password for the bitcoin node"),
-        )
-        .arg(Arg::new("db_path").short('d').long("db-path").help("Sets a custom database path"))
-        .subcommand_required(true);
-
-    // Conditional arguments based on features
-    #[cfg(feature = "v2")]
-    {
-        cmd = cmd.arg(
-            Arg::new("ohttp_relays")
-                .long("ohttp-relays")
-                .help("One or more ohttp relay URLs, comma-separated")
-                .action(clap::ArgAction::Append)
-                .value_delimiter(',')
-                .value_parser(value_parser!(Url)),
-        );
-    }
-
-    cmd = cmd.subcommand(
-        Command::new("send")
-            .arg_required_else_help(true)
-            .arg(arg!(<BIP21> "The `bitcoin:...` payjoin uri to send to"))
-            .arg(
-                Arg::new("fee_rate")
-                    .long("fee-rate")
-                    .value_name("FEE_SAT_PER_VB")
-                    .help("Fee rate in sat/vB")
-                    .value_parser(parse_fee_rate_in_sat_per_vb),
-            ),
-    );
-
-    let mut receive_cmd = Command::new("receive")
-        .arg_required_else_help(true)
-        .arg(arg!(<AMOUNT> "The amount to receive in satoshis").value_parser(parse_amount_in_sat));
-
-    #[cfg(feature = "v2")]
-    let mut cmd = cmd.subcommand(Command::new("resume"));
-
-    // Conditional arguments based on features for the receive subcommand
-    receive_cmd = receive_cmd.arg(
-        Arg::new("max_fee_rate")
-            .long("max-fee-rate")
-            .num_args(1)
-            .help("The maximum effective fee rate the receiver is willing to pay (in sat/vB)")
-            .value_parser(parse_fee_rate_in_sat_per_vb),
-    );
-    #[cfg(feature = "v1")]
-    {
-        receive_cmd = receive_cmd.arg(
-            Arg::new("port")
-                .long("port")
-                .short('p')
-                .num_args(1)
-                .help("The local port to listen on"),
-        );
-        receive_cmd = receive_cmd.arg(
-            Arg::new("pj_endpoint")
-                .long("pj-endpoint")
-                .short('e')
-                .num_args(1)
-                .help("The `pj=` endpoint to receive the payjoin request")
-                .value_parser(value_parser!(Url)),
-        );
-    }
-
-    #[cfg(feature = "v2")]
-    {
-        receive_cmd = receive_cmd.arg(
-            Arg::new("pj_directory")
-                .long("pj-directory")
-                .num_args(1)
-                .help("The directory to store payjoin requests")
-                .value_parser(value_parser!(Url)),
-        );
-        receive_cmd = receive_cmd
-            .arg(Arg::new("ohttp_keys").long("ohttp-keys").help("The ohttp key config file path"));
-    }
-
-    cmd = cmd.subcommand(receive_cmd);
-    cmd.get_matches()
-}
-
-fn parse_amount_in_sat(s: &str) -> Result<Amount, ParseAmountError> {
-    Amount::from_str_in(s, payjoin::bitcoin::Denomination::Satoshi)
-}
-
-fn parse_fee_rate_in_sat_per_vb(s: &str) -> Result<FeeRate, std::num::ParseFloatError> {
-    let fee_rate_sat_per_vb: f32 = s.parse()?;
-    let fee_rate_sat_per_kwu = fee_rate_sat_per_vb * 250.0_f32;
-    Ok(FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64))
 }


### PR DESCRIPTION
Refactors the code to use proc macros over the "legacy" builder method as per `clap`'s recommendation.

The macros allow the code to be more maintainable, readable, and reusable moving forward.

See
[here](https://docs.rs/clap/latest/clap/_faq/index.html#when-should-i-use-the-builder-vs-derive-apis) for more details on proc macro  vs builder method rationales.

Discussion preceding this PR in #684 and [here](https://github.com/thebrandonlucas/rust-payjoin/pull/1)