### PR TITLE
Simplify v1 response processing function signatures

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -88,12 +88,10 @@ impl AppTrait for App {
             "Sent fallback transaction hex: {:#}",
             payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
         );
-        let psbt = ctx.process_response(&mut response.bytes().await?.to_vec().as_slice()).map_err(
-            |e| {
-                log::debug!("Error processing response: {e:?}");
-                anyhow!("Failed to process response {e}")
-            },
-        )?;
+        let psbt = ctx.process_response(&response.bytes().await?).map_err(|e| {
+            log::debug!("Error processing response: {e:?}");
+            anyhow!("Failed to process response {e}")
+        })?;
 
         self.process_pj_response(psbt)?;
         Ok(())

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::bitcoin::Amount;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
-use hyper::body::{Buf, Bytes, Incoming};
+use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
@@ -279,8 +279,8 @@ impl App {
         let (parts, body) = req.into_parts();
         let headers = Headers(&parts.headers);
         let query_string = parts.uri.query().unwrap_or("");
-        let body = body.collect().await.map_err(|e| Implementation(e.into()))?.aggregate().reader();
-        let proposal = UncheckedProposal::from_request(body, query_string, headers)?;
+        let body = body.collect().await.map_err(|e| Implementation(e.into()))?.to_bytes();
+        let proposal = UncheckedProposal::from_request(&body, query_string, headers)?;
 
         let payjoin_proposal = self.process_v1_proposal(proposal)?;
         let psbt = payjoin_proposal.psbt();

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -234,7 +234,7 @@ impl App {
                 println!("Posting Original PSBT Payload request...");
                 let response = post_request(req).await?;
                 println!("Sent fallback transaction");
-                match v1_ctx.process_response(&mut response.bytes().await?.to_vec().as_slice()) {
+                match v1_ctx.process_response(&response.bytes().await?) {
                     Ok(psbt) => Ok(psbt),
                     Err(re) => {
                         println!("{re}");

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -1,4 +1,3 @@
-use std::io::Cursor;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -185,10 +184,9 @@ impl From<payjoin::send::v1::V1Context> for V1Context {
 impl V1Context {
     ///Decodes and validates the response.
     /// Call this method with response from receiver to continue BIP78 flow. If the response is valid you will get appropriate PSBT that you should sign and broadcast.
-    pub fn process_response(&self, response: Vec<u8>) -> Result<String, ResponseError> {
-        let mut decoder = Cursor::new(response);
+    pub fn process_response(&self, response: &[u8]) -> Result<String, ResponseError> {
         <payjoin::send::v1::V1Context as Clone>::clone(&self.0.clone())
-            .process_response(&mut decoder)
+            .process_response(response)
             .map(|e| e.to_string())
             .map_err(Into::into)
     }

--- a/payjoin-ffi/src/send/uni.rs
+++ b/payjoin-ffi/src/send/uni.rs
@@ -185,7 +185,7 @@ impl From<super::V1Context> for V1Context {
 impl V1Context {
     /// Decodes and validates the response.
     /// Call this method with response from receiver to continue BIP78 flow. If the response is valid you will get appropriate PSBT that you should sign and broadcast.
-    pub fn process_response(&self, response: Vec<u8>) -> Result<String, ResponseError> {
+    pub fn process_response(&self, response: &[u8]) -> Result<String, ResponseError> {
         self.0.process_response(response)
     }
 }

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -164,7 +164,7 @@ impl From<InternalPayloadError> for PayloadError {
 #[derive(Debug)]
 pub(crate) enum InternalPayloadError {
     /// The payload is not valid utf-8
-    Utf8(std::string::FromUtf8Error),
+    Utf8(std::str::Utf8Error),
     /// The payload is not a valid PSBT
     ParsePsbt(bitcoin::psbt::PsbtParseError),
     /// Invalid sender parameters

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -212,11 +212,11 @@ impl<'a> From<&'a InputPair> for InternalInputPair<'a> {
 
 /// Validate the payload of a Payjoin request for PSBT and Params sanity
 pub(crate) fn parse_payload(
-    base64: String,
+    base64: &str,
     query: &str,
     supported_versions: &'static [Version],
 ) -> Result<(Psbt, Params), PayloadError> {
-    let unchecked_psbt = Psbt::from_str(&base64).map_err(InternalPayloadError::ParsePsbt)?;
+    let unchecked_psbt = Psbt::from_str(base64).map_err(InternalPayloadError::ParsePsbt)?;
 
     let psbt = unchecked_psbt.validate().map_err(InternalPayloadError::InconsistentPsbt)?;
     log::debug!("Received original psbt: {psbt:?}");

--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -18,8 +18,6 @@ pub struct RequestError(InternalRequestError);
 
 #[derive(Debug)]
 pub(crate) enum InternalRequestError {
-    /// I/O error while reading the request body
-    Io(std::io::Error),
     /// A required HTTP header is missing from the request
     MissingHeader(&'static str),
     /// The Content-Type header has an invalid value
@@ -43,8 +41,7 @@ impl From<RequestError> for JsonReply {
         use InternalRequestError::*;
 
         match &e.0 {
-            Io(_)
-            | MissingHeader(_)
+            MissingHeader(_)
             | InvalidContentType(_)
             | InvalidContentLength(_)
             | ContentLengthTooLarge(_) =>
@@ -56,7 +53,6 @@ impl From<RequestError> for JsonReply {
 impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.0 {
-            InternalRequestError::Io(e) => write!(f, "{e}"),
             InternalRequestError::MissingHeader(header) => write!(f, "Missing header: {header}"),
             InternalRequestError::InvalidContentType(content_type) =>
                 write!(f, "Invalid content type: {content_type}"),
@@ -70,7 +66,6 @@ impl fmt::Display for RequestError {
 impl error::Error for RequestError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &self.0 {
-            InternalRequestError::Io(e) => Some(e),
             InternalRequestError::InvalidContentLength(e) => Some(e),
             InternalRequestError::MissingHeader(_) => None,
             InternalRequestError::InvalidContentType(_) => None,

--- a/payjoin/src/receive/v1/exclusive/mod.rs
+++ b/payjoin/src/receive/v1/exclusive/mod.rs
@@ -29,7 +29,7 @@ impl UncheckedProposal {
     ) -> Result<Self, ReplyableError> {
         let validated_body = validate_body(headers, body).map_err(ReplyableError::V1)?;
 
-        let base64 = String::from_utf8(validated_body).map_err(InternalPayloadError::Utf8)?;
+        let base64 = std::str::from_utf8(validated_body).map_err(InternalPayloadError::Utf8)?;
 
         let (psbt, params) = crate::receive::parse_payload(base64, query, SUPPORTED_VERSIONS)
             .map_err(ReplyableError::Payload)?;
@@ -41,7 +41,7 @@ impl UncheckedProposal {
 /// Validate the request headers for a Payjoin request
 ///
 /// [`RequestError`] should only be produced here.
-fn validate_body(headers: impl Headers, body: &[u8]) -> Result<Vec<u8>, RequestError> {
+fn validate_body(headers: impl Headers, body: &[u8]) -> Result<&[u8], RequestError> {
     let content_type = headers
         .get_header("content-type")
         .ok_or(InternalRequestError::MissingHeader("Content-Type"))?;
@@ -58,7 +58,7 @@ fn validate_body(headers: impl Headers, body: &[u8]) -> Result<Vec<u8>, RequestE
         return Err(InternalRequestError::ContentLengthTooLarge(content_length).into());
     }
 
-    Ok(body[..content_length].to_vec())
+    Ok(&body[..content_length])
 }
 
 #[cfg(test)]

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -95,7 +95,6 @@ pub struct ValidationError(InternalValidationError);
 #[derive(Debug)]
 pub(crate) enum InternalValidationError {
     Parse,
-    Io(std::io::Error),
     ContentTooLarge,
     Proposal(InternalProposalError),
     #[cfg(feature = "v2")]
@@ -120,7 +119,6 @@ impl fmt::Display for ValidationError {
 
         match &self.0 {
             Parse => write!(f, "couldn't decode as PSBT or JSON",),
-            Io(e) => write!(f, "couldn't read PSBT: {e}"),
             ContentTooLarge => write!(f, "content is larger than {MAX_CONTENT_LENGTH} bytes"),
             Proposal(e) => write!(f, "proposal PSBT error: {e}"),
             #[cfg(feature = "v2")]
@@ -135,7 +133,6 @@ impl std::error::Error for ValidationError {
 
         match &self.0 {
             Parse => None,
-            Io(error) => Some(error),
             ContentTooLarge => None,
             Proposal(e) => Some(e),
             #[cfg(feature = "v2")]

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -100,7 +100,7 @@ mod integration {
             // **********************
             // Inside the Sender:
             // Sender checks, signs, finalizes, extracts, and broadcasts
-            let checked_payjoin_proposal_psbt = ctx.process_response(&mut response.as_bytes())?;
+            let checked_payjoin_proposal_psbt = ctx.process_response(response.as_bytes())?;
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
 
@@ -565,7 +565,7 @@ mod integration {
             // **********************
             // Inside the Sender:
             // Sender checks, signs, finalizes, extracts, and broadcasts
-            let checked_payjoin_proposal_psbt = ctx.process_response(&mut response.as_bytes())?;
+            let checked_payjoin_proposal_psbt = ctx.process_response(response.as_bytes())?;
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
 
@@ -694,9 +694,8 @@ mod integration {
                 log::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
 
-                let res = response.bytes().await?.to_vec();
                 let checked_payjoin_proposal_psbt =
-                    send_ctx.process_response(&mut res.as_slice())?;
+                    send_ctx.process_response(&response.bytes().await?)?;
                 let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
                 sender.send_raw_transaction(&payjoin_tx)?;
                 log::info!("sent");
@@ -984,10 +983,7 @@ mod integration {
                         .await?;
                     assert!(response.status().is_success());
 
-                    finalize_ctx.process_response(
-                        response.bytes().await?.to_vec().as_slice(),
-                        ohttp_response_ctx,
-                    )?;
+                    finalize_ctx.process_response(&response.bytes().await?, ohttp_response_ctx)?;
                 }
 
                 //**********************
@@ -1183,7 +1179,7 @@ mod integration {
             // **********************
             // Inside the Sender:
             // Sender checks, signs, finalizes, extracts, and broadcasts
-            let checked_payjoin_proposal_psbt = ctx.process_response(&mut response.as_bytes())?;
+            let checked_payjoin_proposal_psbt = ctx.process_response(response.as_bytes())?;
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
 
@@ -1269,7 +1265,7 @@ mod integration {
             // **********************
             // Inside the Sender:
             // Sender checks, signs, finalizes, extracts, and broadcasts
-            let checked_payjoin_proposal_psbt = ctx.process_response(&mut response.as_bytes())?;
+            let checked_payjoin_proposal_psbt = ctx.process_response(response.as_bytes())?;
             let payjoin_tx = extract_pj_tx(&sender, checked_payjoin_proposal_psbt)?;
             sender.send_raw_transaction(&payjoin_tx)?;
 


### PR DESCRIPTION
This was prompted by the discussion in https://github.com/payjoin/rust-payjoin/pull/710#discussion_r2104814421.

Using a reader still left callers susceptible to writing memory exhaustion vulnerable code, and just introduced extra complexity by having to buffer twice. We can recognize this and leave the buffering entirely up to the caller. Also, the V2 sender and receiver response processing functions already take &[u8], so this makes the function signatures more consistent across versions. 

