### PR TITLE
Cargo mutants version update

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,4 +1,5 @@
 additional_cargo_args = ["--all-features"]
+gitignore = true
 examine_globs = ["payjoin/src/core/uri/*.rs", "payjoin/src/core/receive/**/*.rs", "payjoin/src/core/send/**/*.rs"]
 exclude_globs = []
 exclude_re = [
@@ -12,4 +13,13 @@ exclude_re = [
 	# Receive
 	# src/receive/v1/mod.rs
         "interleave_shuffle", # Replacing index += 1 with index *= 1 in a loop causes a timeout due to an infinite loop
+	"replace > with >= in ProvisionalProposal::apply_fee", # allowing 2 code blocks in this function to run when the additional fee = 0 does nothing
+	"replace < with <= in PsbtContext::check_outputs", # allowing the subtraction of 2 equal values always resulting in a contrib_fee of 0
+	"replace > with >= in PsbtContext::check_fees", # checking if the feerate is below the minimum when the minimum is allowed to be zero does nothing
+	"replace > with >= in Sender<WithReplyKey>::extract_v2", # checking if the system time is equal to the expiry is difficult to reasonably test
+	"replace < with <= in Receiver<Initialized>::apply_unchecked_from_payload", # checking if the system time is equal to the expiry is difficult to reasonably test 
+	"replace > with >= in Receiver<Initialized>::extract_req", # checking if the system time is equal to the expiry is difficult to reasonably test
+	"replace > with >= in extract_err_req", # checking if the system time is equal to the expiry is difficult to reasonably test
+	"replace < with <= in SenderBuilder<'a>::build_recommended", # clamping the fee contribution when the fee equals to the recommended fee does not do anything
+	"replace match guard with true in PsbtContext::check_outputs", # This non-deterministic mutation has a possible test to catch it
 ]

--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants@25.0.1
+          tool: cargo-mutants@25.2.0
       - run: cargo mutants --in-place --no-shuffle
       - uses: actions/upload-artifact@v4
         if: always()

--- a/payjoin/src/core/receive/multiparty/mod.rs
+++ b/payjoin/src/core/receive/multiparty/mod.rs
@@ -356,6 +356,23 @@ mod test {
     }
 
     #[test]
+    fn test_build_multiparty() -> Result<(), BoxError> {
+        let proposal_one = v2::UncheckedProposal {
+            v1: multiparty_proposals()[0].clone(),
+            context: SHARED_CONTEXT.clone(),
+        };
+        let proposal_two = v2::UncheckedProposal {
+            v1: multiparty_proposals()[1].clone(),
+            context: SHARED_CONTEXT_TWO.clone(),
+        };
+        let mut multiparty = UncheckedProposalBuilder::new();
+        multiparty.add(v2::Receiver { state: proposal_one })?;
+        multiparty.add(v2::Receiver { state: proposal_two })?;
+        assert!(multiparty.build().is_ok());
+        Ok(())
+    }
+
+    #[test]
     fn test_duplicate_context_multiparty() -> Result<(), BoxError> {
         let proposal_one = v2::UncheckedProposal {
             v1: multiparty_proposals()[0].clone(),

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -933,6 +933,16 @@ pub(crate) mod test {
             },
             _ => panic!("Broadcast suitability check should fail due to being below the min fee rate or unexpected error type"),
         };
+
+        let min_fee_rate = proposal.psbt_fee_rate().expect("Feerate calculation should not fail");
+        match proposal.clone().check_broadcast_suitability(Some(min_fee_rate), |_| Ok(true)) {
+            Ok(_) => {
+                assert_eq!(proposal.clone().psbt_fee_rate().unwrap(), min_fee_rate)
+            }
+            Err(_) => {
+                panic!("Broadcast suitability check should fail due to being below the min fee rate or unexpected error type")
+            }
+        };
     }
 
     #[test]
@@ -1139,6 +1149,17 @@ pub(crate) mod test {
         let script_pubkey = &wants_outputs.original_psbt.unsigned_tx.output
             [wants_outputs.change_vout]
             .script_pubkey;
+
+        let output_value =
+            wants_outputs.original_psbt.unsigned_tx.output[wants_outputs.change_vout].value;
+        let outputs = vec![TxOut { value: output_value, script_pubkey: script_pubkey.clone() }];
+        let increased_amount =
+            wants_outputs.clone().replace_receiver_outputs(outputs, script_pubkey.as_script());
+        assert!(
+            increased_amount.is_ok(),
+            "Not changing the receiver output amount should always be allowed"
+        );
+        assert_ne!(wants_outputs.payjoin_psbt, increased_amount.unwrap().payjoin_psbt);
 
         let output_value =
             wants_outputs.original_psbt.unsigned_tx.output[wants_outputs.change_vout].value

--- a/payjoin/src/core/send/mod.rs
+++ b/payjoin/src/core/send/mod.rs
@@ -543,6 +543,15 @@ mod test {
             fee_contribution.err(),
             Some(InternalBuildSenderError::FeeOutputValueLowerThanFeeContribution)
         );
+        let fee_contribution = determine_fee_contribution(
+            &PARSED_ORIGINAL_PSBT,
+            Script::from_bytes(&<Vec<u8> as FromHex>::from_hex(
+                "0014b60943f60c3ee848828bdace7474a92e81f3fcdd",
+            )?),
+            Some((Amount::from_sat(95983068), None)),
+            false,
+        );
+        assert!(fee_contribution.is_ok());
         Ok(())
     }
 

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -414,6 +414,7 @@ mod test {
         let fee_contribution = sender.fee_contribution.expect("sender should contribute fees");
         assert_eq!(fee_contribution.max_amount, Amount::from_sat(91));
         assert_eq!(fee_contribution.vout, 0);
+        assert_eq!(NON_WITNESS_INPUT_WEIGHT, bitcoin::Weight::from_wu(160));
         assert_eq!(sender.min_fee_rate, FeeRate::from_sat_per_kwu(250));
         // Ensure the receiver's output substitution preference is respected either way
         let mut pj_uri = pj_uri();
@@ -480,10 +481,12 @@ mod test {
     #[test]
     fn process_response_invalid_utf8() {
         // In UTF-8, 0xF0 represents the start of a 4-byte sequence, so 0xF0 by itself is invalid
-        let invalid_utf8 = &[0xF0];
+        let mut invalid_utf8_padding = PAYJOIN_PROPOSAL.as_bytes().to_vec();
+        invalid_utf8_padding
+            .extend(std::iter::repeat(0).take(MAX_CONTENT_LENGTH - invalid_utf8_padding.len()));
 
         let ctx = create_v1_context();
-        let response = ctx.process_response(invalid_utf8);
+        let response = ctx.process_response(&invalid_utf8_padding);
         match response {
             Ok(_) => panic!("Invalid UTF-8 should have caused an error"),
             Err(error) => match error {


### PR DESCRIPTION
There are still 2 remaining mutants after all of the exclusions I still have todo.
```
Found 444 mutants to test
ok       Unmutated baseline in 32.1s build + 11.9s test
 INFO Auto-set test timeout to 1m
MISSED   payjoin/src/core/receive/v1/mod.rs:519:33: replace > with >= in WantsInputs::avoid_uih in 3.4s build + 28.9s test
444 mutants tested in 13m 52s: 1 missed, 280 caught, 163 unviable
```

The exclusions are catogerized as follows.

- expiry time checks I found not worth creating a test for.
- mutations that allow code to simply skip or follow a code path that does not actually cause or prevent an error
- The non deterministic mutation