### PR TITLE
e2e test concurrency fixes

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -141,7 +141,15 @@ impl Config {
                 #[cfg(feature = "v1")]
                 {
                     match built_config.get::<V1Config>("v1") {
-                        Ok(v1) => config.version = Some(VersionConfig::V1(v1)),
+                        Ok(v1) => {
+                            if v1.pj_endpoint.port().is_none() != (v1.port == 0) {
+                                return Err(ConfigError::Message(
+                                    "If --port is 0, --pj-endpoint may not have a port".to_owned(),
+                                ));
+                            }
+
+                            config.version = Some(VersionConfig::V1(v1))
+                        }
                         Err(e) =>
                             return Err(ConfigError::Message(format!(
                                 "Valid V1 configuration is required for BIP78 mode: {e}"

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -80,18 +80,20 @@ async fn fetch_ohttp_keys(
         let ohttp_keys = {
             #[cfg(feature = "_danger-local-https")]
             {
-                let cert_der = crate::app::read_local_cert()?;
-                payjoin::io::fetch_ohttp_keys_with_cert(
-                    &selected_relay,
-                    &payjoin_directory,
-                    cert_der,
-                )
-                .await
+                if let Some(cert_path) = config.root_certificate.as_ref() {
+                    let cert_der = std::fs::read(cert_path)?;
+                    payjoin::io::fetch_ohttp_keys_with_cert(
+                        &selected_relay,
+                        &payjoin_directory,
+                        cert_der,
+                    )
+                    .await
+                } else {
+                    payjoin::io::fetch_ohttp_keys(&selected_relay, &payjoin_directory).await
+                }
             }
             #[cfg(not(feature = "_danger-local-https"))]
-            {
-                payjoin::io::fetch_ohttp_keys(&selected_relay, &payjoin_directory).await
-            }
+            payjoin::io::fetch_ohttp_keys(&selected_relay, &payjoin_directory).await
         };
 
         match ohttp_keys {

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -75,6 +75,14 @@ pub struct Cli {
     #[cfg(feature = "v2")]
     #[arg(long = "pj-directory", help = "The directory to store payjoin requests", value_parser = value_parser!(Url))]
     pub pj_directory: Option<Url>,
+
+    #[cfg(feature = "_danger-local-https")]
+    #[arg(long = "root-certificate", help = "Specify a TLS certificate to be added as a root", value_parser = value_parser!(PathBuf))]
+    pub root_certificate: Option<PathBuf>,
+
+    #[cfg(feature = "_danger-local-https")]
+    #[arg(long = "certificate-key", help = "Specify the certificate private key", value_parser = value_parser!(PathBuf))]
+    pub certificate_key: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -25,13 +25,12 @@ mod e2e {
         let temp_dir = tempdir()?;
         let receiver_db_path = temp_dir.path().join("receiver_db");
         let sender_db_path = temp_dir.path().join("sender_db");
-        let port = find_free_port()?;
 
         let payjoin_sent = tokio::spawn(async move {
             let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
             let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
             let cookie_file = &bitcoind.params.cookie_file;
-            let pj_endpoint = format!("https://localhost:{port}");
+            let pj_endpoint = "https://localhost";
             let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
 
             let mut cli_receiver = Command::new(payjoin_cli)
@@ -45,9 +44,9 @@ mod e2e {
                 .arg("receive")
                 .arg(RECEIVE_SATS)
                 .arg("--port")
-                .arg(port.to_string())
+                .arg("0")
                 .arg("--pj-endpoint")
-                .arg(&pj_endpoint)
+                .arg(pj_endpoint)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()
@@ -128,11 +127,6 @@ mod e2e {
         .await?;
 
         assert!(payjoin_sent, "Payjoin send was not detected");
-
-        fn find_free_port() -> Result<u16, BoxError> {
-            let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-            Ok(listener.local_addr()?.port())
-        }
 
         Ok(())
     }


### PR DESCRIPTION
This PR addresses two race conditions in the e2e tests:

## Free Port Assignment

Each test tried to bind a free port, and then remembered the number passing it in to the `--port` option of payjoin-cli. There is a brief window where the port is unbound, allowing the same number to be given to both tests concurrently.

Instead the payjoin-cli can be given `--port 0`, binding a free port on its own, and will now use this port when generating a payjoin URI.

## Self Signed Certificate Isolation

The self signed certificate was written to e.g. `/tmp/localhost.der`, so concurrent `cargo test` runs as well as concurrent tests within a test run overwrote each others certificate.

This issue was mostly hidden by the redis test container delaying startup for the v2 test, typically long enough for the v1 test's server and clients to be be initialized consistently.