### PR TITLE
Sender generic over typestate

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -9,7 +9,7 @@ use payjoin::receive::v2::{
     WithContext,
 };
 use payjoin::receive::{Error, ReplyableError};
-use payjoin::send::v2::{Sender, SenderBuilder};
+use payjoin::send::v2::{Sender, SenderBuilder, WithReplyKey};
 use payjoin::{ImplementationError, Uri};
 use tokio::sync::watch;
 
@@ -137,7 +137,7 @@ impl AppTrait for App {
 
 impl App {
     #[allow(clippy::incompatible_msrv)]
-    async fn spawn_payjoin_sender(&self, mut req_ctx: Sender) -> Result<()> {
+    async fn spawn_payjoin_sender(&self, mut req_ctx: Sender<WithReplyKey>) -> Result<()> {
         let mut interrupt = self.interrupt.clone();
         tokio::select! {
             res = self.long_poll_post(&mut req_ctx) => {
@@ -200,7 +200,7 @@ impl App {
         Ok(())
     }
 
-    async fn long_poll_post(&self, req_ctx: &mut Sender) -> Result<Psbt> {
+    async fn long_poll_post(&self, req_ctx: &mut Sender<WithReplyKey>) -> Result<Psbt> {
         let ohttp_relay = self.unwrap_relay_or_else_fetch().await?;
 
         match req_ctx.extract_v2(ohttp_relay.clone()) {

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -50,15 +50,15 @@ class InMemorySenderPersister(SenderPersister):
         super().__init__()
         self.senders = {}
 
-    def save(self, sender: Sender) -> SenderToken:
+    def save(self, sender: WithReplyKey) -> SenderToken:
         self.senders[str(sender.key())] = sender.to_json()
         return sender.key()
 
-    def load(self, token: SenderToken) -> Sender:
+    def load(self, token: SenderToken) -> WithReplyKey:
         token = str(token)
         if token not in self.senders.keys():
             raise ValueError(f"Token not found: {token}")
-        return Sender.from_json(self.senders[token])
+        return WithReplyKey.from_json(self.senders[token])
 
 class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     @classmethod
@@ -106,7 +106,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             new_sender = SenderBuilder(psbt, pj_uri).build_recommended(1000)
             persister = InMemorySenderPersister()
             token = new_sender.persist(persister)
-            req_ctx: Sender = Sender.load(token, persister)
+            req_ctx: WithReplyKey = WithReplyKey.load(token, persister)
             request: RequestV2PostContext = req_ctx.extract_v2(ohttp_relay.as_string())
             response = await agent.post(
                 url=request.request.url.as_string(),

--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -64,15 +64,15 @@ class InMemorySenderPersister(payjoin.payjoin_ffi.SenderPersister):
     def __init__(self):
         self.senders = {}
 
-    def save(self, sender: payjoin.Sender) -> payjoin.SenderToken:
+    def save(self, sender: payjoin.WithReplyKey) -> payjoin.SenderToken:
         self.senders[str(sender.key())] = sender.to_json()
         return sender.key()
     
-    def load(self, token: payjoin.SenderToken) -> payjoin.Sender:
+    def load(self, token: payjoin.SenderToken) -> payjoin.WithReplyKey:
         token = str(token)
         if token not in self.senders.keys():
             raise ValueError(f"Token not found: {token}")
-        return payjoin.Sender.from_json(self.senders[token])
+        return payjoin.WithReplyKey.from_json(self.senders[token])
     
 class TestSenderPersistence(unittest.TestCase):
     def test_sender_persistence(self):
@@ -93,7 +93,7 @@ class TestSenderPersistence(unittest.TestCase):
         psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA="
         new_sender = payjoin.SenderBuilder(psbt, uri).build_recommended(1000)
         token = new_sender.persist(persister)
-        payjoin.Sender.load(token, persister)
+        payjoin.WithReplyKey.load(token, persister)
             
 if __name__ == "__main__":
     unittest.main()

--- a/payjoin-ffi/tests/bdk_integration_test.rs
+++ b/payjoin-ffi/tests/bdk_integration_test.rs
@@ -220,7 +220,7 @@ mod v2 {
     use bdk::wallet::AddressIndex;
     use bitcoin_ffi::{Address, Network};
     use payjoin_ffi::receive::{NewReceiver, PayjoinProposal, UncheckedProposal, WithContext};
-    use payjoin_ffi::send::{Sender, SenderBuilder};
+    use payjoin_ffi::send::{WithReplyKey, SenderBuilder};
     use payjoin_ffi::uri::Uri;
     use payjoin_ffi::{NoopPersister, Request};
     use payjoin_test_utils::TestServices;
@@ -288,7 +288,7 @@ mod v2 {
             let new_sender = SenderBuilder::new(psbt.to_string(), pj_uri)?
                 .build_recommended(payjoin::bitcoin::FeeRate::BROADCAST_MIN.to_sat_per_kwu())?;
             let sender_token = new_sender.persist(&mut NoopPersister)?;
-            let req_ctx = Sender::load(sender_token, &NoopPersister)?;
+            let req_ctx = WithReplyKey::load(sender_token, &NoopPersister)?;
             let (request, context) = req_ctx.extract_v2(ohttp_relay.to_owned().into())?;
             let response = agent
                 .post(request.url.as_string())

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -127,18 +127,20 @@ impl NewReceiver {
     }
 }
 
+pub trait ReceiverState {}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Receiver<State> {
+pub struct Receiver<State: ReceiverState> {
     pub(crate) state: State,
 }
 
-impl<State> core::ops::Deref for Receiver<State> {
+impl<State: ReceiverState> core::ops::Deref for Receiver<State> {
     type Target = State;
 
     fn deref(&self) -> &Self::Target { &self.state }
 }
 
-impl<State> core::ops::DerefMut for Receiver<State> {
+impl<State: ReceiverState> core::ops::DerefMut for Receiver<State> {
     fn deref_mut(&mut self) -> &mut Self::Target { &mut self.state }
 }
 
@@ -146,6 +148,8 @@ impl<State> core::ops::DerefMut for Receiver<State> {
 pub struct WithContext {
     context: SessionContext,
 }
+
+impl ReceiverState for WithContext {}
 
 impl Receiver<WithContext> {
     /// Loads a [`Receiver`] from the provided persister using the storage token.
@@ -281,6 +285,8 @@ pub struct UncheckedProposal {
     pub(crate) context: SessionContext,
 }
 
+impl ReceiverState for UncheckedProposal {}
+
 impl Receiver<UncheckedProposal> {
     /// The Sender's Original PSBT
     pub fn extract_tx_to_schedule_broadcast(&self) -> bitcoin::Transaction {
@@ -366,6 +372,8 @@ pub struct MaybeInputsOwned {
     context: SessionContext,
 }
 
+impl ReceiverState for MaybeInputsOwned {}
+
 impl Receiver<MaybeInputsOwned> {
     /// Check that the Original PSBT has no receiver-owned inputs.
     /// Return original-psbt-rejected error or otherwise refuse to sign undesirable inputs.
@@ -388,6 +396,8 @@ pub struct MaybeInputsSeen {
     v1: v1::MaybeInputsSeen,
     context: SessionContext,
 }
+
+impl ReceiverState for MaybeInputsSeen {}
 
 impl Receiver<MaybeInputsSeen> {
     /// Make sure that the original transaction inputs have never been seen before.
@@ -412,6 +422,8 @@ pub struct OutputsUnknown {
     context: SessionContext,
 }
 
+impl ReceiverState for OutputsUnknown {}
+
 impl Receiver<OutputsUnknown> {
     /// Find which outputs belong to the receiver
     pub fn identify_receiver_outputs(
@@ -431,6 +443,8 @@ pub struct WantsOutputs {
     v1: v1::WantsOutputs,
     context: SessionContext,
 }
+
+impl ReceiverState for WantsOutputs {}
 
 impl Receiver<WantsOutputs> {
     /// Whether the receiver is allowed to substitute original outputs or not.
@@ -475,6 +489,8 @@ pub struct WantsInputs {
     v1: v1::WantsInputs,
     context: SessionContext,
 }
+
+impl ReceiverState for WantsInputs {}
 
 impl Receiver<WantsInputs> {
     /// Select receiver input such that the payjoin avoids surveillance.
@@ -523,6 +539,8 @@ pub struct ProvisionalProposal {
     context: SessionContext,
 }
 
+impl ReceiverState for ProvisionalProposal {}
+
 impl Receiver<ProvisionalProposal> {
     /// Return a Payjoin Proposal PSBT that the sender will find acceptable.
     ///
@@ -552,6 +570,8 @@ pub struct PayjoinProposal {
     v1: v1::PayjoinProposal,
     context: SessionContext,
 }
+
+impl ReceiverState for PayjoinProposal {}
 
 impl PayjoinProposal {
     #[cfg(feature = "_multiparty")]

--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -33,7 +33,7 @@ impl<'a> SenderBuilder<'a> {
 pub struct NewSender(v2::NewSender);
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Sender(v2::Sender);
+pub struct Sender(v2::Sender<v2::WithReplyKey>);
 
 impl Sender {
     pub fn extract_v2(
@@ -76,7 +76,7 @@ impl Sender {
             hpke_ctx: HpkeContext::new(rs, &self.0.reply_key),
             ohttp_ctx,
         };
-        Ok((request, PostContext(v2_post_ctx)))
+        Ok((request, PostContext(v2::Sender { state: v2_post_ctx })))
     }
 }
 
@@ -100,7 +100,7 @@ fn serialize_v2_body(
 
 /// Post context is used to process the response from the directory and generate
 /// the GET context which can be used to extract a request for the receiver
-pub struct PostContext(v2::V2PostContext);
+pub struct PostContext(v2::Sender<v2::V2PostContext>);
 
 impl PostContext {
     pub fn process_response(self, response: &[u8]) -> Result<GetContext, EncapsulationError> {
@@ -111,7 +111,7 @@ impl PostContext {
 
 /// Get context is used to extract a request for the receiver. In the multiparty context this is a
 /// merged PSBT with other senders.
-pub struct GetContext(v2::V2GetContext);
+pub struct GetContext(v2::Sender<v2::V2GetContext>);
 
 impl GetContext {
     /// Extract the GET request that will give us the psbt to be finalized

--- a/payjoin/src/send/multiparty/persist.rs
+++ b/payjoin/src/send/multiparty/persist.rs
@@ -7,8 +7,9 @@ impl NewSender {
         &self,
         persister: &mut P,
     ) -> Result<P::Token, ImplementationError> {
-        let sender =
-            Sender(v2::Sender { v1: self.0.v1.clone(), reply_key: self.0.reply_key.clone() });
+        let sender = Sender(v2::Sender {
+            state: v2::WithReplyKey { v1: self.0.v1.clone(), reply_key: self.0.reply_key.clone() },
+        });
         persister.save(sender).map_err(ImplementationError::from)
     }
 }

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -124,18 +124,20 @@ impl<'a> SenderBuilder<'a> {
     }
 }
 
+pub trait SenderState {}
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Sender<State> {
+pub struct Sender<State: SenderState> {
     pub(crate) state: State,
 }
 
-impl<State> core::ops::Deref for Sender<State> {
+impl<State: SenderState> core::ops::Deref for Sender<State> {
     type Target = State;
 
     fn deref(&self) -> &Self::Target { &self.state }
 }
 
-impl<State> core::ops::DerefMut for Sender<State> {
+impl<State: SenderState> core::ops::DerefMut for Sender<State> {
     fn deref_mut(&mut self) -> &mut Self::Target { &mut self.state }
 }
 
@@ -168,6 +170,8 @@ pub struct WithReplyKey {
     /// The secret key to decrypt the receiver's reply.
     pub(crate) reply_key: HpkeSecretKey,
 }
+
+impl SenderState for WithReplyKey {}
 
 impl Sender<WithReplyKey> {
     /// Loads a [`Sender`] from the provided persister using the storage token.
@@ -304,6 +308,8 @@ pub struct V2PostContext {
     pub(crate) ohttp_ctx: ohttp::ClientResponse,
 }
 
+impl SenderState for V2PostContext {}
+
 impl Sender<V2PostContext> {
     /// Processes the response for the initial POST message from the sender
     /// client in the v2 Payjoin protocol.
@@ -351,6 +357,8 @@ pub struct V2GetContext {
     pub(crate) psbt_ctx: PsbtContext,
     pub(crate) hpke_ctx: HpkeContext,
 }
+
+impl SenderState for V2GetContext {}
 
 impl Sender<V2GetContext> {
     /// Extract an OHTTP Encapsulated HTTP GET request for the Proposal PSBT

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -124,6 +124,21 @@ impl<'a> SenderBuilder<'a> {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Sender<State> {
+    pub(crate) state: State,
+}
+
+impl<State> core::ops::Deref for Sender<State> {
+    type Target = State;
+
+    fn deref(&self) -> &Self::Target { &self.state }
+}
+
+impl<State> core::ops::DerefMut for Sender<State> {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.state }
+}
+
 /// A new payjoin sender, which must be persisted before initiating the payjoin flow.
 #[derive(Debug)]
 pub struct NewSender {
@@ -133,11 +148,13 @@ pub struct NewSender {
 
 impl NewSender {
     /// Saves the new [`Sender`] using the provided persister and returns the storage token.
-    pub fn persist<P: Persister<Sender>>(
+    pub fn persist<P: Persister<Sender<WithReplyKey>>>(
         &self,
         persister: &mut P,
     ) -> Result<P::Token, ImplementationError> {
-        let sender = Sender { v1: self.v1.clone(), reply_key: self.reply_key.clone() };
+        let sender = Sender {
+            state: WithReplyKey { v1: self.v1.clone(), reply_key: self.reply_key.clone() },
+        };
         Ok(persister.save(sender)?)
     }
 }
@@ -145,16 +162,16 @@ impl NewSender {
 /// A payjoin V2 sender, allowing the construction of a payjoin V2 request
 /// and the resulting [`V2PostContext`].
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Sender {
+pub struct WithReplyKey {
     /// The v1 Sender.
     pub(crate) v1: v1::Sender,
     /// The secret key to decrypt the receiver's reply.
     pub(crate) reply_key: HpkeSecretKey,
 }
 
-impl Sender {
+impl Sender<WithReplyKey> {
     /// Loads a [`Sender`] from the provided persister using the storage token.
-    pub fn load<P: Persister<Sender>>(
+    pub fn load<P: Persister<Sender<WithReplyKey>>>(
         token: P::Token,
         persister: &P,
     ) -> Result<Self, ImplementationError> {
@@ -170,7 +187,7 @@ impl Sender {
     pub fn extract_v2(
         &self,
         ohttp_relay: impl IntoUrl,
-    ) -> Result<(Request, V2PostContext), CreateRequestError> {
+    ) -> Result<(Request, Sender<V2PostContext>), CreateRequestError> {
         if let Ok(expiry) = self.v1.endpoint.exp() {
             if std::time::SystemTime::now() > expiry {
                 return Err(InternalCreateRequestError::Expired(expiry).into());
@@ -199,17 +216,19 @@ impl Sender {
         let rs = self.extract_rs_pubkey()?;
         Ok((
             request,
-            V2PostContext {
-                endpoint: self.v1.endpoint.clone(),
-                psbt_ctx: PsbtContext {
-                    original_psbt: self.v1.psbt.clone(),
-                    output_substitution: self.v1.output_substitution,
-                    fee_contribution: self.v1.fee_contribution,
-                    payee: self.v1.payee.clone(),
-                    min_fee_rate: self.v1.min_fee_rate,
+            Sender {
+                state: V2PostContext {
+                    endpoint: self.v1.endpoint.clone(),
+                    psbt_ctx: PsbtContext {
+                        original_psbt: self.v1.psbt.clone(),
+                        output_substitution: self.v1.output_substitution,
+                        fee_contribution: self.v1.fee_contribution,
+                        payee: self.v1.payee.clone(),
+                        min_fee_rate: self.v1.min_fee_rate,
+                    },
+                    hpke_ctx: HpkeContext::new(rs, &self.reply_key),
+                    ohttp_ctx,
                 },
-                hpke_ctx: HpkeContext::new(rs, &self.reply_key),
-                ohttp_ctx,
             },
         ))
     }
@@ -276,7 +295,7 @@ pub(crate) fn serialize_v2_body(
 /// Data required to validate the POST response.
 ///
 /// This type is used to process a BIP77 POST response.
-/// Call [`Self::process_response`] on it to continue the BIP77 flow.
+/// Call [`Sender<V2PostContext>::process_response`] on it to continue the BIP77 flow.
 pub struct V2PostContext {
     /// The endpoint in the Payjoin URI
     pub(crate) endpoint: Url,
@@ -285,7 +304,7 @@ pub struct V2PostContext {
     pub(crate) ohttp_ctx: ohttp::ClientResponse,
 }
 
-impl V2PostContext {
+impl Sender<V2PostContext> {
     /// Processes the response for the initial POST message from the sender
     /// client in the v2 Payjoin protocol.
     ///
@@ -296,19 +315,24 @@ impl V2PostContext {
     ///
     /// After this function is called, the sender can poll for a Proposal PSBT
     /// from the receiver using the returned [`V2GetContext`].
-    pub fn process_response(self, response: &[u8]) -> Result<V2GetContext, EncapsulationError> {
+    pub fn process_response(
+        self,
+        response: &[u8],
+    ) -> Result<Sender<V2GetContext>, EncapsulationError> {
         let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] = response
             .try_into()
             .map_err(|_| InternalEncapsulationError::InvalidSize(response.len()))?;
-        let response = ohttp_decapsulate(self.ohttp_ctx, response_array)
+        let response = ohttp_decapsulate(self.state.ohttp_ctx, response_array)
             .map_err(InternalEncapsulationError::Ohttp)?;
         match response.status() {
             http::StatusCode::OK => {
                 // return OK with new Typestate
-                Ok(V2GetContext {
-                    endpoint: self.endpoint,
-                    psbt_ctx: self.psbt_ctx,
-                    hpke_ctx: self.hpke_ctx,
+                Ok(Sender {
+                    state: V2GetContext {
+                        endpoint: self.state.endpoint,
+                        psbt_ctx: self.state.psbt_ctx,
+                        hpke_ctx: self.state.hpke_ctx,
+                    },
                 })
             }
             _ => Err(InternalEncapsulationError::UnexpectedStatusCode(response.status()))?,
@@ -319,7 +343,7 @@ impl V2PostContext {
 /// Data required to validate the GET response.
 ///
 /// This type is used to make a BIP77 GET request and process the response.
-/// Call [`Self::process_response`] on it to continue the BIP77 flow.
+/// Call [`Sender<V2GetContext>::process_response`] on it to continue the BIP77 flow.
 #[derive(Debug, Clone)]
 pub struct V2GetContext {
     /// The endpoint in the Payjoin URI
@@ -328,7 +352,7 @@ pub struct V2GetContext {
     pub(crate) hpke_ctx: HpkeContext,
 }
 
-impl V2GetContext {
+impl Sender<V2GetContext> {
     /// Extract an OHTTP Encapsulated HTTP GET request for the Proposal PSBT
     pub fn extract_req(
         &self,
@@ -422,18 +446,20 @@ mod test {
 
     const SERIALIZED_BODY_V2: &str = "63484e696450384241484d43414141414159386e757447674a647959475857694245623435486f65396c5747626b78682f36624e694f4a6443447544414141414141442b2f2f2f2f41747956754155414141414146366b554865684a38476e536442554f4f7636756a584c72576d734a5244434867495165414141414141415871525233514a62627a30686e513849765130667074476e2b766f746e656f66544141414141414542494b6762317755414141414146366b55336b34656b47484b57524e6241317256357452356b455644564e4348415163584667415578347046636c4e56676f31575741644e3153594e583874706854414243477343527a424541694238512b41366465702b527a393276687932366c5430416a5a6e3450524c6938426639716f422f434d6b30774967502f526a3250575a3367456a556b546c6844524e415130675877544f3774396e2b563134705a366f6c6a554249514d566d7341616f4e5748564d5330324c6654536530653338384c4e697450613155515a794f6968592b464667414241425941464562324769753663344b4f35595730706677336c4770396a4d55554141413d0a763d32";
 
-    fn create_sender_context() -> Result<super::Sender, BoxError> {
+    fn create_sender_context() -> Result<super::Sender<super::WithReplyKey>, BoxError> {
         let endpoint = Url::parse("http://localhost:1234")?;
         let mut sender = super::Sender {
-            v1: v1::Sender {
-                psbt: PARSED_ORIGINAL_PSBT.clone(),
-                endpoint,
-                output_substitution: OutputSubstitution::Enabled,
-                fee_contribution: None,
-                min_fee_rate: FeeRate::ZERO,
-                payee: ScriptBuf::from(vec![0x00]),
+            state: super::WithReplyKey {
+                v1: v1::Sender {
+                    psbt: PARSED_ORIGINAL_PSBT.clone(),
+                    endpoint,
+                    output_substitution: OutputSubstitution::Enabled,
+                    fee_contribution: None,
+                    min_fee_rate: FeeRate::ZERO,
+                    payee: ScriptBuf::from(vec![0x00]),
+                },
+                reply_key: HpkeKeyPair::gen_keypair().0,
             },
-            reply_key: HpkeKeyPair::gen_keypair().0,
         };
         sender.v1.endpoint.set_exp(SystemTime::now() + Duration::from_secs(60));
         sender.v1.endpoint.set_receiver_pubkey(HpkeKeyPair::gen_keypair().1);

--- a/payjoin/src/send/v2/persist.rs
+++ b/payjoin/src/send/v2/persist.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 
 use url::Url;
 
-use super::Sender;
+use super::{Sender, WithReplyKey};
 use crate::persist::Value;
 
 /// Opaque key type for the sender
@@ -13,15 +13,15 @@ impl Display for SenderToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
 }
 
-impl From<Sender> for SenderToken {
-    fn from(sender: Sender) -> Self { SenderToken(sender.endpoint().clone()) }
+impl From<Sender<WithReplyKey>> for SenderToken {
+    fn from(sender: Sender<WithReplyKey>) -> Self { SenderToken(sender.endpoint().clone()) }
 }
 
 impl AsRef<[u8]> for SenderToken {
     fn as_ref(&self) -> &[u8] { self.0.as_str().as_bytes() }
 }
 
-impl Value for Sender {
+impl Value for Sender<WithReplyKey> {
     type Key = SenderToken;
 
     fn key(&self) -> Self::Key { SenderToken(self.endpoint().clone()) }


### PR DESCRIPTION
This commit updates the `v2::Sender` to be generic over its
typestate (e.g., `V2GetContext`, `V2PostContext`, etc.). The
motivation is outlined in https://github.com/0xBEEFCAF3/rust-payjoin/commit/c8b860d9550ffd92952483e1eccb527527fef1d4

This commit renames the original `Sender` struct to `WithReplyKey`.
This type now represents the v2::sender session once the HPKE context has been
 created. The `Sender` name is re-purposed for the new generic wrapper
 over typestate.

For the UniFFI exported receiver we monomorphize the exported structs over a
specific typestate. UniFFI doesn't support exporting generic structs, so
 we expose a concrete type to the FFI.