### PR TITLE
Expand Python CI trigger to all of payjoin-ffi

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,7 @@ name: Build and Test Python
 on:
   pull_request:
     paths:
-      - payjoin-ffi/python/**
+      - payjoin-ffi/**
 
 jobs:
   build-wheels-and-test:


### PR DESCRIPTION
This commit expands the trigger to any changes within payjoin-ffi, ensuring the workflow runs when changes are made to core FFI library. The python directory contains mostly build files and tests. Since autogenerated files are no longer tracked, UniFFI changes outside this dir could break tests without triggering the workflow.