### PR TITLE
Add python devShell to nix flake

### DIFF
--- a/payjoin-ffi/python/README.md
+++ b/payjoin-ffi/python/README.md
@@ -1,21 +1,28 @@
 # Payjoin
 
-Welcome to the Python language bindings for the [Payjoin Dev Kit](https://payjoindevkit.org/)! Let's get you up and running with some smooth transactions and a sprinkle of fun.
+Welcome to the Python language bindings for the [Payjoin Dev Kit](https://payjoindevkit.org/)!
 
 ## Install from PyPI
 
-Grab the latest release with a simple:
+To grab the latest release:
 
-```shell
+```sh
 pip install payjoin
 ```
 
-## Running Tests
+## Building the Package
 
-Follow these steps to clone the repository and run the tests.
+If you have [nix](https://nixos.org/download/) installed, you can simply run:
 
+```sh
+nix develop .#python
+```
 
-```shell
+This will get you up and running with a shell containing the dependencies you need.
+
+Otherwise, follow these steps to clone the repository and build the package:
+
+```sh
 git clone https://github.com/payjoin/rust-payjoin.git
 cd rust-payjoin/payjoin-ffi/python
 
@@ -24,9 +31,10 @@ python -m venv venv
 source venv/bin/activate
 
 # Install dependencies
+# NOTE: requirements-dev.txt only needed when running tests
 pip install --requirement requirements.txt --requirement requirements-dev.txt
 
-# Generate the bindings (use the script appropriate for your platform)
+# Generate the bindings (use the script appropriate for your platform (linux or macos))
 PYBIN="./venv/bin/" bash ./scripts/generate_<platform>.sh
 
 # Build the wheel
@@ -34,30 +42,21 @@ python setup.py bdist_wheel --verbose
 
 # Force reinstall payjoin
 pip install ./dist/payjoin-<version>.whl --force-reinstall
+```
 
+If all goes well, you should be able to run the Python interpreter and import `payjoin`:
+
+```sh
+python
+import payjoin
+```
+
+## Running Tests
+
+```sh
 # Run all tests
 python -m unittest --verbose
 ```
 
 Note that you'll need Docker to run the integration tests. If you get a "Failed to start container" error, ensure the Docker engine is running on your machine.
 You can [filter which tests](https://docs.python.org/3/library/unittest.html#command-line-interface) to run by passing a file or test name as argument.
-
-## Building the Package
-
-```shell
-# Setup a python virtual environment
-python -m venv venv
-source venv/bin/activate
-
-# Install dependencies
-pip install --requirement requirements.txt
-
-# Generate the bindings (use the script appropriate for your platform)
-PYBIN="./venv/bin/" bash ./scripts/generate_<platform>.sh
-
-# Build the wheel
-python setup.py --verbose bdist_wheel
-
-```
-We hope everything worked smoothly! Now go forth test, and may your test results be as reliable as the Bitcoin blockchain itself!
-₿🔒🤝


### PR DESCRIPTION
Adds a top-level python devShell to the nix flake which creates a python virtual environment with all necessary dependencies installed.

Now, assuming Docker is running and nix is installed on the system, a developer can simply run `nix develop .#python` and have a shell with all the requirements to run `python -m unittest --verbose` setup, or import the `payjoin` package (locally built) to their project.

Addresses [this issue](https://github.com/payjoin/rust-payjoin/issues/457#issuecomment-3009499255) referenced in the nix flake tracking issue.