### PR TITLE
Deduplicate payjoin URI creation logic

### DIFF
--- a/payjoin/src/receive/v2/mod.rs
+++ b/payjoin/src/receive/v2/mod.rs
@@ -390,14 +390,7 @@ impl Receiver<Initialized> {
 
     /// Build a V2 Payjoin URI from the receiver's context
     pub fn pj_uri<'a>(&self) -> crate::PjUri<'a> {
-        use crate::uri::{PayjoinExtras, UrlExt};
-        let mut pj = subdir(&self.context.directory, &self.context.id()).clone();
-        pj.set_receiver_pubkey(self.context.s.public_key().clone());
-        pj.set_ohttp(self.context.ohttp_keys.clone());
-        pj.set_exp(self.context.expiry);
-        let extras =
-            PayjoinExtras { endpoint: pj, output_substitution: OutputSubstitution::Enabled };
-        bitcoin_uri::Uri::with_extras(self.context.address.clone(), extras)
+        pj_uri(&self.context, OutputSubstitution::Enabled)
     }
 
     pub(crate) fn apply_unchecked_from_payload(
@@ -906,6 +899,21 @@ fn subdir(directory: &Url, id: &ShortId) -> Url {
         path_segments.push(&id.to_string());
     }
     url
+}
+
+/// Gets the Payjoin URI from a session context
+pub(crate) fn pj_uri<'a>(
+    session_context: &SessionContext,
+    output_substitution: OutputSubstitution,
+) -> crate::PjUri<'a> {
+    use crate::uri::{PayjoinExtras, UrlExt};
+    let id = session_context.id();
+    let mut pj = subdir(&session_context.directory, &id).clone();
+    pj.set_receiver_pubkey(session_context.s.public_key().clone());
+    pj.set_ohttp(session_context.ohttp_keys.clone());
+    pj.set_exp(session_context.expiry);
+    let extras = PayjoinExtras { endpoint: pj, output_substitution };
+    bitcoin_uri::Uri::with_extras(session_context.address.clone(), extras)
 }
 
 #[cfg(test)]

--- a/payjoin/src/receive/v2/session.rs
+++ b/payjoin/src/receive/v2/session.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::{Receiver, ReceiverTypeState, SessionContext, UninitializedReceiver};
 use crate::output_substitution::OutputSubstitution;
 use crate::persist::SessionPersister;
-use crate::receive::v2::{extract_err_req, subdir, SessionError};
+use crate::receive::v2::{extract_err_req, SessionError};
 use crate::receive::{v1, JsonReply};
 use crate::{ImplementationError, IntoUrl, PjUri, Request};
 
@@ -82,20 +82,8 @@ impl SessionHistory {
     /// Receiver session Payjoin URI
     pub fn pj_uri<'a>(&self) -> Option<PjUri<'a>> {
         self.events.iter().find_map(|event| match event {
-            SessionEvent::Created(session_context) => {
-                // TODO this code was copied from ReceiverInitialized::pj_uri. Should be deduped
-                use crate::uri::{PayjoinExtras, UrlExt};
-                let id = session_context.id();
-                let mut pj = subdir(&session_context.directory, &id).clone();
-                pj.set_receiver_pubkey(session_context.s.public_key().clone());
-                pj.set_ohttp(session_context.ohttp_keys.clone());
-                pj.set_exp(session_context.expiry);
-                let extras = PayjoinExtras {
-                    endpoint: pj,
-                    output_substitution: OutputSubstitution::Disabled,
-                };
-                Some(bitcoin_uri::Uri::with_extras(session_context.address.clone(), extras))
-            }
+            SessionEvent::Created(session_context) =>
+                Some(crate::receive::v2::pj_uri(session_context, OutputSubstitution::Disabled)),
             _ => None,
         })
     }


### PR DESCRIPTION
Create a helper function `create_pj_uri` in the v2 module that centralizes the logic for creating Payjoin URIs from a SessionContext. This eliminates code duplication between `SessionHistory::pj_uri` and `Receiver<WithContext>::pj_uri`.

The helper function takes a SessionContext reference and an OutputSubstitution parameter, making it flexible for both use cases while maintaining the same behavior as the original implementations.

This change:
- Improves maintainability by centralizing URI creation logic
- Reduces code duplication
- Preserves the existing API and behavior