### PR TITLE
Rename _danger-local-https to _manual-tls & Refactor TLS Certificate Handling

### DIFF
--- a/contrib/coverage.sh
+++ b/contrib/coverage.sh
@@ -4,5 +4,5 @@ set -e
 # https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#merge-coverages-generated-under-different-test-conditions
 cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage results
 cargo llvm-cov --no-report --all-features
-cargo llvm-cov --no-report --package payjoin-cli --no-default-features --features=v1,_danger-local-https # Explicitly run payjoin-cli v1 e2e tests
+cargo llvm-cov --no-report --package payjoin-cli --no-default-features --features=v1,_manual-tls # Explicitly run payjoin-cli v1 e2e tests
 cargo llvm-cov report --lcov --output-path lcov.info # generate report without tests

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [features]
 default = ["v2"]
 native-certs = ["reqwest/rustls-tls-native-roots"]
-_danger-local-https = ["rcgen", "reqwest/rustls-tls", "rustls", "hyper-rustls", "payjoin/_danger-local-https", "tokio-rustls"]
+_manual-tls = ["rcgen", "reqwest/rustls-tls", "rustls", "hyper-rustls", "payjoin/_manual-tls", "tokio-rustls"]
 v1 = ["payjoin/v1","hyper", "hyper-util", "http-body-util"]
 v2 = ["payjoin/v2", "payjoin/io"]
 

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -142,10 +142,11 @@ impl Config {
                 {
                     match built_config.get::<V1Config>("v1") {
                         Ok(v1) => config.version = Some(VersionConfig::V1(v1)),
-                        Err(e) =>
+                        Err(e) => {
                             return Err(ConfigError::Message(format!(
                                 "Valid V1 configuration is required for BIP78 mode: {e}"
-                            ))),
+                            )))
+                        }
                     }
                 }
                 #[cfg(not(feature = "v1"))]
@@ -158,10 +159,11 @@ impl Config {
                 {
                     match built_config.get::<V2Config>("v2") {
                         Ok(v2) => config.version = Some(VersionConfig::V2(v2)),
-                        Err(e) =>
+                        Err(e) => {
                             return Err(ConfigError::Message(format!(
                                 "Valid V2 configuration is required for BIP77 mode: {e}"
-                            ))),
+                            )))
+                        }
                     }
                 }
                 #[cfg(not(feature = "v2"))]

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod v1;
 #[cfg(feature = "v2")]
 pub(crate) mod v2;
 
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 #[async_trait::async_trait]
@@ -55,30 +55,25 @@ pub trait App: Send + Sync {
     }
 }
 
-#[cfg(feature = "_danger-local-https")]
-fn http_agent() -> Result<reqwest::Client> { Ok(http_agent_builder()?.build()?) }
+fn http_agent(_cert: Option<Vec<u8>>) -> Result<reqwest::Client> {
+    #[cfg(feature = "_manual-tls")]
+    {
+        if let Some(cert_der) = cert {
+            use rustls::pki_types::CertificateDer;
+            use rustls::RootCertStore;
 
-#[cfg(not(feature = "_danger-local-https"))]
-fn http_agent() -> Result<reqwest::Client> { Ok(reqwest::Client::new()) }
+            let mut root_cert_store = RootCertStore::empty();
+            root_cert_store.add(CertificateDer::from(cert_der.as_slice()))?;
 
-#[cfg(feature = "_danger-local-https")]
-fn http_agent_builder() -> Result<reqwest::ClientBuilder> {
-    use rustls::pki_types::CertificateDer;
-    use rustls::RootCertStore;
+            return Ok(reqwest::ClientBuilder::new()
+                .use_rustls_tls()
+                .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice())?)
+                .build()?);
+        }
+    }
 
-    let cert_der = read_local_cert()?;
-    let mut root_cert_store = RootCertStore::empty();
-    root_cert_store.add(CertificateDer::from(cert_der.as_slice()))?;
-    Ok(reqwest::ClientBuilder::new()
-        .use_rustls_tls()
-        .add_root_certificate(reqwest::tls::Certificate::from_der(cert_der.as_slice())?))
-}
-
-#[cfg(feature = "_danger-local-https")]
-fn read_local_cert() -> Result<Vec<u8>> {
-    let mut local_cert_path = std::env::temp_dir();
-    local_cert_path.push(LOCAL_CERT_FILE);
-    Ok(std::fs::read(local_cert_path)?)
+    // If cert is None or _manual-tls is not enabled, use default client
+    Ok(reqwest::Client::new())
 }
 
 async fn handle_interrupt(tx: watch::Sender<()>) {

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -58,7 +58,9 @@ impl AppTrait for App {
         Ok(app)
     }
 
-    fn wallet(&self) -> BitcoindWallet { self.wallet.clone() }
+    fn wallet(&self) -> BitcoindWallet {
+        self.wallet.clone()
+    }
 
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         let uri =

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -26,7 +26,7 @@ use super::wallet::BitcoindWallet;
 use super::App as AppTrait;
 use crate::app::{handle_interrupt, http_agent};
 use crate::db::Database;
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 pub const LOCAL_CERT_FILE: &str = "localhost.der";
 
 struct Headers<'a>(&'a hyper::HeaderMap);
@@ -70,7 +70,7 @@ impl AppTrait for App {
             .build_recommended(fee_rate)
             .with_context(|| "Failed to build payjoin request")?
             .extract_v1();
-        let http = http_agent()?;
+        let http = http_agent(None)?;
         let body = String::from_utf8(req.body.clone()).unwrap();
         println!("Sending fallback request to {}", &req.url);
         let response = http
@@ -151,14 +151,14 @@ impl App {
         let listener = TcpListener::bind(addr).await?;
         let app = self.clone();
 
-        #[cfg(feature = "_danger-local-https")]
+        #[cfg(feature = "_manual-tls")]
         let tls_acceptor = Self::init_tls_acceptor()?;
         while let Ok((stream, _)) = listener.accept().await {
             let app = app.clone();
-            #[cfg(feature = "_danger-local-https")]
+            #[cfg(feature = "_manual-tls")]
             let tls_acceptor = tls_acceptor.clone();
             tokio::spawn(async move {
-                #[cfg(feature = "_danger-local-https")]
+                #[cfg(feature = "_manual-tls")]
                 let stream = match tls_acceptor.accept(stream).await {
                     Ok(tls_stream) => tls_stream,
                     Err(e) => {
@@ -178,7 +178,7 @@ impl App {
         Ok(())
     }
 
-    #[cfg(feature = "_danger-local-https")]
+    #[cfg(feature = "_manual-tls")]
     fn init_tls_acceptor() -> Result<tokio_rustls::TlsAcceptor> {
         use std::io::Write;
 

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -370,7 +370,7 @@ fn try_contributing_inputs(
 }
 
 async fn post_request(req: payjoin::Request) -> Result<reqwest::Response> {
-    let http = http_agent()?;
+    let http = http_agent(None)?;
     http.post(req.url)
         .header("Content-Type", req.content_type)
         .body(req.body)

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -47,7 +47,9 @@ impl AppTrait for App {
         Ok(app)
     }
 
-    fn wallet(&self) -> BitcoindWallet { self.wallet.clone() }
+    fn wallet(&self) -> BitcoindWallet {
+        self.wallet.clone()
+    }
 
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         use payjoin::UriExt;
@@ -316,10 +318,11 @@ impl App {
             self.relay_manager.lock().expect("Lock should not be poisoned").get_selected_relay();
         let ohttp_relay = match selected_relay {
             Some(relay) => relay,
-            None =>
+            None => {
                 unwrap_ohttp_keys_or_else_fetch(&self.config, directory, self.relay_manager.clone())
                     .await?
-                    .relay_url,
+                    .relay_url
+            }
         };
         Ok(ohttp_relay)
     }

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -78,7 +78,7 @@ async fn fetch_ohttp_keys(
             .set_selected_relay(selected_relay.clone());
 
         let ohttp_keys = {
-            #[cfg(feature = "_danger-local-https")]
+            #[cfg(feature = "_manual-tls")]
             {
                 let cert_der = crate::app::read_local_cert()?;
                 payjoin::io::fetch_ohttp_keys_with_cert(
@@ -88,7 +88,7 @@ async fn fetch_ohttp_keys(
                 )
                 .await
             }
-            #[cfg(not(feature = "_danger-local-https"))]
+            #[cfg(not(feature = "_manual-tls"))]
             {
                 payjoin::io::fetch_ohttp_keys(&selected_relay, &payjoin_directory).await
             }

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -11,15 +11,25 @@ pub struct RelayManager {
 }
 
 impl RelayManager {
-    pub fn new() -> Self { RelayManager { selected_relay: None, failed_relays: Vec::new() } }
+    pub fn new() -> Self {
+        RelayManager { selected_relay: None, failed_relays: Vec::new() }
+    }
 
-    pub fn set_selected_relay(&mut self, relay: payjoin::Url) { self.selected_relay = Some(relay); }
+    pub fn set_selected_relay(&mut self, relay: payjoin::Url) {
+        self.selected_relay = Some(relay);
+    }
 
-    pub fn get_selected_relay(&self) -> Option<payjoin::Url> { self.selected_relay.clone() }
+    pub fn get_selected_relay(&self) -> Option<payjoin::Url> {
+        self.selected_relay.clone()
+    }
 
-    pub fn add_failed_relay(&mut self, relay: payjoin::Url) { self.failed_relays.push(relay); }
+    pub fn add_failed_relay(&mut self, relay: payjoin::Url) {
+        self.failed_relays.push(relay);
+    }
 
-    pub fn get_failed_relays(&self) -> Vec<payjoin::Url> { self.failed_relays.clone() }
+    pub fn get_failed_relays(&self) -> Vec<payjoin::Url> {
+        self.failed_relays.clone()
+    }
 }
 
 pub(crate) struct ValidatedOhttpKeys {
@@ -95,8 +105,9 @@ async fn fetch_ohttp_keys(
         };
 
         match ohttp_keys {
-            Ok(keys) =>
-                return Ok(ValidatedOhttpKeys { ohttp_keys: keys, relay_url: selected_relay }),
+            Ok(keys) => {
+                return Ok(ValidatedOhttpKeys { ohttp_keys: keys, relay_url: selected_relay })
+            }
             Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
                 return Err(payjoin::io::Error::UnexpectedStatusCode(e).into());
             }

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -23,10 +23,11 @@ pub struct BitcoindWallet {
 impl BitcoindWallet {
     pub fn new(config: &crate::app::config::BitcoindConfig) -> Result<Self> {
         let client = match &config.cookie {
-            Some(cookie) if cookie.as_os_str().is_empty() =>
+            Some(cookie) if cookie.as_os_str().is_empty() => {
                 return Err(anyhow!(
                     "Cookie authentication enabled but no cookie path provided in config.toml"
-                )),
+                ))
+            }
             Some(cookie) => Client::new(config.rpchost.as_str(), Auth::CookieFile(cookie.into())),
             None => Client::new(
                 config.rpchost.as_str(),

--- a/payjoin-cli/src/db/error.rs
+++ b/payjoin-cli/src/db/error.rs
@@ -34,5 +34,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl From<SledError> for Error {
-    fn from(error: SledError) -> Self { Error::Sled(error) }
+    fn from(error: SledError) -> Self {
+        Error::Sled(error)
+    }
 }

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -11,7 +11,9 @@ use super::*;
 
 pub(crate) struct SenderPersister(Arc<Database>);
 impl SenderPersister {
-    pub fn new(db: Arc<Database>) -> Self { Self(db) }
+    pub fn new(db: Arc<Database>) -> Self {
+        Self(db)
+    }
 }
 
 impl Persister<Sender<WithReplyKey>> for SenderPersister {
@@ -38,7 +40,9 @@ impl Persister<Sender<WithReplyKey>> for SenderPersister {
 
 pub(crate) struct ReceiverPersister(Arc<Database>);
 impl ReceiverPersister {
-    pub fn new(db: Arc<Database>) -> Self { Self(db) }
+    pub fn new(db: Arc<Database>) -> Self {
+        Self(db)
+    }
 }
 
 impl Persister<Receiver<WithContext>> for ReceiverPersister {

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 mod e2e {
     use std::env;
     use std::path::PathBuf;

--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-_danger-local-https = ["hyper-rustls", "rustls", "tokio-rustls"]
+_manual-tls = ["hyper-rustls", "rustls", "tokio-rustls"]
 
 [dependencies]
 anyhow = "1.0.71"

--- a/payjoin-directory/src/db.rs
+++ b/payjoin-directory/src/db.rs
@@ -42,7 +42,9 @@ impl std::error::Error for Error {
 }
 
 impl From<RedisError> for Error {
-    fn from(value: RedisError) -> Self { Error::Redis(value) }
+    fn from(value: RedisError) -> Self {
+        Error::Redis(value)
+    }
 }
 
 pub(crate) type Result<T> = core::result::Result<T, Error>;
@@ -130,11 +132,12 @@ impl DbPool {
                             }
                         }
                     }
-                    None =>
+                    None => {
                         return Err(RedisError::from((
                             ErrorKind::IoError,
                             "PubSub connection closed",
-                        ))),
+                        )))
+                    }
                 }
             }
         };

--- a/payjoin-directory/src/key_config.rs
+++ b/payjoin-directory/src/key_config.rs
@@ -25,7 +25,9 @@ pub struct ServerKeyConfig {
 }
 
 impl From<ServerKeyConfig> for ohttp::Server {
-    fn from(value: ServerKeyConfig) -> Self { value.server }
+    fn from(value: ServerKeyConfig) -> Self {
+        value.server
+    }
 }
 
 /// Generate a new OHTTP server key configuration
@@ -74,7 +76,9 @@ pub fn read_server_config(dir: &Path) -> Result<ServerKeyConfig> {
 /// Get the path to the key configuration file
 /// For now, default to [KEY_ID].ikm.
 /// In the future this might be able to save multiple keys named by KeyId.
-fn key_path(dir: &Path) -> PathBuf { dir.join(format!("{KEY_ID}.ikm")) }
+fn key_path(dir: &Path) -> PathBuf {
+    dir.join(format!("{KEY_ID}.ikm"))
+}
 
 #[cfg(test)]
 mod tests {

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -37,10 +37,10 @@ const V1_UNAVAILABLE_RES_JSON: &str = r#"{{"errorCode": "unavailable", "message"
 
 mod db;
 
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 pub async fn listen_tcp_with_tls_on_free_port(
     db_host: String,
     timeout: Duration,
@@ -56,7 +56,7 @@ pub async fn listen_tcp_with_tls_on_free_port(
 }
 
 // Helper function to avoid code duplication
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 async fn listen_tcp_with_tls_on_listener(
     listener: tokio::net::TcpListener,
     db_host: String,
@@ -134,7 +134,7 @@ pub async fn listen_tcp(
     Ok(())
 }
 
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 pub async fn listen_tcp_with_tls(
     port: u16,
     db_host: String,
@@ -147,7 +147,7 @@ pub async fn listen_tcp_with_tls(
     listen_tcp_with_tls_on_listener(listener, db_host, timeout, cert_key, ohttp).await
 }
 
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 fn init_tls_acceptor(cert_key: (Vec<u8>, Vec<u8>)) -> Result<tokio_rustls::TlsAcceptor> {
     use rustls::pki_types::{CertificateDer, PrivateKeyDer};
     use rustls::ServerConfig;

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -177,10 +177,12 @@ async fn serve_payjoin_directory(
     let path_segments: Vec<&str> = path.split('/').collect();
     debug!("serve_payjoin_directory: {:?}", &path_segments);
     let mut response = match (parts.method, path_segments.as_slice()) {
-        (Method::POST, ["", ".well-known", "ohttp-gateway"]) =>
-            handle_ohttp_gateway(body, pool, ohttp).await,
-        (Method::GET, ["", ".well-known", "ohttp-gateway"]) =>
-            handle_ohttp_gateway_get(&ohttp, &query).await,
+        (Method::POST, ["", ".well-known", "ohttp-gateway"]) => {
+            handle_ohttp_gateway(body, pool, ohttp).await
+        }
+        (Method::GET, ["", ".well-known", "ohttp-gateway"]) => {
+            handle_ohttp_gateway_get(&ohttp, &query).await
+        }
         (Method::POST, ["", ""]) => handle_ohttp_gateway(body, pool, ohttp).await,
         (Method::GET, ["", "ohttp-keys"]) => get_ohttp_keys(&ohttp).await,
         (Method::POST, ["", id]) => post_fallback_v1(id, query, body, pool).await,
@@ -304,7 +306,9 @@ impl HandlerError {
 }
 
 impl From<hyper::http::Error> for HandlerError {
-    fn from(e: hyper::http::Error) -> Self { HandlerError::InternalServerError(e.into()) }
+    fn from(e: hyper::http::Error) -> Self {
+        HandlerError::InternalServerError(e.into())
+    }
 }
 
 impl From<ShortIdError> for HandlerError {

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["tests"]
 
 [features]
 _test-utils = ["payjoin-test-utils", "tokio", "bitcoind"]
-_danger-local-https = ["payjoin/_danger-local-https"]
+_manual-tls = ["payjoin/_manual-tls"]
 uniffi = ["uniffi/cli", "bitcoin-ffi/default"]
 
 [lib]

--- a/payjoin-ffi/README.md
+++ b/payjoin-ffi/README.md
@@ -39,7 +39,7 @@ The integration tests illustrates and verify integration using bitcoin core and 
 ```shell
 
 # Run the integration test
-cargo test  --package payjoin_ffi --test bdk_integration_test v2_to_v2_full_cycle --features _danger-local-https
+cargo test  --package payjoin_ffi --test bdk_integration_test v2_to_v2_full_cycle --features _manual-tls
 
 
 ```

--- a/payjoin-ffi/contrib/test.sh
+++ b/payjoin-ffi/contrib/test.sh
@@ -4,7 +4,7 @@ set -e
 RUST_VERSION=$(rustc --version | awk '{print $2}')
 
 if [[ ! "$RUST_VERSION" =~ ^1\.63\. ]]; then
-  cargo test --package payjoin-ffi --verbose --features=_danger-local-https,_test-utils
+  cargo test --package payjoin-ffi --verbose --features=_manual-tls,_test-utils
 else
   echo "Skipping payjoin-ffi tests for Rust version $RUST_VERSION (MSRV)"
 fi

--- a/payjoin-ffi/src/io.rs
+++ b/payjoin-ffi/src/io.rs
@@ -42,7 +42,7 @@ pub async fn fetch_ohttp_keys(
 ///   directory stores and forwards payjoin client payloads.
 ///
 /// * `cert_der`: The DER-encoded certificate to use for local HTTPS connections.
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 pub async fn fetch_ohttp_keys_with_cert(
     ohttp_relay: &str,
     payjoin_directory: &str,

--- a/payjoin-ffi/tests/bdk_integration_test.rs
+++ b/payjoin-ffi/tests/bdk_integration_test.rs
@@ -5,7 +5,7 @@ This test suite ensures the soundness of `payjoin_ffi` types. It verifies that t
 
 The tests simulate a full cycle of PayJoin transactions, including wallet initialization, transaction creation, and broadcasting. They cover both v1 and v2 PayJoin protocols, ensuring that the integration with `bdk` and `bitcoind` is seamless and reliable.
 */
-#![cfg(all(feature = "_danger-local-https", feature = "_test-utils", not(feature = "uniffi")))]
+#![cfg(all(feature = "_manual-tls", feature = "_test-utils", not(feature = "uniffi")))]
 
 use std::str::FromStr;
 use std::sync::{Mutex, MutexGuard};
@@ -213,7 +213,7 @@ fn build_original_psbt(
     Ok(psbt)
 }
 
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 mod v2 {
     use std::sync::Arc;
 

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -17,8 +17,8 @@ log = "0.4.7"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 ohttp-relay = { version = "0.0.10", features = ["_test-util"] }
 once_cell = "1.19.0"
-payjoin = { version = "0.23.0", features = ["io", "_danger-local-https"] }
-payjoin-directory = { version = "0.0.2", features = ["_danger-local-https"] }
+payjoin = { version = "0.23.0", features = ["io", "_manual-tls"] }
+payjoin-directory = { version = "0.0.2", features = ["_manual-tls"] }
 rcgen = "0.11"
 rustls = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -79,7 +79,9 @@ impl TestServices {
         })
     }
 
-    pub fn cert(&self) -> Vec<u8> { self.cert.serialize_der().expect("Failed to serialize cert") }
+    pub fn cert(&self) -> Vec<u8> {
+        self.cert.serialize_der().expect("Failed to serialize cert")
+    }
 
     pub fn directory_url(&self) -> Url {
         Url::parse(&format!("https://localhost:{}", self.directory.0)).expect("invalid URL")
@@ -102,7 +104,9 @@ impl TestServices {
         self.ohttp_relay.1.take().expect("ohttp relay handle not found")
     }
 
-    pub fn http_agent(&self) -> Arc<Client> { self.http_agent.clone() }
+    pub fn http_agent(&self) -> Arc<Client> {
+        self.http_agent.clone()
+    }
 
     pub async fn wait_for_services_ready(&self) -> Result<(), &'static str> {
         wait_for_service_ready(self.ohttp_relay_url(), self.http_agent()).await?;

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -43,7 +43,7 @@
 - encode subdirectory IDs in bech32 and other QR optimizations [#417](https://github.com/payjoin/rust-payjoin/pull/417)
 - Upgrade to bitcoin v0.32.5
 - Work around '#' escaping bug in bip21 crate [#373](https://github.com/payjoin/rust-payjoin/pull/373)
-- Hide `_danger-local-https` feature behind `_` prefix so it doesn't show up in docs [#423](https://github.com/payjoin/rust-payjoin/pull/423)
+- Hide `_manual-tls` feature behind `_` prefix so it doesn't show up in docs [#423](https://github.com/payjoin/rust-payjoin/pull/423)
 
 
 ## 0.20.0

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -24,7 +24,7 @@ v1 = ["_core"]
 v2 = ["_core", "bitcoin/serde", "hpke", "dep:http", "bhttp", "ohttp", "url/serde", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
-_danger-local-https = ["reqwest/rustls-tls", "rustls"]
+_manual-tls = ["reqwest/rustls-tls", "rustls"]
 _multiparty = ["v2"]
 
 [dependencies]

--- a/payjoin/src/core/version.rs
+++ b/payjoin/src/core/version.rs
@@ -30,11 +30,15 @@ pub enum Version {
 }
 
 impl fmt::Display for Version {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { (*self as u8).fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (*self as u8).fmt(f)
+    }
 }
 
 impl fmt::Debug for Version {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(self, f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 impl Serialize for Version {

--- a/payjoin/src/directory.rs
+++ b/payjoin/src/directory.rs
@@ -23,8 +23,12 @@ pub const ENCAPSULATED_MESSAGE_BYTES: usize = 8192;
 pub struct ShortId(pub [u8; 8]);
 
 impl ShortId {
-    pub fn as_bytes(&self) -> &[u8] { &self.0 }
-    pub fn as_slice(&self) -> &[u8] { &self.0 }
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 impl std::fmt::Display for ShortId {

--- a/payjoin/src/hpke.rs
+++ b/payjoin/src/hpke.rs
@@ -28,7 +28,9 @@ pub type EncappedKey = <SecpK256HkdfSha256 as hpke::Kem>::EncappedKey;
 pub struct HpkeKeyPair(pub HpkeSecretKey, pub HpkePublicKey);
 
 impl From<HpkeKeyPair> for (HpkeSecretKey, HpkePublicKey) {
-    fn from(value: HpkeKeyPair) -> Self { (value.0, value.1) }
+    fn from(value: HpkeKeyPair) -> Self {
+        (value.0, value.1)
+    }
 }
 
 impl HpkeKeyPair {
@@ -41,8 +43,12 @@ impl HpkeKeyPair {
         let (sk, pk) = <SecpK256HkdfSha256 as hpke::Kem>::gen_keypair(&mut OsRng);
         Self(HpkeSecretKey(sk), HpkePublicKey(pk))
     }
-    pub fn secret_key(&self) -> &HpkeSecretKey { &self.0 }
-    pub fn public_key(&self) -> &HpkePublicKey { &self.1 }
+    pub fn secret_key(&self) -> &HpkeSecretKey {
+        &self.0
+    }
+    pub fn public_key(&self) -> &HpkePublicKey {
+        &self.1
+    }
 }
 
 fn pubkey_from_compressed_bytes(pk_bytes: &[u8]) -> Result<HpkePublicKey, HpkeError> {
@@ -85,7 +91,9 @@ pub struct HpkeSecretKey(pub SecretKey);
 impl Deref for HpkeSecretKey {
     type Target = SecretKey;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl core::fmt::Debug for HpkeSecretKey {
@@ -137,7 +145,9 @@ impl HpkePublicKey {
 impl Deref for HpkePublicKey {
     type Target = PublicKey;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl core::fmt::Debug for HpkePublicKey {
@@ -279,7 +289,9 @@ pub enum HpkeError {
 }
 
 impl From<hpke::HpkeError> for HpkeError {
-    fn from(value: hpke::HpkeError) -> Self { Self::Hpke(value) }
+    fn from(value: hpke::HpkeError) -> Self {
+        Self::Hpke(value)
+    }
 }
 
 impl From<secp256k1::Error> for HpkeError {

--- a/payjoin/src/into_url.rs
+++ b/payjoin/src/into_url.rs
@@ -20,7 +20,9 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Error { Error::ParseError(err) }
+    fn from(err: ParseError) -> Error {
+        Error::ParseError(err)
+    }
 }
 
 type Result<T> = core::result::Result<T, Error>;
@@ -49,9 +51,13 @@ pub trait IntoUrlSealed {
 }
 
 impl IntoUrlSealed for &Url {
-    fn into_url(self) -> Result<Url> { self.clone().into_url() }
+    fn into_url(self) -> Result<Url> {
+        self.clone().into_url()
+    }
 
-    fn as_str(&self) -> &str { self.as_ref() }
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 impl IntoUrlSealed for Url {
@@ -63,25 +69,39 @@ impl IntoUrlSealed for Url {
         }
     }
 
-    fn as_str(&self) -> &str { self.as_ref() }
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 impl IntoUrlSealed for &str {
-    fn into_url(self) -> Result<Url> { Url::parse(self)?.into_url() }
+    fn into_url(self) -> Result<Url> {
+        Url::parse(self)?.into_url()
+    }
 
-    fn as_str(&self) -> &str { self }
+    fn as_str(&self) -> &str {
+        self
+    }
 }
 
 impl IntoUrlSealed for &String {
-    fn into_url(self) -> Result<Url> { (&**self).into_url() }
+    fn into_url(self) -> Result<Url> {
+        (&**self).into_url()
+    }
 
-    fn as_str(&self) -> &str { self.as_ref() }
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 impl IntoUrlSealed for String {
-    fn into_url(self) -> Result<Url> { (&*self).into_url() }
+    fn into_url(self) -> Result<Url> {
+        (&*self).into_url()
+    }
 
-    fn as_str(&self) -> &str { self.as_ref() }
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/payjoin/src/io.rs
+++ b/payjoin/src/io.rs
@@ -35,7 +35,7 @@ pub async fn fetch_ohttp_keys(
 ///   directory stores and forwards payjoin client payloads.
 ///
 /// * `cert_der`: The DER-encoded certificate to use for local HTTPS connections.
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 pub async fn fetch_ohttp_keys_with_cert(
     ohttp_relay: impl IntoUrl,
     payjoin_directory: impl IntoUrl,
@@ -81,7 +81,7 @@ enum InternalErrorInner {
     ParseUrl(crate::into_url::Error),
     Reqwest(reqwest::Error),
     Io(std::io::Error),
-    #[cfg(feature = "_danger-local-https")]
+    #[cfg(feature = "_manual-tls")]
     Rustls(rustls::Error),
     InvalidOhttpKeys(String),
 }
@@ -105,7 +105,7 @@ macro_rules! impl_from_error {
 impl_from_error!(crate::into_url::Error, ParseUrl);
 impl_from_error!(reqwest::Error, Reqwest);
 impl_from_error!(std::io::Error, Io);
-#[cfg(feature = "_danger-local-https")]
+#[cfg(feature = "_manual-tls")]
 impl_from_error!(rustls::Error, Rustls);
 
 impl std::fmt::Display for Error {
@@ -130,7 +130,7 @@ impl std::fmt::Display for InternalErrorInner {
             InvalidOhttpKeys(e) => {
                 write!(f, "Invalid ohttp keys returned from payjoin directory: {e}")
             }
-            #[cfg(feature = "_danger-local-https")]
+            #[cfg(feature = "_manual-tls")]
             Rustls(e) => e.fmt(f),
         }
     }
@@ -154,7 +154,7 @@ impl std::error::Error for InternalErrorInner {
             ParseUrl(e) => Some(e),
             Io(e) => Some(e),
             InvalidOhttpKeys(_) => None,
-            #[cfg(feature = "_danger-local-https")]
+            #[cfg(feature = "_manual-tls")]
             Rustls(e) => Some(e),
         }
     }

--- a/payjoin/src/io.rs
+++ b/payjoin/src/io.rs
@@ -161,11 +161,15 @@ impl std::error::Error for InternalErrorInner {
 }
 
 impl From<InternalError> for Error {
-    fn from(value: InternalError) -> Self { Self::Internal(value) }
+    fn from(value: InternalError) -> Self {
+        Self::Internal(value)
+    }
 }
 
 impl From<InternalErrorInner> for Error {
-    fn from(value: InternalErrorInner) -> Self { Self::Internal(InternalError(value)) }
+    fn from(value: InternalErrorInner) -> Self {
+        Self::Internal(InternalError(value))
+    }
 }
 
 #[cfg(test)]

--- a/payjoin/src/ohttp.rs
+++ b/payjoin/src/ohttp.rs
@@ -151,19 +151,27 @@ pub enum OhttpEncapsulationError {
 }
 
 impl From<http::Error> for OhttpEncapsulationError {
-    fn from(value: http::Error) -> Self { Self::Http(value) }
+    fn from(value: http::Error) -> Self {
+        Self::Http(value)
+    }
 }
 
 impl From<ohttp::Error> for OhttpEncapsulationError {
-    fn from(value: ohttp::Error) -> Self { Self::Ohttp(value) }
+    fn from(value: ohttp::Error) -> Self {
+        Self::Ohttp(value)
+    }
 }
 
 impl From<bhttp::Error> for OhttpEncapsulationError {
-    fn from(value: bhttp::Error) -> Self { Self::Bhttp(value) }
+    fn from(value: bhttp::Error) -> Self {
+        Self::Bhttp(value)
+    }
 }
 
 impl From<url::ParseError> for OhttpEncapsulationError {
-    fn from(value: url::ParseError) -> Self { Self::ParseUrl(value) }
+    fn from(value: url::ParseError) -> Self {
+        Self::ParseUrl(value)
+    }
 }
 
 impl fmt::Display for OhttpEncapsulationError {
@@ -282,11 +290,15 @@ impl Eq for OhttpKeys {}
 impl Deref for OhttpKeys {
     type Target = ohttp::KeyConfig;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl DerefMut for OhttpKeys {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for OhttpKeys {

--- a/payjoin/src/persist.rs
+++ b/payjoin/src/persist.rs
@@ -41,7 +41,9 @@ impl<'de, V: Value> serde::Deserialize<'de> for NoopToken<V> {
 impl<V: Value> Value for NoopToken<V> {
     type Key = V::Key;
 
-    fn key(&self) -> Self::Key { self.0.key() }
+    fn key(&self) -> Self::Key {
+        self.0.key()
+    }
 }
 
 /// A persister that does nothing but store values in memory
@@ -49,15 +51,21 @@ impl<V: Value> Value for NoopToken<V> {
 pub struct NoopPersister;
 
 impl<V: Value> From<V> for NoopToken<V> {
-    fn from(value: V) -> Self { NoopToken(value) }
+    fn from(value: V) -> Self {
+        NoopToken(value)
+    }
 }
 impl<V: Value> Persister<V> for NoopPersister {
     type Token = NoopToken<V>;
     type Error = std::convert::Infallible;
 
-    fn save(&mut self, value: V) -> Result<Self::Token, Self::Error> { Ok(NoopToken(value)) }
+    fn save(&mut self, value: V) -> Result<Self::Token, Self::Error> {
+        Ok(NoopToken(value))
+    }
 
-    fn load(&self, token: Self::Token) -> Result<V, Self::Error> { Ok(token.0) }
+    fn load(&self, token: Self::Token) -> Result<V, Self::Error> {
+        Ok(token.0)
+    }
 }
 
 /// A transition that can result in a state transition, fatal error, transient error, or successfully have no results.
@@ -282,10 +290,14 @@ pub enum Rejection<Event, Err> {
 impl<Event, Err> Rejection<Event, Err> {
     #[inline]
     #[allow(dead_code)]
-    pub fn fatal(event: Event, error: Err) -> Self { Rejection::Fatal(RejectFatal(event, error)) }
+    pub fn fatal(event: Event, error: Err) -> Self {
+        Rejection::Fatal(RejectFatal(event, error))
+    }
     #[inline]
     #[allow(dead_code)]
-    pub fn transient(error: Err) -> Self { Rejection::Transient(RejectTransient(error)) }
+    pub fn transient(error: Err) -> Self {
+        Rejection::Transient(RejectTransient(error))
+    }
 }
 
 /// Represents a fatal rejection of a state transition.
@@ -333,7 +345,9 @@ impl<ApiError: std::error::Error, StorageError: std::error::Error>
     From<InternalPersistedError<ApiError, StorageError>>
     for PersistedError<ApiError, StorageError>
 {
-    fn from(value: InternalPersistedError<ApiError, StorageError>) -> Self { PersistedError(value) }
+    fn from(value: InternalPersistedError<ApiError, StorageError>) -> Self {
+        PersistedError(value)
+    }
 }
 
 impl<ApiError: std::error::Error, StorageError: std::error::Error> std::error::Error
@@ -381,9 +395,13 @@ pub enum OptionalTransitionOutcome<NextState, CurrentState> {
 }
 
 impl<NextState, CurrentState> OptionalTransitionOutcome<NextState, CurrentState> {
-    pub fn is_none(&self) -> bool { matches!(self, OptionalTransitionOutcome::Stasis(_)) }
+    pub fn is_none(&self) -> bool {
+        matches!(self, OptionalTransitionOutcome::Stasis(_))
+    }
 
-    pub fn is_success(&self) -> bool { matches!(self, OptionalTransitionOutcome::Progress(_)) }
+    pub fn is_success(&self) -> bool {
+        matches!(self, OptionalTransitionOutcome::Progress(_))
+    }
 
     pub fn success(&self) -> Option<&NextState> {
         match self {
@@ -508,14 +526,16 @@ trait InternalSessionPersister: SessionPersister {
                     .map_err(|e| InternalPersistedError::Storage(StorageError(e)))?;
                 Ok(OptionalTransitionOutcome::Progress(next_state))
             }
-            Ok(AcceptOptionalTransition::NoResults(current_state)) =>
-                Ok(OptionalTransitionOutcome::Stasis(current_state)),
+            Ok(AcceptOptionalTransition::NoResults(current_state)) => {
+                Ok(OptionalTransitionOutcome::Stasis(current_state))
+            }
             Err(Rejection::Fatal(fatal_rejection)) => {
                 self.handle_fatal_reject(&fatal_rejection)?;
                 Err(InternalPersistedError::Fatal(fatal_rejection.1).into())
             }
-            Err(Rejection::Transient(RejectTransient(err))) =>
-                Err(InternalPersistedError::Transient(err).into()),
+            Err(Rejection::Transient(RejectTransient(err))) => {
+                Err(InternalPersistedError::Transient(err).into())
+            }
         }
     }
 
@@ -591,7 +611,9 @@ pub struct NoopPersisterEvent;
 pub struct NoopSessionPersister<E = NoopPersisterEvent>(std::marker::PhantomData<E>);
 
 impl<E> Default for NoopSessionPersister<E> {
-    fn default() -> Self { Self(std::marker::PhantomData) }
+    fn default() -> Self {
+        Self(std::marker::PhantomData)
+    }
 }
 
 impl<E: 'static> SessionPersister for NoopSessionPersister<E> {
@@ -608,7 +630,9 @@ impl<E: 'static> SessionPersister for NoopSessionPersister<E> {
         Ok(Box::new(std::iter::empty()))
     }
 
-    fn close(&self) -> Result<(), Self::InternalStorageError> { Ok(()) }
+    fn close(&self) -> Result<(), Self::InternalStorageError> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/payjoin/src/psbt/mod.rs
+++ b/payjoin/src/psbt/mod.rs
@@ -45,9 +45,13 @@ pub(crate) trait PsbtExt: Sized {
 }
 
 impl PsbtExt for Psbt {
-    fn inputs_mut(&mut self) -> &mut [psbt::Input] { &mut self.inputs }
+    fn inputs_mut(&mut self) -> &mut [psbt::Input] {
+        &mut self.inputs
+    }
 
-    fn outputs_mut(&mut self) -> &mut [psbt::Output] { &mut self.outputs }
+    fn outputs_mut(&mut self) -> &mut [psbt::Output] {
+        &mut self.outputs
+    }
 
     fn xpub_mut(
         &mut self,
@@ -59,7 +63,9 @@ impl PsbtExt for Psbt {
         &mut self.proprietary
     }
 
-    fn unknown_mut(&mut self) -> &mut BTreeMap<psbt::raw::Key, Vec<u8>> { &mut self.unknown }
+    fn unknown_mut(&mut self) -> &mut BTreeMap<psbt::raw::Key, Vec<u8>> {
+        &mut self.unknown
+    }
 
     fn input_pairs(&self) -> Box<dyn Iterator<Item = InternalInputPair<'_>> + '_> {
         Box::new(
@@ -127,8 +133,9 @@ impl InternalInputPair<'_> {
 
     pub fn validate_utxo(&self) -> Result<(), InternalPsbtInputError> {
         match (&self.psbtin.non_witness_utxo, &self.psbtin.witness_utxo) {
-            (None, None) =>
-                Err(InternalPsbtInputError::PrevTxOut(PrevTxOutError::MissingUtxoInformation)),
+            (None, None) => {
+                Err(InternalPsbtInputError::PrevTxOut(PrevTxOutError::MissingUtxoInformation))
+            }
             (Some(tx), None) if tx.compute_txid() == self.txin.previous_output.txid => tx
                 .output
                 .get::<usize>(self.txin.previous_output.vout.try_into().map_err(|_| {
@@ -197,8 +204,9 @@ impl InternalInputPair<'_> {
                 };
                 match redeem_script {
                     // Nested segwit p2wpkh.
-                    Some(script) if script.is_witness_program() && script.is_p2wpkh() =>
-                        Ok(NESTED_P2WPKH_MAX),
+                    Some(script) if script.is_witness_program() && script.is_p2wpkh() => {
+                        Ok(NESTED_P2WPKH_MAX)
+                    }
                     // Other script or witness program.
                     Some(_) => Err(InputWeightError::NotSupported),
                     // No redeem script provided. Cannot determine the script type.
@@ -274,26 +282,36 @@ impl std::error::Error for InternalPsbtInputError {
 }
 
 impl From<PrevTxOutError> for InternalPsbtInputError {
-    fn from(value: PrevTxOutError) -> Self { InternalPsbtInputError::PrevTxOut(value) }
+    fn from(value: PrevTxOutError) -> Self {
+        InternalPsbtInputError::PrevTxOut(value)
+    }
 }
 
 impl From<AddressTypeError> for InternalPsbtInputError {
-    fn from(value: AddressTypeError) -> Self { Self::AddressType(value) }
+    fn from(value: AddressTypeError) -> Self {
+        Self::AddressType(value)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PsbtInputError(InternalPsbtInputError);
 
 impl From<InternalPsbtInputError> for PsbtInputError {
-    fn from(e: InternalPsbtInputError) -> Self { PsbtInputError(e) }
+    fn from(e: InternalPsbtInputError) -> Self {
+        PsbtInputError(e)
+    }
 }
 
 impl fmt::Display for PsbtInputError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl std::error::Error for PsbtInputError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -309,7 +327,9 @@ impl fmt::Display for PsbtInputsError {
 }
 
 impl std::error::Error for PsbtInputsError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -340,11 +360,15 @@ impl std::error::Error for AddressTypeError {
 }
 
 impl From<PrevTxOutError> for AddressTypeError {
-    fn from(value: PrevTxOutError) -> Self { Self::PrevTxOut(value) }
+    fn from(value: PrevTxOutError) -> Self {
+        Self::PrevTxOut(value)
+    }
 }
 
 impl From<FromScriptError> for AddressTypeError {
-    fn from(value: FromScriptError) -> Self { Self::InvalidScript(value) }
+    fn from(value: FromScriptError) -> Self {
+        Self::InvalidScript(value)
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -374,5 +398,7 @@ impl std::error::Error for InputWeightError {
     }
 }
 impl From<AddressTypeError> for InputWeightError {
-    fn from(value: AddressTypeError) -> Self { Self::AddressType(value) }
+    fn from(value: AddressTypeError) -> Self {
+        Self::AddressType(value)
+    }
 }

--- a/payjoin/src/receive/error.rs
+++ b/payjoin/src/receive/error.rs
@@ -16,7 +16,9 @@ pub enum Error {
 }
 
 impl From<ReplyableError> for Error {
-    fn from(e: ReplyableError) -> Self { Error::ReplyToSender(e) }
+    fn from(e: ReplyableError) -> Self {
+        Error::ReplyToSender(e)
+    }
 }
 
 impl fmt::Display for Error {
@@ -138,7 +140,9 @@ impl error::Error for ReplyableError {
 }
 
 impl From<InternalPayloadError> for ReplyableError {
-    fn from(e: InternalPayloadError) -> Self { ReplyableError::Payload(e.into()) }
+    fn from(e: InternalPayloadError) -> Self {
+        ReplyableError::Payload(e.into())
+    }
 }
 
 /// An error that occurs during validation of the original PSBT payload sent by the sender.
@@ -158,7 +162,9 @@ impl From<InternalPayloadError> for ReplyableError {
 pub struct PayloadError(pub(crate) InternalPayloadError);
 
 impl From<InternalPayloadError> for PayloadError {
-    fn from(value: InternalPayloadError) -> Self { PayloadError(value) }
+    fn from(value: InternalPayloadError) -> Self {
+        PayloadError(value)
+    }
 }
 
 #[derive(Debug)]
@@ -221,8 +227,9 @@ impl From<PayloadError> for JsonReply {
                     JsonReply::new(VersionUnsupported, "This version of payjoin is not supported.")
                         .with_extra("supported", supported_versions_json)
                 }
-                super::optional_parameters::Error::FeeRate =>
-                    JsonReply::new(OriginalPsbtRejected, e),
+                super::optional_parameters::Error::FeeRate => {
+                    JsonReply::new(OriginalPsbtRejected, e)
+                }
             },
         }
     }
@@ -310,7 +317,9 @@ impl fmt::Display for OutputSubstitutionError {
 }
 
 impl From<InternalOutputSubstitutionError> for OutputSubstitutionError {
-    fn from(value: InternalOutputSubstitutionError) -> Self { OutputSubstitutionError(value) }
+    fn from(value: InternalOutputSubstitutionError) -> Self {
+        OutputSubstitutionError(value)
+    }
 }
 
 impl std::error::Error for OutputSubstitutionError {
@@ -349,8 +358,9 @@ impl fmt::Display for SelectionError {
                 f,
                 "Current privacy selection implementation only supports 2-output transactions"
             ),
-            InternalSelectionError::NotFound =>
-                write!(f, "No selection candidates improve privacy"),
+            InternalSelectionError::NotFound => {
+                write!(f, "No selection candidates improve privacy")
+            }
         }
     }
 }
@@ -367,7 +377,9 @@ impl error::Error for SelectionError {
     }
 }
 impl From<InternalSelectionError> for SelectionError {
-    fn from(value: InternalSelectionError) -> Self { SelectionError(value) }
+    fn from(value: InternalSelectionError) -> Self {
+        SelectionError(value)
+    }
 }
 
 /// Error that may occur when input contribution fails.
@@ -386,8 +398,9 @@ pub(crate) enum InternalInputContributionError {
 impl fmt::Display for InputContributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.0 {
-            InternalInputContributionError::ValueTooLow =>
-                write!(f, "Total input value is not enough to cover additional output value"),
+            InternalInputContributionError::ValueTooLow => {
+                write!(f, "Total input value is not enough to cover additional output value")
+            }
         }
     }
 }
@@ -401,5 +414,7 @@ impl error::Error for InputContributionError {
 }
 
 impl From<InternalInputContributionError> for InputContributionError {
-    fn from(value: InternalInputContributionError) -> Self { InputContributionError(value) }
+    fn from(value: InternalInputContributionError) -> Self {
+        InputContributionError(value)
+    }
 }

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -207,7 +207,9 @@ impl InputPair {
 }
 
 impl<'a> From<&'a InputPair> for InternalInputPair<'a> {
-    fn from(pair: &'a InputPair) -> Self { Self { psbtin: &pair.psbtin, txin: &pair.txin } }
+    fn from(pair: &'a InputPair) -> Self {
+        Self { psbtin: &pair.psbtin, txin: &pair.txin }
+    }
 }
 
 /// Validate the payload of a Payjoin request for PSBT and Params sanity

--- a/payjoin/src/receive/multiparty/error.rs
+++ b/payjoin/src/receive/multiparty/error.rs
@@ -47,25 +47,33 @@ impl std::fmt::Display for IdenticalProposalError {
 }
 
 impl From<InternalMultipartyError> for MultipartyError {
-    fn from(e: InternalMultipartyError) -> Self { MultipartyError(e) }
+    fn from(e: InternalMultipartyError) -> Self {
+        MultipartyError(e)
+    }
 }
 
 impl fmt::Display for MultipartyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.0 {
             InternalMultipartyError::NotEnoughProposals => write!(f, "Not enough proposals"),
-            InternalMultipartyError::IdenticalProposals(e) =>
-                write!(f, "More than one identical participant: {e}"),
-            InternalMultipartyError::ProposalVersionNotSupported(v) =>
-                write!(f, "Proposal version not supported: {v}"),
-            InternalMultipartyError::OptimisticMergeNotSupported =>
-                write!(f, "Optimistic merge not supported"),
-            InternalMultipartyError::BitcoinExtractTxError(e) =>
-                write!(f, "Bitcoin extract tx error: {e:?}"),
-            InternalMultipartyError::InputMissingWitnessOrScriptSig =>
-                write!(f, "Input in Finalized Proposal is missing witness or script_sig"),
-            InternalMultipartyError::FailedToCombinePsbts(e) =>
-                write!(f, "Failed to combine psbts: {e:?}"),
+            InternalMultipartyError::IdenticalProposals(e) => {
+                write!(f, "More than one identical participant: {e}")
+            }
+            InternalMultipartyError::ProposalVersionNotSupported(v) => {
+                write!(f, "Proposal version not supported: {v}")
+            }
+            InternalMultipartyError::OptimisticMergeNotSupported => {
+                write!(f, "Optimistic merge not supported")
+            }
+            InternalMultipartyError::BitcoinExtractTxError(e) => {
+                write!(f, "Bitcoin extract tx error: {e:?}")
+            }
+            InternalMultipartyError::InputMissingWitnessOrScriptSig => {
+                write!(f, "Input in Finalized Proposal is missing witness or script_sig")
+            }
+            InternalMultipartyError::FailedToCombinePsbts(e) => {
+                write!(f, "Failed to combine psbts: {e:?}")
+            }
         }
     }
 }

--- a/payjoin/src/receive/multiparty/mod.rs
+++ b/payjoin/src/receive/multiparty/mod.rs
@@ -18,7 +18,9 @@ pub struct UncheckedProposalBuilder {
 }
 
 impl UncheckedProposalBuilder {
-    pub fn new() -> Self { Self { proposals: vec![] } }
+    pub fn new() -> Self {
+        Self { proposals: vec![] }
+    }
 
     pub fn add(
         &mut self,
@@ -220,7 +222,9 @@ impl PayjoinProposal {
             .into_iter()
     }
 
-    pub fn proposal(&self) -> &v1::PayjoinProposal { &self.v1 }
+    pub fn proposal(&self) -> &v1::PayjoinProposal {
+        &self.v1
+    }
 }
 
 /// A multiparty proposal that is ready to be combined into a single psbt
@@ -230,7 +234,9 @@ pub struct FinalizedProposal {
 }
 
 impl FinalizedProposal {
-    pub fn new() -> Self { Self { v2_proposals: vec![] } }
+    pub fn new() -> Self {
+        Self { v2_proposals: vec![] }
+    }
 
     pub fn add(
         &mut self,
@@ -301,7 +307,9 @@ impl FinalizedProposal {
         Ok(agg_psbt)
     }
 
-    pub fn v2(&self) -> &[v2::UncheckedProposal] { &self.v2_proposals }
+    pub fn v2(&self) -> &[v2::UncheckedProposal] {
+        &self.v2_proposals
+    }
 }
 
 #[cfg(test)]

--- a/payjoin/src/receive/optional_parameters.rs
+++ b/payjoin/src/receive/optional_parameters.rs
@@ -52,21 +52,23 @@ impl Params {
 
         for (key, v) in pairs {
             match (key.borrow(), v.borrow()) {
-                ("v", version) =>
+                ("v", version) => {
                     params.v = match version {
                         "1" => Version::One,
                         "2" => Version::Two,
                         _ => return Err(Error::UnknownVersion { supported_versions }),
-                    },
-                ("additionalfeeoutputindex", index) =>
+                    }
+                }
+                ("additionalfeeoutputindex", index) => {
                     additional_fee_output_index = match index.parse::<usize>() {
                         Ok(index) => Some(index),
                         Err(_error) => {
                             warn!("bad `additionalfeeoutputindex` query value '{index}': {_error}");
                             None
                         }
-                    },
-                ("maxadditionalfeecontribution", fee) =>
+                    }
+                }
+                ("maxadditionalfeecontribution", fee) => {
                     max_additional_fee_contribution =
                         match bitcoin::Amount::from_str_in(fee, bitcoin::Denomination::Satoshi) {
                             Ok(contribution) => Some(contribution),
@@ -76,8 +78,9 @@ impl Params {
                             );
                                 None
                             }
-                        },
-                ("minfeerate", fee_rate) =>
+                        }
+                }
+                ("minfeerate", fee_rate) => {
                     params.min_fee_rate = match fee_rate.parse::<f32>() {
                         Ok(fee_rate_sat_per_vb) => {
                             // TODO Parse with serde when rust-bitcoin supports it
@@ -86,13 +89,15 @@ impl Params {
                             FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64)
                         }
                         Err(_) => return Err(Error::FeeRate),
-                    },
-                ("disableoutputsubstitution", v) =>
+                    }
+                }
+                ("disableoutputsubstitution", v) => {
                     params.output_substitution = if v == "true" {
                         OutputSubstitution::Disabled
                     } else {
                         OutputSubstitution::Enabled
-                    },
+                    }
+                }
                 #[cfg(feature = "_multiparty")]
                 ("optimisticmerge", v) => params.optimistic_merge = v == "true",
                 _ => (),
@@ -100,8 +105,9 @@ impl Params {
         }
 
         match (max_additional_fee_contribution, additional_fee_output_index) {
-            (Some(amount), Some(index)) =>
-                params.additional_fee_contribution = Some((amount, index)),
+            (Some(amount), Some(index)) => {
+                params.additional_fee_contribution = Some((amount, index))
+            }
             (Some(_), None) | (None, Some(_)) => {
                 warn!("only one additional-fee parameter specified: {params:?}");
             }
@@ -129,7 +135,9 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -29,11 +29,15 @@ pub(crate) enum InternalRequestError {
 }
 
 impl From<InternalRequestError> for RequestError {
-    fn from(value: InternalRequestError) -> Self { RequestError(value) }
+    fn from(value: InternalRequestError) -> Self {
+        RequestError(value)
+    }
 }
 
 impl From<InternalRequestError> for super::ReplyableError {
-    fn from(e: InternalRequestError) -> Self { super::ReplyableError::V1(e.into()) }
+    fn from(e: InternalRequestError) -> Self {
+        super::ReplyableError::V1(e.into())
+    }
 }
 
 impl From<RequestError> for JsonReply {
@@ -44,8 +48,9 @@ impl From<RequestError> for JsonReply {
             MissingHeader(_)
             | InvalidContentType(_)
             | InvalidContentLength(_)
-            | ContentLengthTooLarge(_) =>
-                JsonReply::new(crate::error_codes::ErrorCode::OriginalPsbtRejected, e),
+            | ContentLengthTooLarge(_) => {
+                JsonReply::new(crate::error_codes::ErrorCode::OriginalPsbtRejected, e)
+            }
         }
     }
 }
@@ -54,11 +59,13 @@ impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.0 {
             InternalRequestError::MissingHeader(header) => write!(f, "Missing header: {header}"),
-            InternalRequestError::InvalidContentType(content_type) =>
-                write!(f, "Invalid content type: {content_type}"),
+            InternalRequestError::InvalidContentType(content_type) => {
+                write!(f, "Invalid content type: {content_type}")
+            }
             InternalRequestError::InvalidContentLength(e) => write!(f, "{e}"),
-            InternalRequestError::ContentLengthTooLarge(length) =>
-                write!(f, "Content length too large: {length}."),
+            InternalRequestError::ContentLengthTooLarge(length) => {
+                write!(f, "Content length too large: {length}.")
+            }
         }
     }
 }

--- a/payjoin/src/receive/v1/exclusive/mod.rs
+++ b/payjoin/src/receive/v1/exclusive/mod.rs
@@ -74,7 +74,9 @@ mod tests {
     }
 
     impl MockHeaders {
-        fn new(length: u64) -> MockHeaders { MockHeaders { length: length.to_string() } }
+        fn new(length: u64) -> MockHeaders {
+            MockHeaders { length: length.to_string() }
+        }
     }
 
     impl Headers for MockHeaders {

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -266,7 +266,9 @@ pub struct WantsOutputs {
 
 impl WantsOutputs {
     /// Whether the receiver is allowed to substitute original outputs or not.
-    pub fn output_substitution(&self) -> OutputSubstitution { self.params.output_substitution }
+    pub fn output_substitution(&self) -> OutputSubstitution {
+        self.params.output_substitution
+    }
 
     /// Substitute the receiver output script with the provided script.
     pub fn substitute_receiver_script(
@@ -780,7 +782,9 @@ impl PayjoinProposal {
     }
 
     /// The Payjoin Proposal PSBT
-    pub fn psbt(&self) -> &Psbt { &self.payjoin_psbt }
+    pub fn psbt(&self) -> &Psbt {
+        &self.payjoin_psbt
+    }
 }
 
 #[cfg(test)]

--- a/payjoin/src/receive/v2/error.rs
+++ b/payjoin/src/receive/v2/error.rs
@@ -14,11 +14,15 @@ use crate::receive::error::Error;
 pub struct SessionError(InternalSessionError);
 
 impl From<InternalSessionError> for SessionError {
-    fn from(value: InternalSessionError) -> Self { SessionError(value) }
+    fn from(value: InternalSessionError) -> Self {
+        SessionError(value)
+    }
 }
 
 impl From<InternalSessionError> for Error {
-    fn from(e: InternalSessionError) -> Self { V2(e.into()) }
+    fn from(e: InternalSessionError) -> Self {
+        V2(e.into())
+    }
 }
 
 #[derive(Debug)]
@@ -42,7 +46,9 @@ impl From<OhttpEncapsulationError> for Error {
 }
 
 impl From<HpkeError> for Error {
-    fn from(e: HpkeError) -> Self { InternalSessionError::Hpke(e).into() }
+    fn from(e: HpkeError) -> Self {
+        InternalSessionError::Hpke(e).into()
+    }
 }
 
 impl fmt::Display for SessionError {

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -139,11 +139,15 @@ pub struct Receiver<State: ReceiverState> {
 impl<State: ReceiverState> core::ops::Deref for Receiver<State> {
     type Target = State;
 
-    fn deref(&self) -> &Self::Target { &self.state }
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
 }
 
 impl<State: ReceiverState> core::ops::DerefMut for Receiver<State> {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.state }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -436,7 +440,9 @@ impl ReceiverState for WantsOutputs {}
 
 impl Receiver<WantsOutputs> {
     /// Whether the receiver is allowed to substitute original outputs or not.
-    pub fn output_substitution(&self) -> OutputSubstitution { self.v1.output_substitution() }
+    pub fn output_substitution(&self) -> OutputSubstitution {
+        self.v1.output_substitution()
+    }
 
     /// Substitute the receiver output script with the provided script.
     pub fn substitute_receiver_script(
@@ -571,7 +577,9 @@ impl PayjoinProposal {
 
 impl Receiver<PayjoinProposal> {
     #[cfg(feature = "_multiparty")]
-    pub(crate) fn new(proposal: PayjoinProposal) -> Self { Receiver { state: proposal } }
+    pub(crate) fn new(proposal: PayjoinProposal) -> Self {
+        Receiver { state: proposal }
+    }
 
     /// The UTXOs that would be spent by this Payjoin transaction
     pub fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
@@ -579,7 +587,9 @@ impl Receiver<PayjoinProposal> {
     }
 
     /// The Payjoin Proposal PSBT
-    pub fn psbt(&self) -> &Psbt { self.v1.psbt() }
+    pub fn psbt(&self) -> &Psbt {
+        self.v1.psbt()
+    }
 
     /// Extract an OHTTP Encapsulated HTTP POST request for the Proposal PSBT
     pub fn extract_req(

--- a/payjoin/src/receive/v2/persist.rs
+++ b/payjoin/src/receive/v2/persist.rs
@@ -9,19 +9,27 @@ use crate::uri::ShortId;
 pub struct ReceiverToken(ShortId);
 
 impl Display for ReceiverToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl From<Receiver<WithContext>> for ReceiverToken {
-    fn from(receiver: Receiver<WithContext>) -> Self { ReceiverToken(receiver.context.id()) }
+    fn from(receiver: Receiver<WithContext>) -> Self {
+        ReceiverToken(receiver.context.id())
+    }
 }
 
 impl AsRef<[u8]> for ReceiverToken {
-    fn as_ref(&self) -> &[u8] { self.0.as_bytes() }
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
 }
 
 impl persist::Value for Receiver<WithContext> {
     type Key = ReceiverToken;
 
-    fn key(&self) -> Self::Key { ReceiverToken(self.context.id()) }
+    fn key(&self) -> Self::Key {
+        ReceiverToken(self.context.id())
+    }
 }

--- a/payjoin/src/send/error.rs
+++ b/payjoin/src/send/error.rs
@@ -32,7 +32,9 @@ pub(crate) enum InternalBuildSenderError {
 }
 
 impl From<InternalBuildSenderError> for BuildSenderError {
-    fn from(value: InternalBuildSenderError) -> Self { BuildSenderError(value) }
+    fn from(value: InternalBuildSenderError) -> Self {
+        BuildSenderError(value)
+    }
 }
 
 impl From<crate::psbt::AddressTypeError> for BuildSenderError {
@@ -102,7 +104,9 @@ pub(crate) enum InternalValidationError {
 }
 
 impl From<InternalValidationError> for ValidationError {
-    fn from(value: InternalValidationError) -> Self { ValidationError(value) }
+    fn from(value: InternalValidationError) -> Self {
+        ValidationError(value)
+    }
 }
 
 impl From<crate::psbt::AddressTypeError> for ValidationError {
@@ -319,11 +323,15 @@ impl std::error::Error for ResponseError {
 }
 
 impl From<WellKnownError> for ResponseError {
-    fn from(value: WellKnownError) -> Self { Self::WellKnown(value) }
+    fn from(value: WellKnownError) -> Self {
+        Self::WellKnown(value)
+    }
 }
 
 impl From<InternalValidationError> for ResponseError {
-    fn from(value: InternalValidationError) -> Self { Self::Validation(ValidationError(value)) }
+    fn from(value: InternalValidationError) -> Self {
+        Self::Validation(ValidationError(value))
+    }
 }
 
 impl From<InternalProposalError> for ResponseError {

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -63,8 +63,9 @@ pub struct PsbtContext {
 macro_rules! check_eq {
     ($proposed:expr, $original:expr, $error:ident) => {
         match ($proposed, $original) {
-            (proposed, original) if proposed != original =>
-                return Err(InternalProposalError::$error { proposed, original }),
+            (proposed, original) if proposed != original => {
+                return Err(InternalProposalError::$error { proposed, original })
+            }
             _ => (),
         }
     };
@@ -380,8 +381,9 @@ fn find_change_index(
 ) -> Result<Option<AdditionalFeeContribution>, InternalBuildSenderError> {
     match (psbt.unsigned_tx.output.len(), clamp_fee_contribution) {
         (0, _) => return Err(InternalBuildSenderError::NoOutputs),
-        (1, false) if psbt.unsigned_tx.output[0].script_pubkey == *payee =>
-            return Err(InternalBuildSenderError::FeeOutputValueLowerThanFeeContribution),
+        (1, false) if psbt.unsigned_tx.output[0].script_pubkey == *payee => {
+            return Err(InternalBuildSenderError::FeeOutputValueLowerThanFeeContribution)
+        }
         (1, true) if psbt.unsigned_tx.output[0].script_pubkey == *payee => return Ok(None),
         (1, _) => return Err(InternalBuildSenderError::MissingPayeeOutput),
         (2, _) => (),
@@ -432,8 +434,9 @@ fn determine_fee_contribution(
 ) -> Result<Option<AdditionalFeeContribution>, InternalBuildSenderError> {
     Ok(match fee_contribution {
         Some((fee, None)) => find_change_index(psbt, payee, fee, clamp_fee_contribution)?,
-        Some((fee, Some(index))) =>
-            Some(check_change_index(psbt, payee, fee, index, clamp_fee_contribution)?),
+        Some((fee, Some(index))) => {
+            Some(check_change_index(psbt, payee, fee, index, clamp_fee_contribution)?)
+        }
         None => None,
     })
 }

--- a/payjoin/src/send/multiparty/error.rs
+++ b/payjoin/src/send/multiparty/error.rs
@@ -21,11 +21,15 @@ pub(crate) enum InternalCreateRequestError {
 }
 
 impl From<InternalCreateRequestError> for CreateRequestError {
-    fn from(value: InternalCreateRequestError) -> Self { CreateRequestError(value) }
+    fn from(value: InternalCreateRequestError) -> Self {
+        CreateRequestError(value)
+    }
 }
 
 impl Display for CreateRequestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
 }
 
 impl std::error::Error for CreateRequestError {
@@ -57,11 +61,15 @@ pub(crate) enum InternalFinalizedError {
 }
 
 impl From<InternalFinalizedError> for FinalizedError {
-    fn from(value: InternalFinalizedError) -> Self { FinalizedError(value) }
+    fn from(value: InternalFinalizedError) -> Self {
+        FinalizedError(value)
+    }
 }
 
 impl Display for FinalizedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
 }
 
 impl std::error::Error for FinalizedError {
@@ -92,11 +100,15 @@ pub(crate) enum InternalFinalizeResponseError {
 }
 
 impl From<InternalFinalizeResponseError> for FinalizeResponseError {
-    fn from(value: InternalFinalizeResponseError) -> Self { FinalizeResponseError(value) }
+    fn from(value: InternalFinalizeResponseError) -> Self {
+        FinalizeResponseError(value)
+    }
 }
 
 impl Display for FinalizeResponseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
 }
 
 impl std::error::Error for FinalizeResponseError {

--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -22,7 +22,9 @@ mod persist;
 pub struct SenderBuilder<'a>(v2::SenderBuilder<'a>);
 
 impl<'a> SenderBuilder<'a> {
-    pub fn new(psbt: Psbt, uri: PjUri<'a>) -> Self { Self(v2::SenderBuilder::new(psbt, uri)) }
+    pub fn new(psbt: Psbt, uri: PjUri<'a>) -> Self {
+        Self(v2::SenderBuilder::new(psbt, uri))
+    }
 
     pub fn build_recommended(self, min_fee_rate: FeeRate) -> Result<NewSender, BuildSenderError> {
         let sender = self.0.build_recommended(min_fee_rate)?;

--- a/payjoin/src/send/multiparty/persist.rs
+++ b/payjoin/src/send/multiparty/persist.rs
@@ -17,7 +17,9 @@ impl NewSender {
 impl persist::Value for Sender {
     type Key = SenderToken;
 
-    fn key(&self) -> Self::Key { SenderToken(self.0.endpoint().clone()) }
+    fn key(&self) -> Self::Key {
+        SenderToken(self.0.endpoint().clone())
+    }
 }
 
 impl Sender {

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -255,7 +255,9 @@ impl Sender {
     }
 
     /// The endpoint in the Payjoin URI
-    pub fn endpoint(&self) -> &Url { &self.endpoint }
+    pub fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
 }
 
 /// Data required to validate the response.

--- a/payjoin/src/send/v2/error.rs
+++ b/payjoin/src/send/v2/error.rs
@@ -30,8 +30,9 @@ impl fmt::Display for CreateRequestError {
             Hpke(e) => write!(f, "v2 error: {e}"),
             OhttpEncapsulation(e) => write!(f, "v2 error: {e}"),
             ParseReceiverPubkey(e) => write!(f, "cannot parse receiver public key: {e}"),
-            MissingOhttpConfig =>
-                write!(f, "no ohttp configuration with which to make a v2 request available"),
+            MissingOhttpConfig => {
+                write!(f, "no ohttp configuration with which to make a v2 request available")
+            }
             Expired(expiry) => write!(f, "session expired at {expiry:?}"),
         }
     }
@@ -53,7 +54,9 @@ impl std::error::Error for CreateRequestError {
 }
 
 impl From<InternalCreateRequestError> for CreateRequestError {
-    fn from(value: InternalCreateRequestError) -> Self { CreateRequestError(value) }
+    fn from(value: InternalCreateRequestError) -> Self {
+        CreateRequestError(value)
+    }
 }
 
 impl From<crate::into_url::Error> for CreateRequestError {
@@ -103,7 +106,9 @@ impl std::error::Error for EncapsulationError {
 }
 
 impl From<InternalEncapsulationError> for EncapsulationError {
-    fn from(value: InternalEncapsulationError) -> Self { EncapsulationError(value) }
+    fn from(value: InternalEncapsulationError) -> Self {
+        EncapsulationError(value)
+    }
 }
 
 impl From<InternalEncapsulationError> for super::ResponseError {

--- a/payjoin/src/send/v2/mod.rs
+++ b/payjoin/src/send/v2/mod.rs
@@ -50,7 +50,9 @@ impl<'a> SenderBuilder<'a> {
     ///
     /// Call [`SenderBuilder::build_recommended()`] or other `build` methods
     /// to create a [`Sender`]
-    pub fn new(psbt: Psbt, uri: PjUri<'a>) -> Self { Self(v1::SenderBuilder::new(psbt, uri)) }
+    pub fn new(psbt: Psbt, uri: PjUri<'a>) -> Self {
+        Self(v1::SenderBuilder::new(psbt, uri))
+    }
 
     /// Disable output substitution even if the receiver didn't.
     ///
@@ -134,11 +136,15 @@ pub struct Sender<State: SenderState> {
 impl<State: SenderState> core::ops::Deref for Sender<State> {
     type Target = State;
 
-    fn deref(&self) -> &Self::Target { &self.state }
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
 }
 
 impl<State: SenderState> core::ops::DerefMut for Sender<State> {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.state }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
 }
 
 /// A new payjoin sender, which must be persisted before initiating the payjoin flow.
@@ -182,7 +188,9 @@ impl Sender<WithReplyKey> {
         persister.load(token).map_err(ImplementationError::from)
     }
     /// Extract serialized V1 Request and Context from a Payjoin Proposal
-    pub fn extract_v1(&self) -> (Request, v1::V1Context) { self.v1.extract_v1() }
+    pub fn extract_v1(&self) -> (Request, v1::V1Context) {
+        self.v1.extract_v1()
+    }
 
     /// Extract serialized Request and Context from a Payjoin Proposal.
     ///
@@ -244,7 +252,9 @@ impl Sender<WithReplyKey> {
     }
 
     /// The endpoint in the Payjoin URI
-    pub fn endpoint(&self) -> &Url { self.v1.endpoint() }
+    pub fn endpoint(&self) -> &Url {
+        self.v1.endpoint()
+    }
 }
 
 pub(crate) fn extract_request(

--- a/payjoin/src/send/v2/persist.rs
+++ b/payjoin/src/send/v2/persist.rs
@@ -10,19 +10,27 @@ use crate::persist::Value;
 pub struct SenderToken(pub(crate) Url);
 
 impl Display for SenderToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl From<Sender<WithReplyKey>> for SenderToken {
-    fn from(sender: Sender<WithReplyKey>) -> Self { SenderToken(sender.endpoint().clone()) }
+    fn from(sender: Sender<WithReplyKey>) -> Self {
+        SenderToken(sender.endpoint().clone())
+    }
 }
 
 impl AsRef<[u8]> for SenderToken {
-    fn as_ref(&self) -> &[u8] { self.0.as_str().as_bytes() }
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_str().as_bytes()
+    }
 }
 
 impl Value for Sender<WithReplyKey> {
     type Key = SenderToken;
 
-    fn key(&self) -> Self::Key { SenderToken(self.endpoint().clone()) }
+    fn key(&self) -> Self::Key {
+        SenderToken(self.endpoint().clone())
+    }
 }

--- a/payjoin/src/uri/error.rs
+++ b/payjoin/src/uri/error.rs
@@ -25,14 +25,17 @@ impl std::fmt::Display for BadEndpointError {
         match self {
             BadEndpointError::UrlParse(e) => write!(f, "Invalid URL: {e:?}"),
             #[cfg(feature = "v2")]
-            BadEndpointError::LowercaseFragment =>
-                write!(f, "Some or all of the fragment is lowercase"),
+            BadEndpointError::LowercaseFragment => {
+                write!(f, "Some or all of the fragment is lowercase")
+            }
         }
     }
 }
 
 impl From<InternalPjParseError> for PjParseError {
-    fn from(value: InternalPjParseError) -> Self { PjParseError(value) }
+    fn from(value: InternalPjParseError) -> Self {
+        PjParseError(value)
+    }
 }
 
 impl std::fmt::Display for PjParseError {

--- a/payjoin/src/uri/mod.rs
+++ b/payjoin/src/uri/mod.rs
@@ -40,8 +40,12 @@ pub struct PayjoinExtras {
 }
 
 impl PayjoinExtras {
-    pub fn endpoint(&self) -> &Url { &self.endpoint }
-    pub fn output_substitution(&self) -> OutputSubstitution { self.output_substitution }
+    pub fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
+    pub fn output_substitution(&self) -> OutputSubstitution {
+        self.output_substitution
+    }
 }
 
 pub type Uri<'a, NetworkValidation> = bitcoin_uri::Uri<'a, NetworkValidation, MaybePayjoinExtras>;
@@ -140,7 +144,9 @@ impl bitcoin_uri::SerializeParams for &PayjoinExtras {
 impl bitcoin_uri::de::DeserializationState<'_> for DeserializationState {
     type Value = MaybePayjoinExtras;
 
-    fn is_param_known(&self, param: &str) -> bool { matches!(param, "pj" | "pjos") }
+    fn is_param_known(&self, param: &str) -> bool {
+        matches!(param, "pj" | "pjos")
+    }
 
     fn deserialize_temp(
         &mut self,
@@ -370,8 +376,9 @@ mod tests {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com&pjos=0";
         let parsed = Uri::try_from(uri).unwrap();
         match parsed.extras {
-            MaybePayjoinExtras::Supported(extras) =>
-                assert_eq!(extras.output_substitution, OutputSubstitution::Disabled),
+            MaybePayjoinExtras::Supported(extras) => {
+                assert_eq!(extras.output_substitution, OutputSubstitution::Disabled)
+            }
             _ => panic!("Expected Supported PayjoinExtras"),
         }
 
@@ -379,8 +386,9 @@ mod tests {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com&pjos=1";
         let parsed = Uri::try_from(uri).unwrap();
         match parsed.extras {
-            MaybePayjoinExtras::Supported(extras) =>
-                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled),
+            MaybePayjoinExtras::Supported(extras) => {
+                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled)
+            }
             _ => panic!("Expected Supported PayjoinExtras"),
         }
 
@@ -388,8 +396,9 @@ mod tests {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com";
         let parsed = Uri::try_from(uri).unwrap();
         match parsed.extras {
-            MaybePayjoinExtras::Supported(extras) =>
-                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled),
+            MaybePayjoinExtras::Supported(extras) => {
+                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled)
+            }
             _ => panic!("Expected Supported PayjoinExtras"),
         }
     }

--- a/payjoin/src/uri/url_ext.rs
+++ b/payjoin/src/uri/url_ext.rs
@@ -57,7 +57,9 @@ impl UrlExt for Url {
     }
 
     /// Set the ohttp parameter in the URL fragment
-    fn set_ohttp(&mut self, ohttp: OhttpKeys) { set_param(self, "OH1", &ohttp.to_string()) }
+    fn set_ohttp(&mut self, ohttp: OhttpKeys) {
+        set_param(self, "OH1", &ohttp.to_string())
+    }
 
     /// Retrieve the exp parameter from the URL fragment
     fn exp(&self) -> Result<std::time::SystemTime, ParseExpParamError> {
@@ -179,8 +181,9 @@ impl std::fmt::Display for ParseExpParamError {
             MissingExp => write!(f, "exp is missing"),
             InvalidHrp(h) => write!(f, "incorrect hrp for exp: {h}"),
             DecodeBech32(d) => write!(f, "exp is not valid bech32: {d}"),
-            InvalidExp(i) =>
-                write!(f, "exp param does not contain a bitcoin consensus encoded u32: {i}"),
+            InvalidExp(i) => {
+                write!(f, "exp param does not contain a bitcoin consensus encoded u32: {i}")
+            }
         }
     }
 }
@@ -203,8 +206,9 @@ impl std::fmt::Display for ParseReceiverPubkeyParamError {
             MissingPubkey => write!(f, "receiver public key is missing"),
             InvalidHrp(h) => write!(f, "incorrect hrp for receiver key: {h}"),
             DecodeBech32(e) => write!(f, "receiver public is not valid base64: {e}"),
-            InvalidPubkey(e) =>
-                write!(f, "receiver public key does not represent a valid pubkey: {e}"),
+            InvalidPubkey(e) => {
+                write!(f, "receiver public key does not represent a valid pubkey: {e}")
+            }
         }
     }
 }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -164,7 +164,7 @@ mod integration {
         }
     }
 
-    #[cfg(all(feature = "io", feature = "v2", feature = "_danger-local-https"))]
+    #[cfg(all(feature = "io", feature = "v2", feature = "_manual-tls"))]
     mod v2 {
         use std::sync::Arc;
         use std::time::Duration;

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -1481,7 +1481,9 @@ mod integration {
     struct HeaderMock(HashMap<String, String>);
 
     impl payjoin::receive::v1::Headers for HeaderMock {
-        fn get_header(&self, key: &str) -> Option<&str> { self.0.get(key).map(|e| e.as_str()) }
+        fn get_header(&self, key: &str) -> Option<&str> {
+            self.0.get(key).map(|e| e.as_str())
+        }
     }
 
     impl HeaderMock {


### PR DESCRIPTION
Hi @benalleng, here is the current changes i've made regarding #729 
you can please refer to the first commit, second commit formatted the codebase.
please review and point me to what needs to be done.

## What’s Changed
- Renamed all occurrences of _danger-local-https to _manual-tls across the codebase.
- Refactored http_agent and related TLS logic:
- http_agent now accepts an optional cert: Option<Vec<u8>> argument.
- Removed reliance on hardcoded local cert file paths (read_local_cert()).
- TLS setup is now explicitly triggered only when _manual-tls is enabled.
- Simplified conditional compilation and removed duplicated code paths.