### PR TITLE
Remove to/from json methods on typestates

### DIFF
--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -151,7 +151,6 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             sender_persister = InMemorySenderPersister(1)
             session = self.create_receiver_context(receiver_address, directory, ohttp_keys, recv_persister)
             process_response = await self.process_receiver_proposal(ReceiveSession.INITIALIZED(session), recv_persister, ohttp_relay)
-            print(f"session: {session.to_json()}")
             self.assertIsNone(process_response)
 
             # **********************

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -232,18 +232,6 @@ impl Initialized {
         .pj_uri()
         .into()
     }
-
-    pub fn to_json(&self) -> Result<String, SerdeJsonError> {
-        serde_json::to_string(&self.0).map_err(Into::into)
-    }
-
-    pub fn from_json(json: &str) -> Result<Self, SerdeJsonError> {
-        serde_json::from_str::<payjoin::receive::v2::Receiver<payjoin::receive::v2::Initialized>>(
-            json,
-        )
-        .map_err(Into::into)
-        .map(Into::into)
-    }
 }
 
 #[derive(Clone)]

--- a/payjoin-ffi/src/receive/uni.rs
+++ b/payjoin-ffi/src/receive/uni.rs
@@ -285,13 +285,6 @@ impl Initialized {
     pub fn process_res(&self, body: &[u8], context: Arc<ClientResponse>) -> InitializedTransition {
         InitializedTransition(self.0.process_res(body, &context))
     }
-
-    pub fn to_json(&self) -> Result<String, SerdeJsonError> { self.0.to_json() }
-
-    #[uniffi::constructor]
-    pub fn from_json(json: &str) -> Result<Self, SerdeJsonError> {
-        super::Initialized::from_json(json).map(Into::into)
-    }
 }
 
 #[derive(uniffi::Record)]

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -236,16 +236,6 @@ impl WithReplyKey {
             self.clone().0.process_response(response, post_ctx.into()),
         ))))
     }
-
-    pub fn to_json(&self) -> Result<String, SerdeJsonError> {
-        serde_json::to_string(&self.0).map_err(Into::into)
-    }
-
-    pub fn from_json(json: &str) -> Result<Self, SerdeJsonError> {
-        serde_json::from_str::<payjoin::send::v2::Sender<payjoin::send::v2::WithReplyKey>>(json)
-            .map_err(Into::into)
-            .map(Into::into)
-    }
 }
 
 /// Data required for validation of response.

--- a/payjoin-ffi/src/send/uni.rs
+++ b/payjoin-ffi/src/send/uni.rs
@@ -254,13 +254,6 @@ impl WithReplyKey {
         let post_ctx = guard.take().expect("Value should not be taken");
         WithReplyKeyTransition(self.0.process_response(response, post_ctx.into()))
     }
-
-    pub fn to_json(&self) -> Result<String, SerdeJsonError> { self.0.to_json() }
-
-    #[uniffi::constructor]
-    pub fn from_json(json: &str) -> Result<Self, SerdeJsonError> {
-        super::WithReplyKey::from_json(json).map(Into::into)
-    }
 }
 
 #[derive(uniffi::Record)]


### PR DESCRIPTION
Now that we have proper session peristance in
[0.24](https://github.com/payjoin/rust-payjoin/releases/tag/payjoin-0.24.0) we should remove these one off to/from json method as to descourage devs from creating their own custom peristance strategies.

Resolves https://github.com/payjoin/rust-payjoin/issues/834