### PR TITLE
Add dart github workflow

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,47 @@
+name: Build and Test Dart
+on:
+  pull_request:
+    paths:
+      - payjoin-ffi/**
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: payjoin-ffi/dart
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-13]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate bindings and binaries
+        run: |
+          if [ "${{ matrix.os }}" = "macos-13" ]; then
+            bash ./scripts/generate_macos.sh
+          else
+            bash ./scripts/generate_linux.sh
+          fi
+
+      - name: Run tests
+        # Skip integration test on macOS due to Docker issues
+        run: |
+          if [ "${{ matrix.os }}" = "macos-13" ]; then
+            dart test "test/test_payjoin_unit_test.dart"
+          else
+            dart test
+          fi
+

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,3 @@
-# Copied from [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi/blob/master/.github/workflows/test-python.yaml)
 name: Build and Test Python
 on:
   pull_request:
@@ -7,11 +6,8 @@ on:
 
 jobs:
   build-wheels-and-test:
-    name: "Build and test wheels with Redis"
+    name: "Build and test Linux"
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:7-alpine
     defaults:
       run:
         working-directory: payjoin-ffi/python
@@ -27,10 +23,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: "Install Rust 1.78.0"
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.78.0
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
 
       - name: "Install Python"
         uses: actions/setup-python@v4
@@ -57,8 +51,6 @@ jobs:
         run: pip install ./dist/*.whl
 
       - name: "Run tests"
-        env:
-          REDIS_URL: redis://localhost:6379
         run: python -m unittest -v
 
   build-macos:
@@ -77,18 +69,13 @@ jobs:
         with:
           submodules: true
 
-      - name: "Install Rust 1.78.0"
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.78.0
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
 
       - name: "Install Python"
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Setup Docker on macOS
-        uses: douglascamata/setup-docker-macos-action@v1.0.0
 
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
@@ -103,6 +90,5 @@ jobs:
         run: pip3 install ./dist/*.whl
 
       - name: "Run tests"
-        env:
-          REDIS_URL: redis://localhost:6379
-        run: python3 -m unittest -v
+        # Skip integration test on macOS due to Docker issues
+        run: python3 -m unittest -v test/test_payjoin_unit_test.py

--- a/payjoin-ffi/README.md
+++ b/payjoin-ffi/README.md
@@ -4,34 +4,19 @@ Welcome! This repository creates libraries for various programming languages, al
 
 Our mission is to provide developers with cross-language libraries that seamlessly integrate with different platform languages. By offering support for multiple languages, we aim to enhance the accessibility and usability of Payjoin, empowering developers to incorporate this privacy-enhancing feature into their applications, no matter their preferred programming language.
 
-With a commitment to collaboration and interoperability, this repository strives to foster a more inclusive and diverse ecosystem around Payjoin, contributing to the wider adoption of privacy-focused practices within the Bitcoin community. Join us in our mission to build a more private and secure future for Bitcoin transactions through Payjoin!
-
-**Current Status:**
-This project is in the pre-alpha stage and currently in the design phase. The first language bindings available will be for Python, followed by Swift and Kotlin. Our ultimate goal is to provide Payjoin implementations for Android, iOS, Java, Python, React Native, Flutter, C#, and Golang.
-
 ## Supported Target Languages and Platforms
 
-Each supported language and the platform(s) it's packaged for has its own directory. The Rust code in this project is in the `src` directory and is a wrapper around the [Payjoin Dev Kit] to expose its APIs uniformly using the [mozilla/uniffi-rs] bindings generator for each supported target language.
+Each supported language is in its own directory. The Rust code in this project is in the `src` directory and is a wrapper around the [Payjoin Dev Kit] to expose its APIs uniformly using the [mozilla/uniffi-rs] bindings generator for each supported target language.
 
 The directories below include instructions for using, building, and publishing the native language bindings for [Payjoin Dev Kit] supported by this project.
 
-| Language | Platform              | Published Package | Building Documentation             | API Docs |
-|----------|-----------------------|-------------------|------------------------------------|----------|
-| Python   | linux, macOS | payjoin           | [Readme payjoin](python/README.md) |          |
+| Language | Platform              | Repository | Published Package | 
+|----------|-----------------------|-------------------|------------------------------------|
+| Python   | linux, macOS          | [payjoin-ffi/python](python) | [payjoin](https://pypi.org/project/payjoin/) |
 
 ## Minimum Supported Rust Version (MSRV)
 
 This library should compile with any combination of features with Rust 1.78.0.
-
-## Using the Libraries
-
-### Python
-
-```shell
-pip install payjoin
-
-```
-
 
 ## References
 

--- a/payjoin-ffi/README.md
+++ b/payjoin-ffi/README.md
@@ -13,6 +13,7 @@ The directories below include instructions for using, building, and publishing t
 | Language | Platform              | Repository | Published Package | 
 |----------|-----------------------|-------------------|------------------------------------|
 | Python   | linux, macOS          | [payjoin-ffi/python](python) | [payjoin](https://pypi.org/project/payjoin/) |
+| Dart     | linux, macOS          | [payjoin-ffi/dart](dart)     | N/A |
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/payjoin-ffi/dart/README.md
+++ b/payjoin-ffi/dart/README.md
@@ -1,0 +1,21 @@
+# Payjoin Dart Bindings
+
+Welcome to the Dart language bindings for the [Payjoin Dev Kit](https://payjoindevkit.org/)!
+
+## Running Tests
+
+Follow these steps to clone the repository and run the tests.
+
+
+```shell
+git clone https://github.com/payjoin/rust-payjoin.git
+cd rust-payjoin/payjoin-ffi/dart
+
+# Generate the bindings (use the script appropriate for your platform)
+bash ./scripts/generate_<platform>.sh
+
+# Run all tests
+dart test
+```
+
+Note that you'll need Docker to run the integration tests. If you get a "Failed to start container" error, ensure the Docker engine is running on your machine.

--- a/payjoin-ffi/dart/scripts/generate_linux.sh
+++ b/payjoin-ffi/dart/scripts/generate_linux.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+dart --version
+dart pub get
 LIBNAME=libpayjoin_ffi.so
 LINUX_TARGET=x86_64-unknown-linux-gnu
 

--- a/payjoin-ffi/dart/scripts/generate_macos.sh
+++ b/payjoin-ffi/dart/scripts/generate_macos.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+dart --version
+dart pub get
 LIBNAME=libpayjoin_ffi.dylib
 
 echo "Generating payjoin_ffi.dart..."

--- a/payjoin-ffi/python/README.md
+++ b/payjoin-ffi/python/README.md
@@ -1,6 +1,6 @@
-# Payjoin
+# Payjoin Python Bindings
 
-Welcome to the Python language bindings for the [Payjoin Dev Kit](https://payjoindevkit.org/)! Let's get you up and running with some smooth transactions and a sprinkle of fun.
+Welcome to the Python language bindings for the [Payjoin Dev Kit](https://payjoindevkit.org/)!
 
 ## Install from PyPI
 
@@ -22,9 +22,6 @@ cd rust-payjoin/payjoin-ffi/python
 # Setup a python virtual environment
 python -m venv venv
 source venv/bin/activate
-
-# Install dependencies
-pip install --requirement requirements.txt --requirement requirements-dev.txt
 
 # Generate the bindings (use the script appropriate for your platform)
 PYBIN="./venv/bin/" bash ./scripts/generate_<platform>.sh
@@ -49,9 +46,6 @@ You can [filter which tests](https://docs.python.org/3/library/unittest.html#com
 python -m venv venv
 source venv/bin/activate
 
-# Install dependencies
-pip install --requirement requirements.txt
-
 # Generate the bindings (use the script appropriate for your platform)
 PYBIN="./venv/bin/" bash ./scripts/generate_<platform>.sh
 
@@ -59,5 +53,3 @@ PYBIN="./venv/bin/" bash ./scripts/generate_<platform>.sh
 python setup.py --verbose bdist_wheel
 
 ```
-We hope everything worked smoothly! Now go forth test, and may your test results be as reliable as the Bitcoin blockchain itself!
-₿🔒🤝


### PR DESCRIPTION
This adds Dart tests to CI and updates the READMEs for payoin-ffi. It also fixes inconsistencies in the python CI workflow, and addresses #974 by skipping integration tests on macOS as a workaround until #915 is completed.