### PR TITLE
Limit visibility of id method for SessionContext to the crate only

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -58,7 +58,7 @@ impl SessionContext {
     }
 
     /// The per-session identifier
-    pub fn id(&self) -> ShortId {
+    pub(crate) fn id(&self) -> ShortId {
         sha256::Hash::hash(&self.s.public_key().to_compressed_bytes()).into()
     }
 }


### PR DESCRIPTION
Because SessionContext itself is limited in visibility to the crate this id method should also be limited to crate visibility.

Based on the conversation linked here, https://github.com/payjoin/rust-payjoin/pull/698#discussion_r2092195001