### PR TITLE
Add mutants for sender module

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 additional_cargo_args = ["--all-features"]
-examine_globs = ["payjoin/src/uri/*.rs", "payjoin/src/receive/**/*.rs"]
+examine_globs = ["payjoin/src/uri/*.rs", "payjoin/src/receive/**/*.rs", "payjoin/src/send/mod.rs"]
 exclude_globs = []
 exclude_re = [
 	"impl Debug",


### PR DESCRIPTION
This adds the mutants for the mod file in the sender.

This is the first part of the sender to be covered by mutation testing. Once the the sender has complete mutation coverage we can look at finalizing #539 