### PR TITLE
Remove unused Python callback classes

### DIFF
--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -31,22 +31,6 @@ class TestURIs(unittest.TestCase):
                 except Exception as e:
                     self.fail(f"Failed to create a valid Uri for {uri}. Error: {e}")
 
-
-class ScriptOwnershipCallback(payjoin.IsScriptOwned):
-    def __init__(self, value):
-        self.value = value
-
-    def callback(self, script):
-        return self.value
-
-
-class OutputOwnershipCallback(payjoin.IsOutputKnown):
-    def __init__(self, value):
-        self.value = value
-
-    def callback(self, outpoint: payjoin.bitcoin.OutPoint):
-        return False
-
 class InMemoryReceiverPersister(payjoin.payjoin_ffi.ReceiverPersister):
     def __init__(self):
         self.receivers = {}


### PR DESCRIPTION
We created these callback classes while processing the receiver state machine in the unit tests. They are now moved to
`test/test_payjoin_integration_test.py`.