### PR TITLE
Remove macos workflow redis dependency

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,25 +87,30 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: "Install build dependencies"
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential python3-dev
+
       - name: Setup Docker on macOS
         uses: douglascamata/setup-docker-macos-action@v1.0.0
 
-      - name: "Install Redis"
-        run: |
-          brew update
-          brew install redis
+      # - name: "Install Redis"
+      #   run: |
+      #     brew update
+      #     brew install redis
 
-      - name: "Start Redis"
-        run: |
-          redis-server --daemonize yes
-          for i in {1..10}; do
-            if redis-cli ping | grep -q PONG; then
-              echo "Redis is ready"
-              break
-            fi
-            echo "Waiting for Redis..."
-            sleep 1
-          done
+      # - name: "Start Redis"
+      #   run: |
+      #     redis-server --daemonize yes
+      #     for i in {1..10}; do
+      #       if redis-cli ping | grep -q PONG; then
+      #         echo "Redis is ready"
+      #         break
+      #       fi
+      #       echo "Waiting for Redis..."
+      #       sleep 1
+      #     done
 
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
We should use the redis within the payjoin-test-utils and not install redis seperately.