### PR TITLE
Remove unneeded PSBT fields when extracting request

### DIFF
--- a/payjoin/src/core/send/mod.rs
+++ b/payjoin/src/core/send/mod.rs
@@ -203,7 +203,7 @@ impl PsbtContextBuilder {
         self,
         output_substitution: OutputSubstitution,
     ) -> Result<PsbtContext, BuildSenderError> {
-        let mut psbt =
+        let psbt =
             self.psbt.validate().map_err(InternalBuildSenderError::InconsistentOriginalPsbt)?;
         psbt.validate_input_utxos().map_err(InternalBuildSenderError::InvalidOriginalInput)?;
 
@@ -214,7 +214,6 @@ impl PsbtContextBuilder {
             self.fee_contribution,
             self.clamp_fee_contribution,
         )?;
-        clear_unneeded_fields(&mut psbt);
 
         Ok(PsbtContext {
             original_psbt: psbt,
@@ -662,7 +661,9 @@ pub(crate) fn create_v1_post_request(endpoint: Url, psbt_ctx: PsbtContext) -> (R
         psbt_ctx.min_fee_rate,
         Version::One,
     );
-    let body = psbt_ctx.original_psbt.to_string().as_bytes().to_vec();
+    let mut sanitized_psbt = psbt_ctx.original_psbt.clone();
+    clear_unneeded_fields(&mut sanitized_psbt);
+    let body = sanitized_psbt.to_string().as_bytes().to_vec();
     (
         Request::new_v1(&url, &body),
         V1Context {
@@ -708,9 +709,10 @@ mod test {
     use std::str::FromStr;
 
     use bitcoin::absolute::LockTime;
+    use bitcoin::bip32::{DerivationPath, Fingerprint};
     use bitcoin::ecdsa::Signature;
     use bitcoin::hex::FromHex;
-    use bitcoin::secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
+    use bitcoin::secp256k1::{Message, PublicKey, Secp256k1, SecretKey, SECP256K1};
     use bitcoin::{
         Amount, FeeRate, OutPoint, Script, ScriptBuf, Sequence, Witness, XOnlyPublicKey,
     };
@@ -738,6 +740,38 @@ mod test {
             min_fee_rate: FeeRate::ZERO,
             payee,
         })
+    }
+
+    #[test]
+    fn test_restore_original_utxos() -> Result<(), BoxError> {
+        let mut original_psbt = PARSED_ORIGINAL_PSBT.clone();
+        let mut payjoin_proposal = PARSED_PAYJOIN_PROPOSAL.clone();
+        let payee = original_psbt.unsigned_tx.output[1].script_pubkey.clone();
+        let (_, pk) = SECP256K1.generate_keypair(&mut bitcoin::key::rand::thread_rng());
+        let x_only = pk.x_only_public_key().0;
+        // Fill out dummy data in the original PSBT so we can restore it
+        let _ = original_psbt.inputs[0].tap_internal_key.insert(x_only);
+        let _ = original_psbt.outputs[0].tap_internal_key.insert(x_only);
+        original_psbt.inputs[0]
+            .bip32_derivation
+            .insert(pk, (Fingerprint::default(), DerivationPath::default()));
+        original_psbt.inputs[0]
+            .tap_key_origins
+            .insert(x_only, (vec![], (Fingerprint::default(), DerivationPath::default())));
+
+        let prev_txout = TxOut { value: Amount::ONE_BTC, script_pubkey: payee.clone() };
+        original_psbt.inputs[0].witness_utxo = Some(prev_txout.clone());
+        let psbt_ctx = PsbtContextBuilder::new(original_psbt, payee, None)
+            .build(OutputSubstitution::Disabled)?;
+        clear_unneeded_fields(&mut payjoin_proposal);
+
+        psbt_ctx.restore_original_utxos(&mut payjoin_proposal)?;
+        assert!(payjoin_proposal.inputs[0].bip32_derivation.contains_key(&pk));
+        assert!(payjoin_proposal.inputs[0].tap_key_origins.contains_key(&x_only));
+        assert_eq!(payjoin_proposal.inputs[0].witness_utxo, Some(prev_txout));
+        assert_eq!(payjoin_proposal.inputs[0].tap_internal_key, Some(x_only));
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
`PsbtContextBuilder` stores a Psbt with [unneeded fields removed](https://github.com/payjoin/rust-payjoin/blob/57ec41b1ebfd325ded9fc216096ec3930ed40b4b/payjoin/src/core/send/mod.rs#L524). Our API later attempts to restore _some_ of these fields after we process the response from the receiver.
https://github.com/payjoin/rust-payjoin/blob/57ec41b1ebfd325ded9fc216096ec3930ed40b4b/payjoin/src/core/send/mod.rs#L411

However, since the original psbt was already stripped of "unneeded" fields there is nothing to restore. This commit removes the extranous PSBT fields when we are extracting the POST request but leaves the fields in the `original_psbt` untouched.