### PR TITLE
Enforce nightly rust toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,9 +39,10 @@ jobs:
         uses: actions/checkout@v4
       - name: "Install nightly toolchain"
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
-      - run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: "Run formatting check"
         run: cargo fmt --all -- --check
   
@@ -52,9 +53,10 @@ jobs:
         uses: actions/checkout@v4
       - name: "Install nightly toolchain"
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
-      - run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: "Run formatting check"
         run: cd payjoin-ffi && cargo fmt --all -- --check
   
@@ -65,9 +67,10 @@ jobs:
         uses: actions/checkout@v4
       - name: "Install nightly toolchain"
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
-      - run: rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
       - name: "Run linting check"
         run: cd payjoin-ffi && bash contrib/lint.sh
 
@@ -78,10 +81,10 @@ jobs:
         uses: actions/checkout@v4
       - name: "Install nightly toolchain"
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
-      - name: "Install clippy"
-        run: rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
       - name: "Run code linting"
         run: bash contrib/lint.sh
       - name: "Run documentation linting"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,13 +12,20 @@ jobs:
           - 1.63.0 # MSRV
           - stable
           - nightly
+    env:
+      # Override the value from the rust-toolchain file
+      # This is necessary because even though the correct toolchain
+      # is explicitly specified for the rust-toolchain action,
+      # rustup honors the rust-toolchain file over the default
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
       - name: "Install ${{ matrix.rust }} toolchain"
-        # https://github.com/dtolnay/rust-toolchain?tab=readme-ov-file#inputs
         uses: dtolnay/rust-toolchain@master
         with:
+          # The toolchain must be specified manually, as this action ignores the rust-toolchain override
+          # https://github.com/dtolnay/rust-toolchain?tab=readme-ov-file#inputs
           toolchain: ${{ matrix.rust }}
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
@@ -85,11 +92,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+      # Override the value from the rust-toolchain file
+      # This is necessary because even though the correct toolchain
+      # is explicitly specified for the rust-toolchain action,
+      # rustup honors the rust-toolchain file over the default
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
       - name: "Install toolchain"
-        # https://github.com/dtolnay/rust-toolchain
+        # rust-cache usage with stable Rust is most effective, as a cache is tied to the Rust version
         uses: dtolnay/rust-toolchain@stable
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-analyzer", "rust-src"]


### PR DESCRIPTION
We use the nightly rust toolchain for formatting and linting checks, but this is easy to miss or forget for new contributors. This change automatically enforces nightly project-wide.