### PR TITLE
Remove MAX_CONTENT_LENGTH, validate content-length with body length

### DIFF
--- a/payjoin/src/receive/v1/exclusive/error.rs
+++ b/payjoin/src/receive/v1/exclusive/error.rs
@@ -24,8 +24,8 @@ pub(crate) enum InternalRequestError {
     InvalidContentType(String),
     /// The Content-Length header could not be parsed as a number
     InvalidContentLength(std::num::ParseIntError),
-    /// The Content-Length value exceeds the maximum allowed size
-    ContentLengthTooLarge(usize),
+    /// The Content-Length value does not match the actual body length
+    ContentLengthMismatch { expected: usize, actual: usize },
 }
 
 impl From<InternalRequestError> for RequestError {
@@ -44,7 +44,7 @@ impl From<&RequestError> for JsonReply {
             MissingHeader(_)
             | InvalidContentType(_)
             | InvalidContentLength(_)
-            | ContentLengthTooLarge(_) =>
+            | ContentLengthMismatch { .. } =>
                 JsonReply::new(crate::error_codes::ErrorCode::OriginalPsbtRejected, e),
         }
     }
@@ -57,8 +57,8 @@ impl fmt::Display for RequestError {
             InternalRequestError::InvalidContentType(content_type) =>
                 write!(f, "Invalid content type: {content_type}"),
             InternalRequestError::InvalidContentLength(e) => write!(f, "{e}"),
-            InternalRequestError::ContentLengthTooLarge(length) =>
-                write!(f, "Content length too large: {length}."),
+            InternalRequestError::ContentLengthMismatch { expected, actual } =>
+                write!(f, "Content length mismatch: expected {expected}, got {actual}."),
         }
     }
 }
@@ -69,7 +69,7 @@ impl error::Error for RequestError {
             InternalRequestError::InvalidContentLength(e) => Some(e),
             InternalRequestError::MissingHeader(_) => None,
             InternalRequestError::InvalidContentType(_) => None,
-            InternalRequestError::ContentLengthTooLarge(_) => None,
+            InternalRequestError::ContentLengthMismatch { .. } => None,
         }
     }
 }


### PR DESCRIPTION
This PR addresses issue #756 by removing the `MAX_CONTENT_LENGTH` check from the v1 receive path.

Instead, the code now validates that the request body length matches the Content-Length header, returning a specific error if there is a mismatch. This change assumes the body is already allocated and within application limits, simplifying validation and improving error reporting.

- Removes `MAX_CONTENT_LENGTH` check from `validate_body`
- Adds a `ContentLengthMismatch` error variant
- Updates test and error handling accordingly

Closes #756.