### PR TITLE
Remove python-bitcoinlib dependency for ffi

### DIFF
--- a/payjoin-ffi/python/requirements-dev.txt
+++ b/payjoin-ffi/python/requirements-dev.txt
@@ -1,4 +1,3 @@
-python-bitcoinlib==0.12.2
 toml==0.10.2
 yapf==0.43.0
 httpx==0.28.1


### PR DESCRIPTION
We do not have a need for the python-bitcoinlib package as we use it for imports that we already have access to in our payjoin_ffi source.