### PR TITLE
Remove unnecessary payjoin-ffi dependencies

### DIFF
--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -40,14 +40,6 @@ url = "2.5.0"
 [dev-dependencies]
 bdk = { version = "0.29.0", features = ["all-keys", "use-esplora-ureq", "keys-bip39", "rpc"] }
 bitcoincore-rpc = "0.19.0"
-http = "1"
-ohttp-relay = "0.0.8"
-rcgen = { version = "0.11" }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-rustls = "0.22.2"
-testcontainers = "0.15.0"
-testcontainers-modules = { version = "0.1.3", features = ["redis"] }
-uniffi = { version = "0.29.1", features = ["bindgen-tests"] }
 
 [profile.release-smaller]
 inherits = "release"


### PR DESCRIPTION
These are internal rust-payjoin dependencies, not directly needed by payjoin-ffi.