### PR TITLE
Randomly pad OHTTP requests

### DIFF
--- a/payjoin/src/ohttp.rs
+++ b/payjoin/src/ohttp.rs
@@ -3,6 +3,7 @@ use std::{error, fmt};
 
 use bitcoin::bech32::{self, EncodeError};
 use bitcoin::key::constants::UNCOMPRESSED_PUBLIC_KEY_SIZE;
+use hpke::rand_core::{OsRng, RngCore};
 
 use crate::directory::ENCAPSULATED_MESSAGE_BYTES;
 
@@ -41,6 +42,7 @@ pub fn ohttp_encapsulate(
     }
 
     let mut bhttp_req = [0u8; PADDED_BHTTP_REQ_BYTES];
+    OsRng.fill_bytes(&mut bhttp_req);
     bhttp_message.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_req.as_mut_slice())?;
     let (encapsulated, ohttp_ctx) = ctx.encapsulate(&bhttp_req)?;
 


### PR DESCRIPTION
Using random padding instead of 0 padding allows for multi-hop OHTTP to use pre-computed filler strings similarly to Sphinx indistinguishably from single hop requests which just use random padding.

Making this change now means that if we ever implement multi-hop requests, their use would not be observable by the directory.