### PR TITLE
Add `contribute_inputs_with_weights()`

### DIFF
--- a/payjoin/src/psbt/mod.rs
+++ b/payjoin/src/psbt/mod.rs
@@ -215,10 +215,10 @@ impl InternalInputPair {
             P2wsh =>
                 if psbtin.final_script_witness.is_some() {
                     let witness_size = txin.segwit_weight().to_wu() as usize;
-                    Ok(InputWeightPrediction::new(0, &[witness_size]))
+                    Ok(InputWeightPrediction::new(0, [witness_size]))
                 } else if weight > Weight::ZERO {
                     let witness_size = weight.to_wu() as usize;
-                    Ok(InputWeightPrediction::new(0, &[witness_size]))
+                    Ok(InputWeightPrediction::new(0, [witness_size]))
                 } else {
                     Err(InputWeightError::NoWitnessScriptWeight)
                 },

--- a/payjoin/src/psbt/mod.rs
+++ b/payjoin/src/psbt/mod.rs
@@ -10,6 +10,7 @@ use bitcoin::address::FromScriptError;
 use bitcoin::psbt::Psbt;
 use bitcoin::transaction::InputWeightPrediction;
 use bitcoin::{bip32, psbt, Address, AddressType, Network, TxOut, Weight};
+use serde::{Deserialize, Serialize};
 
 use crate::receive::InputPair;
 
@@ -104,7 +105,7 @@ impl PsbtExt for Psbt {
 const NESTED_P2WPKH_MAX: InputWeightPrediction = InputWeightPrediction::from_slice(23, &[72, 33]);
 
 // TODO(arturgontijo): InputPairWithWeight makes more sense...
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct InternalInputPair {
     pub pair: InputPair,
     pub weight: Weight,

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -11,7 +11,9 @@
 
 use std::str::FromStr;
 
-use bitcoin::{psbt, AddressType, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Weight};
+use bitcoin::{
+    psbt, AddressType, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Weight,
+};
 pub(crate) use error::InternalPayloadError;
 pub use error::{
     Error, InputContributionError, JsonReply, OutputSubstitutionError, PayloadError,
@@ -212,7 +214,9 @@ impl From<&InputPair> for InternalInputPair {
 }
 
 impl InternalInputPair {
-    pub fn from_with_weight(pair: &InputPair, weight: Weight) -> Self { Self { pair: pair.clone(), weight } }
+    pub fn from_with_weight(pair: &InputPair, weight: Weight) -> Self {
+        Self { pair: pair.clone(), weight }
+    }
 }
 
 /// Validate the payload of a Payjoin request for PSBT and Params sanity

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -11,7 +11,7 @@
 
 use std::str::FromStr;
 
-use bitcoin::{psbt, AddressType, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
+use bitcoin::{psbt, AddressType, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Weight};
 pub(crate) use error::InternalPayloadError;
 pub use error::{
     Error, InputContributionError, JsonReply, OutputSubstitutionError, PayloadError,
@@ -206,8 +206,8 @@ impl InputPair {
     }
 }
 
-impl<'a> From<&'a InputPair> for InternalInputPair<'a> {
-    fn from(pair: &'a InputPair) -> Self { Self { psbtin: &pair.psbtin, txin: &pair.txin } }
+impl From<&InputPair> for InternalInputPair {
+    fn from(pair: &InputPair) -> Self { Self { pair: pair.clone(), weight: Weight::ZERO } }
 }
 
 /// Validate the payload of a Payjoin request for PSBT and Params sanity

--- a/payjoin/src/receive/mod.rs
+++ b/payjoin/src/receive/mod.rs
@@ -18,6 +18,7 @@ pub use error::{
     ReplyableError, SelectionError,
 };
 use optional_parameters::Params;
+use serde::{Deserialize, Serialize};
 
 pub use crate::psbt::PsbtInputError;
 use crate::psbt::{InternalInputPair, InternalPsbtInputError, PrevTxOutError, PsbtExt};
@@ -40,7 +41,7 @@ pub mod v2;
 
 /// Helper to construct a pair of (txin, psbtin) with some built-in validation
 /// Use with [`InputPair::new`] to contribute receiver inputs.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputPair {
     pub(crate) txin: TxIn,
     pub(crate) psbtin: psbt::Input,
@@ -208,6 +209,10 @@ impl InputPair {
 
 impl From<&InputPair> for InternalInputPair {
     fn from(pair: &InputPair) -> Self { Self { pair: pair.clone(), weight: Weight::ZERO } }
+}
+
+impl InternalInputPair {
+    pub fn from_with_weight(pair: &InputPair, weight: Weight) -> Self { Self { pair: pair.clone(), weight } }
 }
 
 /// Validate the payload of a Payjoin request for PSBT and Params sanity

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -671,7 +671,7 @@ impl ProvisionalProposal {
                 let mut acc = Weight::ZERO;
                 for input_pair in psbt.input_pairs() {
                     let maybe_weight = internal_input_pairs.iter().find(|input| input.pair.txin.previous_output == input_pair.pair.txin.previous_output).map(|input| input.weight);
-                    let input_weight = expected_input_weight(input_pair.address_type().unwrap(), &input_pair.pair.psbtin, maybe_weight)
+                    let input_weight = expected_input_weight(input_pair.address_type().unwrap(), &InternalInputPair { pair: input_pair.pair.clone(), weight: maybe_weight.unwrap_or(Weight::ZERO) })
                         .map_err(InternalPayloadError::InputWeight)?;
                     acc += input_weight;
                 }
@@ -680,7 +680,8 @@ impl ProvisionalProposal {
                 psbt.input_pairs().try_fold(
                     Weight::ZERO,
                     |acc, input_pair| -> Result<Weight, InternalPayloadError> {
-                        let input_weight = expected_input_weight(input_pair.address_type().unwrap(), &input_pair.pair.psbtin, Some(Weight::ZERO))
+                        let input_weight = input_pair
+                            .expected_input_weight()
                             .map_err(InternalPayloadError::InputWeight)?;
                         Ok(acc + input_weight)
                     },

--- a/payjoin/src/receive/v1/mod.rs
+++ b/payjoin/src/receive/v1/mod.rs
@@ -481,7 +481,9 @@ impl WantsInputs {
         self,
         inputs: impl IntoIterator<Item = InputPair>,
     ) -> Result<WantsInputs, InputContributionError> {
-        self._contribute_inputs(inputs.into_iter().map(|input| InternalInputPair::from(&input)).collect())
+        self._contribute_inputs(
+            inputs.into_iter().map(|input| InternalInputPair::from(&input)).collect(),
+        )
     }
 
     pub fn contribute_inputs_with_weights(
@@ -490,7 +492,13 @@ impl WantsInputs {
         input_weights: impl IntoIterator<Item = Weight>,
     ) -> Result<WantsInputs, InputContributionError> {
         let input_weights: Vec<Weight> = input_weights.into_iter().collect();
-        self._contribute_inputs(inputs.into_iter().zip(input_weights).map(|(input, weight)| InternalInputPair::from_with_weight(&input, weight)).collect())
+        self._contribute_inputs(
+            inputs
+                .into_iter()
+                .zip(input_weights)
+                .map(|(input, weight)| InternalInputPair::from_with_weight(&input, weight))
+                .collect(),
+        )
     }
 
     fn _contribute_inputs(
@@ -666,13 +674,18 @@ impl ProvisionalProposal {
 
     /// Calculate the additional input weight contributed by the receiver
     fn additional_input_weight(&self) -> Result<Weight, InternalPayloadError> {
-        fn inputs_weight(psbt: &Psbt, internal_input_pairs: &Option<Vec<InternalInputPair>>) -> Result<Weight, InternalPayloadError> {
+        fn inputs_weight(
+            psbt: &Psbt,
+            internal_input_pairs: &Option<Vec<InternalInputPair>>,
+        ) -> Result<Weight, InternalPayloadError> {
             if let Some(internal_input_pairs) = internal_input_pairs {
                 let mut acc = Weight::ZERO;
                 for input_pair in psbt.input_pairs() {
                     let input_pair = internal_input_pairs
                         .iter()
-                        .find(|input| input.pair.txin.previous_output == input_pair.pair.txin.previous_output)
+                        .find(|input| {
+                            input.pair.txin.previous_output == input_pair.pair.txin.previous_output
+                        })
                         .unwrap_or(&input_pair);
                     let input_weight = input_pair
                         .expected_input_weight()

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::psbt::Psbt;
-use bitcoin::{Address, FeeRate, OutPoint, Script, TxOut};
+use bitcoin::{Address, FeeRate, OutPoint, Script, TxOut, Weight};
 pub(crate) use error::InternalSessionError;
 pub use error::SessionError;
 pub use persist::{ReceiverToken, SessionEvent};
@@ -506,6 +506,15 @@ impl Receiver<WantsInputs> {
         inputs: impl IntoIterator<Item = InputPair>,
     ) -> Result<Self, InputContributionError> {
         let inner = self.state.v1.contribute_inputs(inputs)?;
+        Ok(Receiver { state: WantsInputs { v1: inner, context: self.state.context } })
+    }
+
+    pub fn contribute_inputs_with_weights(
+        self,
+        inputs: impl IntoIterator<Item = InputPair>,
+        input_weights: impl IntoIterator<Item = Weight>,
+    ) -> Result<Self, InputContributionError> {
+        let inner = self.state.v1.contribute_inputs_with_weights(inputs, input_weights)?;
         Ok(Receiver { state: WantsInputs { v1: inner, context: self.state.context } })
     }
 

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -226,9 +226,11 @@ impl PsbtContext {
         for (proposed_txin, proposed_psbtin) in proposal_inputs {
             if let Some(original) = original_inputs.peek() {
                 if proposed_txin.previous_output == original.pair.txin.previous_output {
-                    proposed_psbtin.non_witness_utxo = original.pair.psbtin.non_witness_utxo.clone();
+                    proposed_psbtin.non_witness_utxo =
+                        original.pair.psbtin.non_witness_utxo.clone();
                     proposed_psbtin.witness_utxo = original.pair.psbtin.witness_utxo.clone();
-                    proposed_psbtin.bip32_derivation = original.pair.psbtin.bip32_derivation.clone();
+                    proposed_psbtin.bip32_derivation =
+                        original.pair.psbtin.bip32_derivation.clone();
                     proposed_psbtin.tap_internal_key = original.pair.psbtin.tap_internal_key;
                     proposed_psbtin.tap_key_origins = original.pair.psbtin.tap_key_origins.clone();
                     original_inputs.next();

--- a/payjoin/src/send/mod.rs
+++ b/payjoin/src/send/mod.rs
@@ -158,29 +158,29 @@ impl PsbtContext {
 
         for proposed in proposal.input_pairs() {
             ensure(
-                proposed.psbtin.bip32_derivation.is_empty(),
+                proposed.pair.psbtin.bip32_derivation.is_empty(),
                 InternalProposalError::TxInContainsKeyPaths,
             )?;
             ensure(
-                proposed.psbtin.partial_sigs.is_empty(),
+                proposed.pair.psbtin.partial_sigs.is_empty(),
                 InternalProposalError::ContainsPartialSigs,
             )?;
             match original_inputs.peek() {
                 // our (sender)
                 Some(original)
-                    if proposed.txin.previous_output == original.txin.previous_output =>
+                    if proposed.pair.txin.previous_output == original.pair.txin.previous_output =>
                 {
                     check_eq!(
-                        proposed.txin.sequence,
-                        original.txin.sequence,
+                        proposed.pair.txin.sequence,
+                        original.pair.txin.sequence,
                         SenderTxinSequenceChanged
                     );
                     ensure(
-                        proposed.psbtin.final_script_sig.is_none(),
+                        proposed.pair.psbtin.final_script_sig.is_none(),
                         InternalProposalError::SenderTxinContainsFinalScriptSig,
                     )?;
                     ensure(
-                        proposed.psbtin.final_script_witness.is_none(),
+                        proposed.pair.psbtin.final_script_witness.is_none(),
                         InternalProposalError::SenderTxinContainsFinalScriptWitness,
                     )?;
                     original_inputs.next();
@@ -194,18 +194,18 @@ impl PsbtContext {
                         .ok_or(InternalProposalError::NoInputs)?;
                     // Verify the PSBT input is finalized
                     ensure(
-                        proposed.psbtin.final_script_sig.is_some()
-                            || proposed.psbtin.final_script_witness.is_some(),
+                        proposed.pair.psbtin.final_script_sig.is_some()
+                            || proposed.pair.psbtin.final_script_witness.is_some(),
                         InternalProposalError::ReceiverTxinNotFinalized,
                     )?;
                     // Verify that non_witness_utxo or witness_utxo are filled in.
                     ensure(
-                        proposed.psbtin.witness_utxo.is_some()
-                            || proposed.psbtin.non_witness_utxo.is_some(),
+                        proposed.pair.psbtin.witness_utxo.is_some()
+                            || proposed.pair.psbtin.non_witness_utxo.is_some(),
                         InternalProposalError::ReceiverTxinMissingUtxoInfo,
                     )?;
                     ensure(
-                        proposed.txin.sequence == original.txin.sequence,
+                        proposed.pair.txin.sequence == original.pair.txin.sequence,
                         InternalProposalError::MixedSequence,
                     )?;
                 }
@@ -225,12 +225,12 @@ impl PsbtContext {
 
         for (proposed_txin, proposed_psbtin) in proposal_inputs {
             if let Some(original) = original_inputs.peek() {
-                if proposed_txin.previous_output == original.txin.previous_output {
-                    proposed_psbtin.non_witness_utxo = original.psbtin.non_witness_utxo.clone();
-                    proposed_psbtin.witness_utxo = original.psbtin.witness_utxo.clone();
-                    proposed_psbtin.bip32_derivation = original.psbtin.bip32_derivation.clone();
-                    proposed_psbtin.tap_internal_key = original.psbtin.tap_internal_key;
-                    proposed_psbtin.tap_key_origins = original.psbtin.tap_key_origins.clone();
+                if proposed_txin.previous_output == original.pair.txin.previous_output {
+                    proposed_psbtin.non_witness_utxo = original.pair.psbtin.non_witness_utxo.clone();
+                    proposed_psbtin.witness_utxo = original.pair.psbtin.witness_utxo.clone();
+                    proposed_psbtin.bip32_derivation = original.pair.psbtin.bip32_derivation.clone();
+                    proposed_psbtin.tap_internal_key = original.pair.psbtin.tap_internal_key;
+                    proposed_psbtin.tap_key_origins = original.pair.psbtin.tap_key_origins.clone();
                     original_inputs.next();
                 }
             }

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -51,7 +51,7 @@ pub struct SenderBuilder<'a> {
 /// We only need to add the weight of the txid: 32, index: 4 and sequence: 4 as rust_bitcoin
 /// already accounts for the scriptsig length when calculating InputWeightPrediction
 /// <https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/transaction.rs.html#1621>
-const NON_WITNESS_INPUT_WEIGHT: bitcoin::Weight = Weight::from_non_witness_data_size(32 + 4 + 4);
+pub const NON_WITNESS_INPUT_WEIGHT: bitcoin::Weight = Weight::from_non_witness_data_size(32 + 4 + 4);
 
 impl<'a> SenderBuilder<'a> {
     /// Prepare the context from which to make Sender requests

--- a/payjoin/src/send/v1.rs
+++ b/payjoin/src/send/v1.rs
@@ -51,7 +51,8 @@ pub struct SenderBuilder<'a> {
 /// We only need to add the weight of the txid: 32, index: 4 and sequence: 4 as rust_bitcoin
 /// already accounts for the scriptsig length when calculating InputWeightPrediction
 /// <https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/transaction.rs.html#1621>
-pub const NON_WITNESS_INPUT_WEIGHT: bitcoin::Weight = Weight::from_non_witness_data_size(32 + 4 + 4);
+pub const NON_WITNESS_INPUT_WEIGHT: bitcoin::Weight =
+    Weight::from_non_witness_data_size(32 + 4 + 4);
 
 impl<'a> SenderBuilder<'a> {
     /// Prepare the context from which to make Sender requests


### PR DESCRIPTION
This PR implements a way to applications be able to set the weight of their inputs via `contribute_inputs_with_weights()`.
By doing that we will be able to solve #659 

This PR also unblock the Liana's integration as it deals with P2wsh:
https://github.com/arturgontijo/liana/blob/payjoin-v3/lianad/src/payjoin/receiver.rs#L191-L197

TODO (if high level design is ok):
- [ ] `InternalInputPair` -> `InputPairWithWeight` (or use only a new `InputPair` with the `weight` field)
- [ ] Add tests