### PR TITLE
Remove FinalizeResponseError in favor of using FinalizedError

### DIFF
--- a/payjoin/src/send/multiparty/error.rs
+++ b/payjoin/src/send/multiparty/error.rs
@@ -79,33 +79,3 @@ impl std::error::Error for FinalizedError {
         }
     }
 }
-
-#[derive(Debug)]
-pub struct FinalizeResponseError(InternalFinalizeResponseError);
-
-#[derive(Debug)]
-pub(crate) enum InternalFinalizeResponseError {
-    DirectoryResponse(DirectoryResponseError),
-}
-
-impl From<InternalFinalizeResponseError> for FinalizeResponseError {
-    fn from(value: InternalFinalizeResponseError) -> Self { FinalizeResponseError(value) }
-}
-
-impl From<DirectoryResponseError> for FinalizeResponseError {
-    fn from(err: DirectoryResponseError) -> Self {
-        FinalizeResponseError(InternalFinalizeResponseError::DirectoryResponse(err))
-    }
-}
-
-impl Display for FinalizeResponseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:?}", self.0) }
-}
-
-impl std::error::Error for FinalizeResponseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.0 {
-            InternalFinalizeResponseError::DirectoryResponse(e) => Some(e),
-        }
-    }
-}

--- a/payjoin/src/send/multiparty/mod.rs
+++ b/payjoin/src/send/multiparty/mod.rs
@@ -1,7 +1,6 @@
 use bitcoin::{FeeRate, Psbt};
 use error::{
-    CreateRequestError, FinalizeResponseError, FinalizedError, InternalCreateRequestError,
-    InternalFinalizedError,
+    CreateRequestError, FinalizedError, InternalCreateRequestError, InternalFinalizedError,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -192,7 +191,7 @@ impl FinalizeContext {
         self,
         response: &[u8],
         ohttp_ctx: ohttp::ClientResponse,
-    ) -> Result<(), FinalizeResponseError> {
+    ) -> Result<(), FinalizedError> {
         match process_post_res(response, ohttp_ctx) {
             Ok(()) => Ok(()),
             Err(e) => Err(e.into()),


### PR DESCRIPTION
After #745 I realized we can go further and completely remove the `FinalizeResponseError` in favor of using `FinalizedError` which already has access to `DirectoryResponse` errors.