### PR TITLE
Add default directory to payjoin-cli

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -745,6 +745,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1657,7 @@ dependencies = [
  "bitcoincore-rpc",
  "clap",
  "config",
+ "dirs",
  "env_logger",
  "http-body-util",
  "hyper",
@@ -1978,6 +2006,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -745,6 +745,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1657,7 @@ dependencies = [
  "bitcoincore-rpc",
  "clap",
  "config",
+ "dirs",
  "env_logger",
  "http-body-util",
  "hyper",
@@ -1978,6 +2006,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -46,6 +46,7 @@ sled = "0.34"
 tokio = { version = "1.38.1", features = ["full"] }
 tokio-rustls = { version = "0.25", features = ["ring"], default-features = false, optional = true }
 url = { version = "2.3.1", features = ["serde"] }
+dirs = "5"
 
 [dev-dependencies]
 nix = "0.26.4"

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -94,7 +94,10 @@ impl Config {
         ));
     }
 
-    pub(crate) fn new(cli: &Cli) -> Result<Self, ConfigError> {
+    pub(crate) fn new(
+        cli: &Cli,
+        config_path: Option<std::path::PathBuf>,
+    ) -> Result<Self, ConfigError> {
         let mut config = config::Config::builder();
         config = add_bitcoind_defaults(config, cli)?;
         config = add_common_defaults(config, cli)?;
@@ -125,7 +128,11 @@ impl Config {
         }
 
         config = handle_subcommands(config, cli)?;
-        config = config.add_source(File::new("config.toml", FileFormat::Toml).required(false));
+        if let Some(path) = config_path {
+            config = config.add_source(File::from(path).format(FileFormat::Toml).required(true));
+        } else {
+            config = config.add_source(File::new("config.toml", FileFormat::Toml).required(false));
+        }
 
         let built_config = config.build()?;
 

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -1,3 +1,6 @@
+use std::fs;
+use std::path::PathBuf;
+
 use anyhow::Result;
 use app::config::Config;
 use app::App as AppTrait;
@@ -11,12 +14,55 @@ mod db;
 #[cfg(not(any(feature = "v1", feature = "v2")))]
 compile_error!("At least one of the features ['v1', 'v2'] must be enabled");
 
+fn ensure_payjoin_dirs() -> std::io::Result<PathBuf> {
+    let home = dirs::home_dir().expect("Could not determine home directory");
+    let payjoin_dir = home.join(".payjoin");
+    let sender_dir = payjoin_dir.join("sender");
+    let receiver_dir = payjoin_dir.join("receiver");
+    fs::create_dir_all(&sender_dir)?;
+    fs::create_dir_all(&receiver_dir)?;
+    Ok(payjoin_dir)
+}
+
+fn find_config_path(command: &cli::Commands) -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let local_config = cwd.join("config.toml");
+    if local_config.exists() {
+        return Some(local_config);
+    }
+    let home = dirs::home_dir()?;
+    let payjoin_dir = home.join(".payjoin");
+    match command {
+        cli::Commands::Receive { .. } => {
+            let config_path = payjoin_dir.join("receiver").join("config.toml");
+            if config_path.exists() {
+                Some(config_path)
+            } else {
+                None
+            }
+        }
+        cli::Commands::Send { .. } => {
+            let config_path = payjoin_dir.join("sender").join("config.toml");
+            if config_path.exists() {
+                Some(config_path)
+            } else {
+                None
+            }
+        }
+        #[cfg(feature = "v2")]
+        cli::Commands::Resume => None,
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
 
+    ensure_payjoin_dirs().expect("Failed to create ~/.payjoin directory structure");
+
     let cli = Cli::parse();
-    let config = Config::new(&cli)?;
+    let config_path = find_config_path(&cli.command);
+    let config = Config::new(&cli, config_path)?;
 
     #[allow(clippy::if_same_then_else)]
     let app: Box<dyn AppTrait> = if cli.flags.bip78.unwrap_or(false) {


### PR DESCRIPTION
# SUMMARY

Currently Cli looks for a config file in current working  directory where  it is run from . This commit changes that , it first looks in .payjoin  depending on the command run. if its receive , it Looks for config in .payjoin/receiver/config.toml and if it's send , it looks for config in ./payjoin/sender/config.toml, if no configs are seen  it checks the current directory.

It also creates the .payjoin folder on first run . This pr closes #64 

For now the db created as a result of payjoin-cli is stored in current working directory , but once #873  goes in , i'll update that to use the default directory when the --db-path flag isn't specified