### PR TITLE
Introduce metrics Collection via prometheus for payjoin directory

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "hyper-rustls 0.26.0",
  "hyper-util",
  "payjoin",
+ "prometheus",
  "redis",
  "rustls 0.22.4",
  "tempfile",
@@ -2223,6 +2224,27 @@ checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.3",
+ "protobuf",
+ "thiserror 1.0.63",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "hyper-rustls 0.26.0",
  "hyper-util",
  "payjoin",
+ "prometheus",
  "redis",
  "rustls 0.22.4",
  "tempfile",
@@ -2223,6 +2224,27 @@ checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.3",
+ "protobuf",
+ "thiserror 1.0.63",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1.12.0", features = ["full"] }
 tokio-rustls = { version = "0.25", features = ["ring"], default-features = false, optional = true }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+prometheus = "0.13.4"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/payjoin-directory/src/metrics.rs
+++ b/payjoin-directory/src/metrics.rs
@@ -1,0 +1,60 @@
+use prometheus::{Encoder, IntCounter, Registry, TextEncoder};
+
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    /// Total number of connections accepted by the directory
+    pub connections_total: IntCounter,
+    registry: Registry,
+}
+
+impl Default for Metrics {
+    fn default() -> Self { Self::new() }
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let registry = Registry::new();
+        let connections_total =
+            IntCounter::new("connections_total", "Total number of tcp connections")
+                .expect("Failed to create connections_total metrics ");
+
+        registry
+            .register(Box::new(connections_total.clone()))
+            .expect("Failed to register connections_total");
+
+        Self { connections_total, registry }
+    }
+
+    /// Records a new connection
+    pub fn record_connection(&self) { self.connections_total.inc(); }
+
+    pub fn generate_metrics(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let encoder = TextEncoder::new();
+        let all_metrics = self.registry.gather();
+        let mut buffer = Vec::new();
+        encoder.encode(&all_metrics, &mut buffer)?;
+        Ok(String::from_utf8(buffer)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_recording_metrics() {
+        let metrics = Metrics::new();
+        metrics.record_connection();
+
+        let metrics_recorded = metrics.generate_metrics().expect("Failed to generate metrics");
+        assert!(metrics_recorded.contains("connections_total"));
+    }
+
+    #[test]
+    fn does_not_error_on_empty_metrics() {
+        let metrics = Metrics::new();
+        let metrics_recorded = metrics.generate_metrics().expect("Failed to generate metrics");
+        assert!(metrics_recorded.contains("connections_total 0"));
+    }
+}

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -142,7 +142,8 @@ pub async fn init_directory(
 
     println!("Database running on {db_host}");
     let db = payjoin_directory::DbPool::new(timeout, db_host).await?;
-    let service = payjoin_directory::Service::new(db, ohttp_server.into());
+    let metrics = payjoin_directory::metrics::Metrics::new();
+    let service = payjoin_directory::Service::new(db, ohttp_server.into(), metrics);
 
     let listener = bind_free_port().await?;
     let port = listener.local_addr()?.port();


### PR DESCRIPTION
This pr addresses #735 

This PR begins the implementation of a Prometheus-based metrics collection system for Payjoin-directory. In a system like Payjoin-directory, metrics are essential for observability, reliability, and debugging.

A /metrics endpoint is exposed via the control plane to ensure metrics remain available even during disruptive events like DoS attacks.

The design choices are mostly straightforward, but one key consideration is the path normalization function. Without normalization, the system would collect thousands of unique metrics for short dynamic paths (e.g. /abc123, /xyz456), leading to metrics explosion. Normalization ensures similar endpoints are grouped correctly, preserving performance and clarity.

Additional metrics will be instrumented over time based on ongoing discussions [Here](https://github.com/orgs/payjoin/discussions/775)

