### PR TITLE
Export `InMemoryTestPersister` under `_test-utils`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@ members = ["payjoin", "payjoin-cli", "payjoin-directory", "payjoin-test-utils"]
 resolver = "2"
 exclude = ["payjoin-ffi"]
 
-[patch.crates-io.payjoin]
-path = "payjoin"
-
-[patch.crates-io.payjoin-directory]
-path = "payjoin-directory"
+[patch.crates-io]
+payjoin = { path = "payjoin" }
+payjoin-directory = { path = "payjoin-directory" }
+payjoin-test-utils = { path = "payjoin-test-utils" }

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -49,4 +49,4 @@ url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
 nix = "0.26.4"
-payjoin-test-utils = { path = "../payjoin-test-utils" }
+payjoin-test-utils = { version = "0.0.0" }

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.7"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 ohttp-relay = { version = "0.0.10", features = ["_test-util"] }
 once_cell = "1.19.0"
-payjoin = { version = "0.23.0", features = ["io", "_danger-local-https"] }
+payjoin = { version = "0.23.0", features = ["io", "_danger-local-https", "_test-utils"] }
 payjoin-directory = { version = "0.0.2", features = ["_danger-local-https"] }
 rcgen = "0.11"
 rustls = "0.22"

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -27,6 +27,9 @@ use url::Url;
 pub type BoxError = Box<dyn std::error::Error + 'static>;
 pub type BoxSendSyncError = Box<dyn std::error::Error + Send + Sync>;
 
+pub use payjoin::persist::test_utils::InMemoryTestPersister;
+pub use payjoin::persist::SessionPersister;
+
 static INIT_TRACING: OnceCell<()> = OnceCell::new();
 
 pub fn init_tracing() {

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -26,6 +26,7 @@ v2 = ["_core", "hpke", "dep:http", "bhttp", "ohttp", "url/serde", "directory"]
 io = ["v2", "reqwest/rustls-tls"]
 _danger-local-https = ["reqwest/rustls-tls", "rustls"]
 _multiparty = ["v2"]
+_test-utils = []
 
 [dependencies]
 bitcoin = { version = "0.32.5", features = ["base64"] }
@@ -43,7 +44,7 @@ serde_json = { version = "1.0.108", optional = true }
 
 [dev-dependencies]
 bitcoind = { version = "0.36.0", features = ["0_21_2"] }
-payjoin-test-utils = { path = "../payjoin-test-utils" }
+payjoin-test-utils = { version = "0.0.0" }
 once_cell = "1.19.0"
 tokio = { version = "1.38.1", features = ["full"] }
 tracing = "0.1.40"


### PR DESCRIPTION
`InMemoryTestPerister` now becomes generic over what events it is storing in memory allowing for other rust-payjoin mods to test storing and replaying session logs. We expose the in-memory session persister under a new feature flag: `_test-utils`.

We also re-export the in-memory session persister through the payjoin-test-utils crate and added a crates-io patch making it available to other workspace members that use payjoin-test-utils at version 0.0.0. This exposes the in-memory session persister to the int. and FFI test suites.