### PR TITLE
Fix import of OutputSubstition in send::v2 test

### DIFF
--- a/payjoin/src/send/v2/session.rs
+++ b/payjoin/src/send/v2/session.rs
@@ -93,9 +93,10 @@ mod tests {
     use payjoin_test_utils::PARSED_ORIGINAL_PSBT;
 
     use super::*;
+    use crate::output_substitution::OutputSubstitution;
     use crate::send::v2::HpkeContext;
     use crate::send::{v1, PsbtContext};
-    use crate::{HpkeKeyPair, OutputSubstitution};
+    use crate::HpkeKeyPair;
 
     #[test]
     fn test_sender_session_event_serialization_roundtrip() {


### PR DESCRIPTION
It is used in v2 tests but only exported at root with `v1` feature

problem line: https://github.com/payjoin/rust-payjoin/blob/b7491be795a3a7d636af6d6da9cd9202414e7293/payjoin/src/send/v2/session.rs#L98