### PR TITLE
Helper method for optional parameters with docstring

### DIFF
--- a/payjoin/src/core/receive/optional_parameters.rs
+++ b/payjoin/src/core/receive/optional_parameters.rs
@@ -36,6 +36,35 @@ impl Default for Params {
 }
 
 impl Params {
+    /// when only one parameter is present rather than failing the entire payjoin process.
+    ///
+    /// This  allows for graceful degradation and doesn't halt the payjoin process
+    /// due to incomplete optional parameters, while still alerting about the suboptimal
+    /// configuration that prevents fee adjustment capability.
+    ///
+    /// # Arguments
+    /// * `max_additional_fee_contribution` - Optional maximum fee contribution amount
+    /// * `additional_fee_output_index` - Optional index of output to adjust for fees
+    /// * `
+    fn handle_additonal_fee_param(
+        max_additional_fee_contribution: Option<bitcoin::Amount>,
+        additional_fee_output_index: Option<usize>,
+        params: &mut Params,
+    ) {
+        match (max_additional_fee_contribution, additional_fee_output_index) {
+            (Some(amount), Some(index)) => {
+                params.additional_fee_contribution = Some((amount, index));
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                warn!(
+                    "Only one additional-fee parameter specified, proceeding without fee adjustment capability. \
+                     Both maxadditionalfeecontribution and additionalfeeoutputindex must be present for receiver \
+                     to alter sender's output: {params:?}"
+                );
+            }
+            (None, None) => (), // Neither parameter provided, normal case
+        }
+    }
     pub fn from_query_pairs<K, V, I>(
         pairs: I,
         supported_versions: &'static [Version],
@@ -99,14 +128,11 @@ impl Params {
             }
         }
 
-        match (max_additional_fee_contribution, additional_fee_output_index) {
-            (Some(amount), Some(index)) =>
-                params.additional_fee_contribution = Some((amount, index)),
-            (Some(_), None) | (None, Some(_)) => {
-                warn!("only one additional-fee parameter specified: {params:?}");
-            }
-            (None, None) => (),
-        }
+        Self::handle_additonal_fee_param(
+            max_additional_fee_contribution,
+            additional_fee_output_index,
+            &mut params,
+        );
 
         log::debug!("parsed optional parameters: {params:?}");
         Ok(params)


### PR DESCRIPTION
This pr addresess #685 

### summary
in the specs if the both parameter max_additional_fee_contribution and additional_fee_output_index isn't present  then the receiver should not be able to alter sender output https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#optional-parameters 

We follow postel's law here and by implementing a helper method with docstring explaining why we proceed and don't fail in this case .