### PR TITLE
Move `JsonReply` to its own session event log

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -473,8 +473,8 @@ async fn handle_recoverable_error(
     ohttp_relay: &payjoin::Url,
     session_history: &SessionHistory,
 ) -> Result<()> {
-    let e = match session_history.terminal_error() {
-        Some((_, Some(e))) => e,
+    let e = match session_history.json_reply() {
+        Some(e) => e,
         _ => return Ok(()),
     };
     let (err_req, err_ctx) = session_history

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -279,7 +279,7 @@ impl Sender<WithReplyKey> {
             Ok(()) => {}
             Err(e) => {
                 return MaybeFatalTransition::fatal(
-                    SessionEvent::SessionInvalid(e.to_string()),
+                    [SessionEvent::SessionInvalid(e.to_string())],
                     InternalEncapsulationError::DirectoryResponse(e).into(),
                 );
             }
@@ -435,7 +435,7 @@ impl Sender<V2GetContext> {
             Ok(None) => return MaybeSuccessTransitionWithNoResults::no_results(self.clone()),
             Err(e) =>
                 return MaybeSuccessTransitionWithNoResults::fatal(
-                    SessionEvent::SessionInvalid(e.to_string()),
+                    [SessionEvent::SessionInvalid(e.to_string())],
                     InternalEncapsulationError::DirectoryResponse(e).into(),
                 ),
         };
@@ -447,7 +447,7 @@ impl Sender<V2GetContext> {
             Ok(psbt) => psbt,
             Err(e) =>
                 return MaybeSuccessTransitionWithNoResults::fatal(
-                    SessionEvent::SessionInvalid(e.to_string()),
+                    [SessionEvent::SessionInvalid(e.to_string())],
                     InternalEncapsulationError::Hpke(e).into(),
                 ),
         };
@@ -455,7 +455,7 @@ impl Sender<V2GetContext> {
             Ok(proposal) => proposal,
             Err(e) =>
                 return MaybeSuccessTransitionWithNoResults::fatal(
-                    SessionEvent::SessionInvalid(e.to_string()),
+                    [SessionEvent::SessionInvalid(e.to_string())],
                     InternalProposalError::Psbt(e).into(),
                 ),
         };
@@ -463,7 +463,7 @@ impl Sender<V2GetContext> {
             Ok(processed_proposal) => processed_proposal,
             Err(e) =>
                 return MaybeSuccessTransitionWithNoResults::fatal(
-                    SessionEvent::SessionInvalid(e.to_string()),
+                    [SessionEvent::SessionInvalid(e.to_string())],
                     e.into(),
                 ),
         };


### PR DESCRIPTION
This commit separates the JSON reply event from the fatal error session event log. Previously, both were combined into a single event. To store them independently, the fatal path in state transition objects now accepts an iterator of session events.