### PR TITLE
Move `extract_fallback_tx` to `MaybeInputsOwned`

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -296,13 +296,13 @@ impl App {
     ) -> Result<PayjoinProposal, ReplyableError> {
         let wallet = self.wallet();
 
-        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-        let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
-
         // Receive Check 1: Can Broadcast
         let proposal =
             proposal.check_broadcast_suitability(None, |tx| Ok(wallet.can_broadcast(tx)?))?;
         log::trace!("check1");
+
+        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
+        let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // Receive Check 2: receiver can't sign for proposal inputs
         let proposal = proposal.check_inputs_not_owned(|input| Ok(wallet.is_mine(input)?))?;

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -342,8 +342,6 @@ impl App {
                 return Err(anyhow!("Interrupted"));
             }
         }?;
-        println!("Fallback transaction received. Consider broadcasting this to get paid if the Payjoin fails:");
-        println!("{}", serialize_hex(&receiver.extract_tx_to_schedule_broadcast()));
         self.check_proposal(receiver, persister).await
     }
 
@@ -357,6 +355,8 @@ impl App {
             .check_broadcast_suitability(None, |tx| Ok(wallet.can_broadcast(tx)?))
             .save(persister)?;
 
+        println!("Fallback transaction received. Consider broadcasting this to get paid if the Payjoin fails:");
+        println!("{}", serialize_hex(&proposal.extract_tx_to_schedule_broadcast()));
         self.check_inputs_not_owned(proposal, persister).await
     }
 

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -331,13 +331,6 @@ impl AssumeInteractiveTransition {
 }
 
 impl UncheckedProposal {
-    ///The Sender’s Original PSBT
-    pub fn extract_tx_to_schedule_broadcast(&self) -> Vec<u8> {
-        payjoin::bitcoin::consensus::encode::serialize(
-            &self.0.clone().extract_tx_to_schedule_broadcast(),
-        )
-    }
-
     pub fn check_broadcast_suitability(
         &self,
         min_fee_rate: Option<u64>,
@@ -413,6 +406,12 @@ impl MaybeInputsOwnedTransition {
 }
 
 impl MaybeInputsOwned {
+    ///The Sender’s Original PSBT
+    pub fn extract_tx_to_schedule_broadcast(&self) -> Vec<u8> {
+        payjoin::bitcoin::consensus::encode::serialize(
+            &self.0.clone().extract_tx_to_schedule_broadcast(),
+        )
+    }
     pub fn check_inputs_not_owned(
         &self,
         is_owned: impl Fn(&Vec<u8>) -> Result<bool, ImplementationError>,

--- a/payjoin-ffi/src/receive/uni.rs
+++ b/payjoin-ffi/src/receive/uni.rs
@@ -343,11 +343,6 @@ impl AssumeInteractiveTransition {
 }
 #[uniffi::export]
 impl UncheckedProposal {
-    /// The Sender’s Original PSBT
-    pub fn extract_tx_to_schedule_broadcast(&self) -> Vec<u8> {
-        self.0.extract_tx_to_schedule_broadcast()
-    }
-
     /// Call after checking that the Original PSBT can be broadcast.
     ///
     /// Receiver MUST check that the Original PSBT from the sender can be broadcast, i.e. testmempoolaccept bitcoind rpc returns { “allowed”: true,.. } for get_transaction_to_check_broadcast() before calling this method.
@@ -418,6 +413,10 @@ impl MaybeInputsOwnedTransition {
 
 #[uniffi::export]
 impl MaybeInputsOwned {
+    /// The Sender’s Original PSBT
+    pub fn extract_tx_to_schedule_broadcast(&self) -> Vec<u8> {
+        self.0.extract_tx_to_schedule_broadcast()
+    }
     ///Check that the Original PSBT has no receiver-owned inputs. Return original-psbt-rejected error or otherwise refuse to sign undesirable inputs.
     /// An attacker could try to spend receiver's own inputs. This check prevents that.
     pub fn check_inputs_not_owned(

--- a/payjoin-ffi/tests/bdk_integration_test.rs
+++ b/payjoin-ffi/tests/bdk_integration_test.rs
@@ -359,15 +359,15 @@ mod v2 {
 
     fn handle_directory_proposal(receiver: Wallet, proposal: UncheckedProposal) -> PayjoinProposal {
         let session_persister = NoopSessionPersister::default();
-        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-        let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
-
         // Receive Check 1: Can Broadcast
         let proposal = proposal
             .assume_interactive_receiver()
             .save(&session_persister)
             .expect("Noop Persister should not fail");
         let receiver = Arc::new(receiver);
+        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
+        let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
+
         // Receive Check 2: receiver can't sign for proposal inputs
         let proposal = proposal
             .check_inputs_not_owned(|script| is_script_owned(&receiver, script.clone()))

--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -426,10 +426,6 @@ impl Receiver<WithContext> {
 /// This type is used to process the request. It is returned by
 /// [`Receiver::process_res()`].
 ///
-/// If you are implementing an interactive payment processor, you should get extract the original
-/// transaction with extract_tx_to_schedule_broadcast() and schedule, followed by checking
-/// that the transaction can be broadcast with check_broadcast_suitability. Otherwise it is safe to
-/// call assume_interactive_receive to proceed with validation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct UncheckedProposal {
     pub(crate) v1: v1::UncheckedProposal,
@@ -439,11 +435,6 @@ pub struct UncheckedProposal {
 impl ReceiverState for UncheckedProposal {}
 
 impl Receiver<UncheckedProposal> {
-    /// The Sender's Original PSBT
-    pub fn extract_tx_to_schedule_broadcast(&self) -> bitcoin::Transaction {
-        self.v1.extract_tx_to_schedule_broadcast()
-    }
-
     /// Call after checking that the Original PSBT can be broadcast.
     ///
     /// Receiver MUST check that the Original PSBT from the sender
@@ -504,6 +495,8 @@ impl Receiver<UncheckedProposal> {
 /// Typestate to validate that the Original PSBT has no receiver-owned inputs.
 ///
 /// Call [`Receiver<MaybeInputsOwned>::check_inputs_not_owned`] to proceed.
+/// If you are implementing an interactive payment processor, you should get extract the original
+/// transaction with extract_tx_to_schedule_broadcast() and schedule
 #[derive(Debug, Clone, PartialEq)]
 pub struct MaybeInputsOwned {
     v1: v1::MaybeInputsOwned,
@@ -513,6 +506,10 @@ pub struct MaybeInputsOwned {
 impl ReceiverState for MaybeInputsOwned {}
 
 impl Receiver<MaybeInputsOwned> {
+    /// The Sender's Original PSBT
+    pub fn extract_tx_to_schedule_broadcast(&self) -> bitcoin::Transaction {
+        self.v1.extract_tx_to_schedule_broadcast()
+    }
     /// Check that the Original PSBT has no receiver-owned inputs.
     /// Return original-psbt-rejected error or otherwise refuse to sign undesirable inputs.
     ///

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -743,8 +743,6 @@ mod integration {
             custom_inputs: Option<Vec<InputPair>>,
         ) -> Result<Receiver<PayjoinProposal>, BoxError> {
             let noop_persister = NoopSessionPersister::default();
-            // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-            let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
             // Receive Check 1: Can Broadcast
             let proposal = proposal
@@ -758,6 +756,9 @@ mod integration {
                         .allowed)
                 })
                 .save(&noop_persister)?;
+
+            // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
+            let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
             // Receive Check 2: receiver can't sign for proposal inputs
             let proposal = proposal
@@ -1377,9 +1378,6 @@ mod integration {
         drain_script: Option<&bitcoin::Script>,
         custom_inputs: Option<Vec<InputPair>>,
     ) -> Result<payjoin::receive::v1::PayjoinProposal, BoxError> {
-        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-        let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
-
         // Receive Check 1: Can Broadcast
         let proposal = proposal.check_broadcast_suitability(None, |tx| {
             Ok(receiver
@@ -1388,6 +1386,8 @@ mod integration {
                 .ok_or(ImplementationError::from("testmempoolaccept should return a result"))?
                 .allowed)
         })?;
+        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
+        let _to_broadcast_in_failure_case = proposal.extract_tx_to_schedule_broadcast();
 
         // Receive Check 2: receiver can't sign for proposal inputs
         let proposal = proposal.check_inputs_not_owned(|input| {


### PR DESCRIPTION
Per BIP-77:

> At any point, either party may choose to broadcast the fallback
> transaction described by the Original PSBT instead of proceeding.

However, the fallback transaction available at the `UncheckedProposal` typestate may not be "broadcastable". Only after transitioning to `MaybeInputsOwned` via `check_broadcast_suitability` can we determine with high confidence that the fallback is valid for broadcast.

Related PR: [#799](https://github.com/payjoin/rust-payjoin/pull/799)