### PR TITLE
Shift cargo mutants inclusion files to be within the core module

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 additional_cargo_args = ["--all-features"]
-examine_globs = ["payjoin/src/uri/*.rs", "payjoin/src/receive/**/*.rs", "payjoin/src/send/**/*.rs"]
+examine_globs = ["payjoin/src/core/uri/*.rs", "payjoin/src/core/receive/**/*.rs", "payjoin/src/core/send/**/*.rs"]
 exclude_globs = []
 exclude_re = [
 	"impl Debug",


### PR DESCRIPTION
After #746 was merged a small path discrepancy was created with the core module now being the direct path to all the src modules. This Pr simply adds core/ into the path so that cargo mutants has the correct path to find those modules.