### PR TITLE
Merge parallel feature flag local certificate logic in cli ohttp

### DIFF
--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -1,8 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "_danger-local-https")]
-use anyhow::Result;
-#[cfg(not(feature = "_danger-local-https"))]
 use anyhow::{anyhow, Result};
 
 use super::Config;
@@ -10,49 +7,44 @@ use super::Config;
 #[derive(Debug, Clone)]
 pub struct RelayManager {
     selected_relay: Option<payjoin::Url>,
-    #[cfg(not(feature = "_danger-local-https"))]
     failed_relays: Vec<payjoin::Url>,
 }
 
 impl RelayManager {
-    #[cfg(feature = "_danger-local-https")]
-    pub fn new() -> Self { RelayManager { selected_relay: None } }
-    #[cfg(not(feature = "_danger-local-https"))]
     pub fn new() -> Self { RelayManager { selected_relay: None, failed_relays: Vec::new() } }
 
-    #[cfg(not(feature = "_danger-local-https"))]
     pub fn set_selected_relay(&mut self, relay: payjoin::Url) { self.selected_relay = Some(relay); }
 
     pub fn get_selected_relay(&self) -> Option<payjoin::Url> { self.selected_relay.clone() }
 
-    #[cfg(not(feature = "_danger-local-https"))]
     pub fn add_failed_relay(&mut self, relay: payjoin::Url) { self.failed_relays.push(relay); }
 
-    #[cfg(not(feature = "_danger-local-https"))]
     pub fn get_failed_relays(&self) -> Vec<payjoin::Url> { self.failed_relays.clone() }
+}
+
+pub(crate) struct ValidatedOhttpKeys {
+    pub(crate) ohttp_keys: payjoin::OhttpKeys,
+    pub(crate) relay_url: payjoin::Url,
 }
 
 pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
     config: &Config,
     relay_manager: Arc<Mutex<RelayManager>>,
-) -> Result<payjoin::OhttpKeys> {
-    if let Some(keys) = config.v2()?.ohttp_keys.clone() {
-        println!("Using OHTTP Keys from config");
-        Ok(keys)
-    } else {
-        println!("Bootstrapping private network transport over Oblivious HTTP");
+) -> Result<ValidatedOhttpKeys> {
+    let config_keys = config.v2()?.ohttp_keys.clone();
+    let mut fetched_keys = fetch_ohttp_keys(config, relay_manager).await?;
 
-        fetch_keys(config, relay_manager.clone())
-            .await
-            .and_then(|keys| keys.ok_or_else(|| anyhow::anyhow!("No OHTTP keys found")))
+    if let Some(keys) = config_keys {
+        fetched_keys.ohttp_keys = keys;
     }
+
+    Ok(fetched_keys)
 }
 
-#[cfg(not(feature = "_danger-local-https"))]
-async fn fetch_keys(
+async fn fetch_ohttp_keys(
     config: &Config,
     relay_manager: Arc<Mutex<RelayManager>>,
-) -> Result<Option<payjoin::OhttpKeys>> {
+) -> Result<ValidatedOhttpKeys> {
     use payjoin::bitcoin::secp256k1::rand::prelude::SliceRandom;
     let payjoin_directory = config.v2()?.pj_directory.clone();
     let relays = config.v2()?.ohttp_relays.clone();
@@ -80,11 +72,25 @@ async fn fetch_keys(
             .set_selected_relay(selected_relay.clone());
 
         let ohttp_keys = {
-            payjoin::io::fetch_ohttp_keys(selected_relay.clone(), payjoin_directory.clone()).await
+            #[cfg(feature = "_danger-local-https")]
+            {
+                let cert_der = crate::app::read_local_cert()?;
+                payjoin::io::fetch_ohttp_keys_with_cert(
+                    &selected_relay,
+                    &payjoin_directory,
+                    cert_der,
+                )
+                .await
+            }
+            #[cfg(not(feature = "_danger-local-https"))]
+            {
+                payjoin::io::fetch_ohttp_keys(&selected_relay, &payjoin_directory).await
+            }
         };
 
         match ohttp_keys {
-            Ok(keys) => return Ok(Some(keys)),
+            Ok(keys) =>
+                return Ok(ValidatedOhttpKeys { ohttp_keys: keys, relay_url: selected_relay }),
             Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
                 return Err(payjoin::io::Error::UnexpectedStatusCode(e).into());
             }
@@ -97,75 +103,4 @@ async fn fetch_keys(
             }
         }
     }
-}
-
-///Local relays are incapable of acting as proxies so we must opportunistically fetch keys from the config
-#[cfg(feature = "_danger-local-https")]
-async fn fetch_keys(
-    config: &Config,
-    _relay_manager: Arc<Mutex<RelayManager>>,
-) -> Result<Option<payjoin::OhttpKeys>> {
-    let keys = config.v2()?.ohttp_keys.clone().expect("No OHTTP keys set");
-
-    Ok(Some(keys))
-}
-
-#[cfg(not(feature = "_danger-local-https"))]
-pub(crate) async fn validate_relay(
-    config: &Config,
-    relay_manager: Arc<Mutex<RelayManager>>,
-) -> Result<payjoin::Url> {
-    use payjoin::bitcoin::secp256k1::rand::prelude::SliceRandom;
-    let payjoin_directory = config.v2()?.pj_directory.clone();
-    let relays = config.v2()?.ohttp_relays.clone();
-
-    loop {
-        let failed_relays =
-            relay_manager.lock().expect("Lock should not be poisoned").get_failed_relays();
-
-        let remaining_relays: Vec<_> =
-            relays.iter().filter(|r| !failed_relays.contains(r)).cloned().collect();
-
-        if remaining_relays.is_empty() {
-            return Err(anyhow!("No valid relays available"));
-        }
-
-        let selected_relay =
-            match remaining_relays.choose(&mut payjoin::bitcoin::key::rand::thread_rng()) {
-                Some(relay) => relay.clone(),
-                None => return Err(anyhow!("Failed to select from remaining relays")),
-            };
-
-        relay_manager
-            .lock()
-            .expect("Lock should not be poisoned")
-            .set_selected_relay(selected_relay.clone());
-
-        let ohttp_keys =
-            payjoin::io::fetch_ohttp_keys(selected_relay.clone(), payjoin_directory.clone()).await;
-
-        match ohttp_keys {
-            Ok(_) => return Ok(selected_relay),
-            Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
-                return Err(payjoin::io::Error::UnexpectedStatusCode(e).into());
-            }
-            Err(e) => {
-                log::debug!("Failed to connect to relay: {selected_relay}, {e:?}");
-                relay_manager
-                    .lock()
-                    .expect("Lock should not be poisoned")
-                    .add_failed_relay(selected_relay);
-            }
-        }
-    }
-}
-
-#[cfg(feature = "_danger-local-https")]
-pub(crate) async fn validate_relay(
-    config: &Config,
-    _relay_manager: Arc<Mutex<RelayManager>>,
-) -> Result<payjoin::Url> {
-    let relay = config.v2()?.ohttp_relays.first().expect("no OHTTP relay set").clone();
-
-    Ok(relay)
 }


### PR DESCRIPTION
These ohttp functions had parallel methods when running tests vs running in production. This made it difficult to read as there were two functions that appeared to do completely different things when a feature flag was present.

Because localhost relays are not actually able to be proxies here we still need to opportunistically select them from the config when running our tests instead of just allowing local cert validation.
```
[2025-05-30T17:17:53Z DEBUG payjoin_cli::app::v2::ohttp] Failed to connect to relay: http://localhost:34391/, Internal(InternalError(Reqwest(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("payjo.in")), port: None, path: "/.well-known/ohttp-gateway", query: None, fragment: None }, source: hyper_util::client::legacy::Error(Connect, "unsuccessful tunnel") })))
```