### PR TITLE
Capture hpke reply key in session event

### DIFF
--- a/payjoin/src/receive/v2/persist.rs
+++ b/payjoin/src/receive/v2/persist.rs
@@ -34,7 +34,7 @@ impl persist::Value for Receiver<WithContext> {
 /// Each event can be used to transition the receiver state machine to a new state
 pub enum SessionEvent {
     Created(SessionContext),
-    UncheckedProposal(v1::UncheckedProposal),
+    UncheckedProposal((v1::UncheckedProposal, Option<crate::HpkePublicKey>)),
     MaybeInputsOwned(v1::MaybeInputsOwned),
     MaybeInputsSeen(v1::MaybeInputsSeen),
     OutputsUnknown(v1::OutputsUnknown),
@@ -80,7 +80,11 @@ mod tests {
 
         let test_cases = vec![
             SessionEvent::Created(SHARED_CONTEXT.clone()),
-            SessionEvent::UncheckedProposal(unchecked_proposal),
+            SessionEvent::UncheckedProposal((unchecked_proposal.clone(), None)),
+            SessionEvent::UncheckedProposal((
+                unchecked_proposal,
+                Some(crate::HpkeKeyPair::gen_keypair().1),
+            )),
             SessionEvent::MaybeInputsOwned(maybe_inputs_owned),
             SessionEvent::MaybeInputsSeen(maybe_inputs_seen),
             SessionEvent::OutputsUnknown(outputs_unknown),


### PR DESCRIPTION
The session reply key stays `None` until we parse it from an `UncheckedProposal`. We lose this information because we don’t store an updated `SessionContext` in the `UncheckedProposal` session event and we don’t want to store the full updated context either. Instead, we stick to storing only what the session learns at that point. In this case, that’s the proposal itself and the optional HPKE reply key.

This change is cherry-picked off #750 