### PR TITLE
Session persister mutants

### DIFF
--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -45,7 +45,7 @@ impl<Event, SuccessValue, CurrentState, Err>
         persister.save_maybe_no_results_success_transition(self)
     }
 }
-/// A transition that can result in a state transition, fatal error, transient error, or successfully have no results.
+/// A transition that can result in a state transition, fatal error, or successfully have no results.
 pub struct MaybeFatalTransitionWithNoResults<Event, NextState, CurrentState, Err>(
     Result<AcceptOptionalTransition<Event, NextState, CurrentState>, Rejection<Event, Err>>,
 );
@@ -56,11 +56,6 @@ impl<Event, NextState, CurrentState, Err>
     #[inline]
     pub(crate) fn fatal(event: Event, error: Err) -> Self {
         MaybeFatalTransitionWithNoResults(Err(Rejection::fatal(event, error)))
-    }
-
-    #[inline]
-    pub(crate) fn transient(error: Err) -> Self {
-        MaybeFatalTransitionWithNoResults(Err(Rejection::transient(error)))
     }
 
     #[inline]
@@ -1066,19 +1061,6 @@ mod tests {
                 },
                 test: Box::new(move |persister| {
                     MaybeFatalTransitionWithNoResults::no_results(current_state.clone())
-                        .save(persister)
-                }),
-            },
-            // Transient error
-            TestCase {
-                expected_result: ExpectedResult {
-                    events: vec![],
-                    is_closed: false,
-                    error: Some(InternalPersistedError::Transient(InMemoryTestError {}).into()),
-                    success: None,
-                },
-                test: Box::new(move |persister| {
-                    MaybeFatalTransitionWithNoResults::transient(InMemoryTestError {})
                         .save(persister)
                 }),
             },

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -281,19 +281,11 @@ impl Receiver<Initialized> {
         let current_state = self.clone();
         let proposal = match self.inner_process_res(body, context) {
             Ok(proposal) => proposal,
-            Err(e) => {
-                // Dir and OHTTP related error are transient
-                // Malformities or invalid responses are considered fatal
-                match e {
-                    Error::ReplyToSender(ReplyableError::Implementation(_)) =>
-                        return MaybeFatalTransitionWithNoResults::transient(e),
-                    _ =>
-                        return MaybeFatalTransitionWithNoResults::fatal(
-                            SessionEvent::SessionInvalid(e.to_string(), None),
-                            e,
-                        ),
-                };
-            }
+            Err(e) =>
+                return MaybeFatalTransitionWithNoResults::fatal(
+                    SessionEvent::SessionInvalid(e.to_string(), None),
+                    e,
+                ),
         };
 
         if let Some(proposal) = proposal {


### PR DESCRIPTION
Closes #786 

@0xBEEFCAF3 curious if you have any initial thoughts on catching all of the `MaybeFatalTransition::transient(e)` mutants. Currently all of those match arms are untested at each stage of the receiver.