### PR TITLE
Add documentation builder to pre-commit hook recommendation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,9 +55,13 @@ set -euo pipefail
 echo "▶  cargo +nightly fmt --check"
 cargo +nightly fmt --all -- --check
 
-# -------- 2. Project-specific linter --------
+# -------- 2.1 Project-specific linter --------
 echo "▶  ./contrib/lint.sh"
 ./contrib/lint.sh
+
+# -------- 2.2 Documentation builder --------
+echo '▶  RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --document-private-items'
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --document-private-items
 
 # -------- 3. Fast local test suite --------
 echo "▶  ./contrib/test_local.sh"


### PR DESCRIPTION
Noticed that the suggested pre-commit hooks in the CONTRIBUTING.md guidelines do not have the documentation building step which does have some checks of it's own. This is ran in the lint CI test, so adding it here as well. 

"2.1" instead of a new 3 since in the CI, it is a part of the linting.