### PR TITLE
Remove redis from macos CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,23 +90,6 @@ jobs:
       - name: Setup Docker on macOS
         uses: douglascamata/setup-docker-macos-action@v1.0.0
 
-      - name: "Install Redis"
-        run: |
-          brew update
-          brew install redis
-
-      - name: "Start Redis"
-        run: |
-          redis-server --daemonize yes
-          for i in {1..10}; do
-            if redis-cli ping | grep -q PONG; then
-              echo "Redis is ready"
-              break
-            fi
-            echo "Waiting for Redis..."
-            sleep 1
-          done
-
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
We should use the redis within the payjoin-test-utils and not install redis seperately.

I think the issue cropped up parallel to the fact that macos worker does not natively have access to docker so I was having trouble getting those both solved at the same time but as it turns out we can simply remove the redis dep directly from the CI workflow without any additional changes!