### PR TITLE
Fix PR #812 review issues

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime};
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::psbt::Psbt;
 use bitcoin::{Address, FeeRate, OutPoint, Script, TxOut};
+use bitcoin_uri::Uri;
 pub(crate) use error::InternalSessionError;
 pub use error::SessionError;
 use serde::de::Deserializer;
@@ -909,7 +910,7 @@ pub(crate) fn pj_uri<'a>(
     pj.set_ohttp(session_context.ohttp_keys.clone());
     pj.set_exp(session_context.expiry);
     let extras = PayjoinExtras { endpoint: pj, output_substitution };
-    bitcoin_uri::Uri::with_extras(session_context.address.clone(), extras)
+    Uri::with_extras(session_context.address.clone(), extras)
 }
 
 #[cfg(test)]

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -8,6 +8,7 @@ use crate::persist::SessionPersister;
 use crate::receive::v2::{extract_err_req, SessionError};
 use crate::receive::{v1, JsonReply};
 use crate::{ImplementationError, IntoUrl, PjUri, Request, Version};
+use crate::{ImplementationError, IntoUrl, PjUri, Request, Version};
 
 /// Errors that can occur when replaying a receiver event log
 #[derive(Debug)]
@@ -78,16 +79,11 @@ pub struct SessionHistory {
 impl SessionHistory {
     /// Receiver session Payjoin URI
     pub fn pj_uri<'a>(&self) -> Option<PjUri<'a>> {
-        // Find the session context from Created event
         let session_context = self.events.iter().find_map(|event| match event {
             SessionEvent::Created(session_context) => Some(session_context),
             _ => None,
         })?;
-
-        // Default to enabled output substitution
         let mut output_substitution = OutputSubstitution::Enabled;
-
-        // Check if there's an UncheckedProposal event to determine version
         for event in &self.events {
             if let SessionEvent::UncheckedProposal((unchecked_proposal, _)) = event {
                 // If version is v1, disable output substitution
@@ -97,8 +93,6 @@ impl SessionHistory {
                 break;
             }
         }
-
-        // Generate the URI with the appropriate output substitution setting
         Some(crate::receive::v2::pj_uri(session_context, output_substitution))
     }
 

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -7,7 +7,7 @@ use crate::output_substitution::OutputSubstitution;
 use crate::persist::SessionPersister;
 use crate::receive::v2::{extract_err_req, SessionError};
 use crate::receive::{v1, JsonReply};
-use crate::{ImplementationError, IntoUrl, PjUri, Request};
+use crate::{ImplementationError, IntoUrl, PjUri, Request, Version};
 
 /// Errors that can occur when replaying a receiver event log
 #[derive(Debug)]
@@ -78,11 +78,28 @@ pub struct SessionHistory {
 impl SessionHistory {
     /// Receiver session Payjoin URI
     pub fn pj_uri<'a>(&self) -> Option<PjUri<'a>> {
-        self.events.iter().find_map(|event| match event {
-            SessionEvent::Created(session_context) =>
-                Some(crate::receive::v2::pj_uri(session_context, OutputSubstitution::Disabled)),
+        // Find the session context from Created event
+        let session_context = self.events.iter().find_map(|event| match event {
+            SessionEvent::Created(session_context) => Some(session_context),
             _ => None,
-        })
+        })?;
+
+        // Default to enabled output substitution
+        let mut output_substitution = OutputSubstitution::Enabled;
+
+        // Check if there's an UncheckedProposal event to determine version
+        for event in &self.events {
+            if let SessionEvent::UncheckedProposal((unchecked_proposal, _)) = event {
+                // If version is v1, disable output substitution
+                if unchecked_proposal.params.v == Version::One {
+                    output_substitution = OutputSubstitution::Disabled;
+                }
+                break;
+            }
+        }
+
+        // Generate the URI with the appropriate output substitution setting
+        Some(crate::receive::v2::pj_uri(session_context, output_substitution))
     }
 
     /// Fallback transaction from the session if present


### PR DESCRIPTION

This PR addresses the review comments from @nothingmuch and @0xBEEFCAF3 on PR #812 (Deduplicate payjoin URI creation logic) 
##  Changes Made


* **Import Cleanup**: Add direct import of `bitcoin_uri::Uri` instead of using relative imports  
* **Output Substitution Fix**: Fix output substitution handling to properly default to enabled for v2 and disabled for v1

## Implementation Details

The `pj_uri` function in `SessionHistory` now follows a clearer flow:

1. **Find the session context**: First locates the session context from the Created event in the history
2. **Determine version and set output substitution**: Checks if there's an UncheckedProposal event to determine the protocol version, then sets output substitution to disabled for v1 and enabled for v2
3. **Generate the URI**: Creates the Payjoin URI with the appropriate context and output substitution setting
