### PR TITLE
Expose fallback tx off receiver session history

### DIFF
--- a/payjoin-ffi/src/receive/uni.rs
+++ b/payjoin-ffi/src/receive/uni.rs
@@ -126,6 +126,11 @@ impl SessionHistory {
         })
     }
 
+    /// Fallback transaction from the session if present
+    pub fn fallback_tx(&self) -> Option<Arc<crate::Transaction>> {
+        self.0 .0.fallback_tx().map(|tx| Arc::new(tx.into()))
+    }
+
     /// Extract the error request to be posted on the directory if an error occurred.
     /// To process the response, use [process_err_res]
     pub fn extract_err_req(


### PR DESCRIPTION
If a `MaybeInputsOwned` session event is present in the log then we know the session has persisted a "broadcastable" fallback tx by virute of successfully transitioning past `UncheckedProposal` via `check_broadcast_suitability` and persisting the result. This commit explicitly does not use the unchecked session event because the fallback at that typestate may fail consensus or policy checks.

I'm not a fan of the double find_map in `SessionHistory`. We could pub(crate) the v1 psbt on `MaybeInputsOwned` and duplicate a tiny bit of code (`self.psbt.clone().extract_tx_unchecked_fee_rate()`).

 But something else seems a bit off to me. why is `extract_tx_to_schedule_broadcast` is on the unchecked typestate? 
According to Bip77 
>At any point, either party may choose to broadcast the fallback transaction described by the Original PSBT instead of proceeding.

Wouldn't it make more sense for `extract_tx_to_schedule_broadcast` to live on the `MaybeInputsOwned` type state? 

Resolves #798 

