### PR TITLE
De-duplicate non-witness data weight const

### DIFF
--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -43,3 +43,11 @@ pub mod io;
 /// 4M block size limit with base64 encoding overhead => maximum reasonable size of content-length
 /// 4_000_000 * 4 / 3 fits in u32
 pub const MAX_CONTENT_LENGTH: usize = 4_000_000 * 4 / 3;
+
+/// Weight of non-witness data in an input. This excludes the weight of the scriptSig and the varint
+/// for the length of the scriptSig.
+/// We only need to add the weight of the txid: 32, index: 4 and sequence: 4 as rust_bitcoin
+/// already accounts for the scriptsig length when calculating InputWeightPrediction
+/// <https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/transaction.rs.html#1621>
+pub(crate) const NON_WITNESS_INPUT_WEIGHT: bitcoin::Weight =
+    bitcoin::Weight::from_non_witness_data_size(32 + 4 + 4);

--- a/payjoin/src/core/psbt/mod.rs
+++ b/payjoin/src/core/psbt/mod.rs
@@ -11,6 +11,8 @@ use bitcoin::psbt::Psbt;
 use bitcoin::transaction::InputWeightPrediction;
 use bitcoin::{bip32, psbt, Address, AddressType, Network, TxIn, TxOut, Weight};
 
+use crate::NON_WITNESS_INPUT_WEIGHT;
+
 #[derive(Debug, PartialEq)]
 pub(crate) enum InconsistentPsbt {
     UnequalInputCounts { tx_ins: usize, psbt_ins: usize },
@@ -214,8 +216,7 @@ impl InternalInputPair<'_> {
             _ => Err(AddressTypeError::UnknownAddressType.into()),
         }?;
 
-        // Lengths of txid, index and sequence: (32, 4, 4).
-        let input_weight = iwp.weight() + Weight::from_non_witness_data_size(32 + 4 + 4);
+        let input_weight = iwp.weight() + NON_WITNESS_INPUT_WEIGHT;
         Ok(input_weight)
     }
 }

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -254,10 +254,7 @@ mod tests {
 
     use super::*;
     use crate::psbt::InternalPsbtInputError::InvalidScriptPubKey;
-
-    // TODO: this is duplicated in a couple places. In these tests, receiver, and the sender.
-    // We should pub(crate) it and moved to a common place.
-    const NON_WITNESS_DATA_WEIGHT: Weight = Weight::from_non_witness_data_size(32 + 4 + 4);
+    use crate::NON_WITNESS_INPUT_WEIGHT;
 
     #[test]
     fn input_pair_with_expected_weight() {
@@ -311,7 +308,7 @@ mod tests {
         assert_eq!(p2pkh_pair.psbtin.non_witness_utxo.unwrap(), utxo);
         assert_eq!(
             p2pkh_pair.expected_weight,
-            InputWeightPrediction::P2PKH_COMPRESSED_MAX.weight() + NON_WITNESS_DATA_WEIGHT
+            InputWeightPrediction::P2PKH_COMPRESSED_MAX.weight() + NON_WITNESS_INPUT_WEIGHT
         );
 
         // Failures
@@ -427,7 +424,7 @@ mod tests {
         assert_eq!(p2wpkh_pair.psbtin.witness_utxo.unwrap(), p2wpkh_txout);
         assert_eq!(
             p2wpkh_pair.expected_weight,
-            InputWeightPrediction::P2WPKH_MAX.weight() + NON_WITNESS_DATA_WEIGHT
+            InputWeightPrediction::P2WPKH_MAX.weight() + NON_WITNESS_INPUT_WEIGHT
         );
 
         let p2sh_txout = TxOut {
@@ -498,7 +495,7 @@ mod tests {
         assert_eq!(p2tr_pair.psbtin.witness_utxo.unwrap(), p2tr_txout);
         assert_eq!(
             p2tr_pair.expected_weight,
-            InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH.weight() + NON_WITNESS_DATA_WEIGHT
+            InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH.weight() + NON_WITNESS_INPUT_WEIGHT
         );
 
         let p2sh_txout = TxOut {

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -22,14 +22,14 @@
 //! wallet and http client.
 
 use bitcoin::psbt::Psbt;
-use bitcoin::{FeeRate, ScriptBuf, Weight};
+use bitcoin::{FeeRate, ScriptBuf};
 use error::{BuildSenderError, InternalBuildSenderError};
 use url::Url;
 
 use super::*;
 pub use crate::output_substitution::OutputSubstitution;
 use crate::psbt::PsbtExt;
-use crate::{PjUri, Request, MAX_CONTENT_LENGTH};
+use crate::{PjUri, Request, MAX_CONTENT_LENGTH, NON_WITNESS_INPUT_WEIGHT};
 
 /// A builder to construct the properties of a `Sender`.
 #[derive(Clone)]
@@ -46,11 +46,6 @@ pub struct SenderBuilder<'a> {
     pub(crate) clamp_fee_contribution: bool,
     pub(crate) min_fee_rate: FeeRate,
 }
-
-/// We only need to add the weight of the txid: 32, index: 4 and sequence: 4 as rust_bitcoin
-/// already accounts for the scriptsig length when calculating InputWeightPrediction
-/// <https://docs.rs/bitcoin/latest/src/bitcoin/blockdata/transaction.rs.html#1621>
-const NON_WITNESS_INPUT_WEIGHT: bitcoin::Weight = Weight::from_non_witness_data_size(32 + 4 + 4);
 
 impl<'a> SenderBuilder<'a> {
     /// Prepare the context from which to make Sender requests


### PR DESCRIPTION
I was hoping to also get rid of the length numbers and replace them with rust bitcoin consts (e.g `bitcoin::Outpoint::SIZE`) but alas those values are private.