### PR TITLE
Add Feature Request, Good First Issue, and General Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest an idea for this project.
+labels: [Feature]
+body:
+  - type: dropdown
+    attributes:
+      label: Which crate is this feature request for?
+      multiple: true
+      options:
+        - payjoin
+        - payjoin-cli
+        - payjoin-directory
+        - payjoin-test-utils
+        - payjoin-ffi
+  - type: textarea
+    id: feature
+    attributes:
+      label: Please describe the feature you'd like to see added.
+      description: Attach screenshots or logs if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: related-problem
+    attributes:
+      label: Is your feature related to a problem, if so please describe it.
+      description: Attach screenshots or logs if applicable.
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe any alternatives you've considered
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Please leave any additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,20 @@
+name: General Question / Support
+description: A general question or support issue that isn't a bug or feature.
+body:
+  - type: dropdown
+    attributes:
+      label: Which crate is this feature request for (if any)?
+      multiple: true
+      options:
+        - payjoin
+        - payjoin-cli
+        - payjoin-directory
+        - payjoin-test-utils
+        - payjoin-ffi
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Describe the issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/good-first-issue.yml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.yml
@@ -1,0 +1,49 @@
+name: Good First Issue
+description: (Regular devs only) Suggest a new good first issue
+labels: [good first issue]
+body:
+  - type: dropdown
+    attributes:
+      label: Which crate is this issue for?
+      multiple: true
+      options:
+        - payjoin
+        - payjoin-cli
+        - payjoin-directory
+        - payjoin-test-utils
+        - payjoin-ffi
+  - type: markdown
+    attributes:
+      value: |
+        Please add the label "good first issue" manually before or after opening
+
+        A good first issue is an uncontroversial issue, that has a relatively unique and obvious solution
+
+        Motivate the issue and explain the solution briefly
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Motivate the issue
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible solution
+      description: Describe a possible solution
+    validations:
+      required: false
+  - type: textarea
+    id: useful-skills
+    attributes:
+      label: Useful Skills
+      description: For example, “Familiarity with BIP 77”.
+  - type: textarea
+    attributes:
+      label: Guidance for new contributors
+      description: Please leave this to automatically add the footer for new contributors
+      value: |
+        Want to work on this issue?
+
+        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md) before opening your pull request.


### PR DESCRIPTION
Followup to #758. Adds the following issue templates mostly from their Bitcoin Core counterparts (excepting the "General" template):

- [x] [Feature Request](https://github.com/bitcoin/bitcoin/blob/master/.github/ISSUE_TEMPLATE/feature_request.yml)
- [x] [Good First Issue](https://github.com/bitcoin/bitcoin/blob/master/.github/ISSUE_TEMPLATE/good_first_issue.yml)
- [x] General

It would probably be prudent for us to add [SECURITY.md](https://github.com/bitcoin/bitcoin/blob/master/SECURITY.md) as well, but I'd need clarity on if we want to follow the pattern Bitcoin Core has established, and if so, which contributors should be contacted when reporting vulnerabilities and what methods of contact would be best (i.e. should we use a security issues dedicated email & PGP keys for contributors to whom issues can be reported).

Upon receiving that information if we would like to do this I will create `SECURITY.md` in a subsequent PR.