### PR TITLE
Lock cargo mutants version to 25.0.1

### DIFF
--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-mutants
+          version: "25.0.1"
       - run: cargo mutants --in-place --no-shuffle
       - uses: actions/upload-artifact@v4
         if: always()
@@ -24,11 +25,15 @@ jobs:
         run: |
           if [ -s mutants.out/missed.txt ]; then
             echo "New missed mutants found"
+            MUTANTS_VERSION=$(cargo mutants --version)
             gh issue create \
             --title "New Mutants Found" \
             --body "$(cat <<EOF
           Displaying up to the first 15 missed mutants:
+          \`\`\`
           $(head -n 15 mutants.out/missed.txt)
+          \`\`\`
+          Running cargo mutants version: ${MUTANTS_VERSION}
           For the complete list, please check the [mutants.out artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
           EOF
           )"


### PR DESCRIPTION
The new version of cargo mutants introduced a set of new mutants that ultimately is not worth the added effort to fix at the moment as well as introducing some breaking changes that have not been clarified yet how to work around them. For now I am locking the cargo mutants version until we have more clarity on the stability of the mutants workflow and we can put more priority into full mutation coverage.

This should resolve the mutants found in #752 for now. However, as we move up to future versions we will need to get coverage for these eventually.