### PR TITLE
update links to reference BIP-77 document

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ### `payjoin`
 
-The Payjoin Dev Kit `payjoin` library implements both [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [BIP 77 Payjoin V2](https://github.com/bitcoin/bips/pull/1483).
+The Payjoin Dev Kit `payjoin` library implements both [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [BIP 77 Payjoin V2](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
 
 ### `payjoin-cli`
 

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -6,7 +6,7 @@
 
 It enables sending and receiving [BIP 78 Payjoin
 (v1)](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft
-BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/pull/1483)
+BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
 transactions via `bitcoind`. By default it supports Payjoin v2, which is
 backwards compatible with v1. Enable the `v1` feature to disable Payjoin v2 to
 send and receive using only v1.

--- a/payjoin-directory/README.md
+++ b/payjoin-directory/README.md
@@ -1,6 +1,6 @@
 # Payjoin Directory
 
-[BIP 77](https://github.com/bitcoin/bips/pull/1483) Async Payjoin (v2)
+[BIP 77](https://github.com/bitcoin/bips/blob/master/bip-0077.md) Async Payjoin (v2)
 peers store and forward HTTP client messages via a directory server in order to
 make asynchronous Payjoin transactions. This is a reference implementation of
 such a server

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -44,7 +44,7 @@ impl NewReceiver {
     /// A new instance of [`NewReceiver`].
     ///
     /// # References
-    /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/pull/1483)
+    /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
     pub fn new(
         address: Address,
         directory: String,

--- a/payjoin-ffi/src/receive/uni.rs
+++ b/payjoin-ffi/src/receive/uni.rs
@@ -35,7 +35,7 @@ impl NewReceiver {
     /// A new instance of [`NewReceiver`].
     ///
     /// # References
-    /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/pull/1483)
+    /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
     #[uniffi::constructor]
     pub fn new(
         address: Arc<Address>,

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Supercharge payment batching to save you fees and preserve your privacy.
 //!
-//! This library implements both [BIP 78 Payjoin V1](https://github.com/shesek/bips/blob/master/bip-0078.mediawiki) and [BIP 77 Payjoin V2](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
+//! This library implements both [BIP 78 Payjoin V1](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [BIP 77 Payjoin V2](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
 //!
 //! Only the latest BIP 77 Payjoin V2 is enabled by default. To use BIP 78 Payjoin V1, enable the `v1` feature.
 //!

--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Supercharge payment batching to save you fees and preserve your privacy.
 //!
-//! This library implements both [BIP 78 Payjoin V1](https://github.com/shesek/bips/blob/master/bip-0078.mediawiki) and [BIP 77 Payjoin V2](https://github.com/bitcoin/bips/pull/1483).
+//! This library implements both [BIP 78 Payjoin V1](https://github.com/shesek/bips/blob/master/bip-0078.mediawiki) and [BIP 77 Payjoin V2](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
 //!
 //! Only the latest BIP 77 Payjoin V2 is enabled by default. To use BIP 78 Payjoin V1, enable the `v1` feature.
 //!

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -95,7 +95,7 @@ impl NewReceiver {
     /// A new instance of [`NewReceiver`].
     ///
     /// # References
-    /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/pull/1483)
+    /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
     pub fn new(
         address: Address,
         directory: impl IntoUrl,

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -1,7 +1,7 @@
 //! Send BIP 77 Payjoin v2
 //!
 //! This module contains types and methods used to implement sending via [BIP77
-//! Payjoin](https://github.com/bitcoin/bips/pull/1483).
+//! Payjoin](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
 //!
 //! Usage is pretty simple:
 //!


### PR DESCRIPTION
This PR updates all references to BIP-77 by replacing links to the original pull request with direct links to the now merged BIP-77 document in the [BIPs master branch](https://github.com/bitcoin/bips/blob/master/bip-0077.md).
No other content changes were made.

closes #731 