### PR TITLE
Add amount to recv session context

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -106,11 +106,11 @@ impl AppTrait for App {
             self.config.v2()?.pj_directory.clone(),
             ohttp_keys,
             None,
+            Some(amount),
         )
         .save(&persister)?;
         println!("Receive session established");
-        let mut pj_uri = session.pj_uri();
-        pj_uri.amount = Some(amount);
+        let pj_uri = session.pj_uri();
         println!("Request Payjoin by sharing this Payjoin Uri:");
         println!("{}", pj_uri);
 

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -135,7 +135,7 @@ payjoin.Initialized create_receiver_context(
     payjoin.OhttpKeys ohttp_keys,
     InMemoryReceiverPersister persister) {
   var receiver = payjoin.UninitializedReceiver()
-      .createSession(address, directory, ohttp_keys, null)
+      .createSession(address, directory, ohttp_keys, null, null)
       .save(persister);
   return receiver;
 }

--- a/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
@@ -109,6 +109,7 @@ void main() {
               "https://example.com",
               payjoin.OhttpKeys.fromString(
                   "OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"),
+              null,
               null)
           .save(persister);
       final result = payjoin.replayReceiverEventLog(persister);
@@ -126,6 +127,7 @@ void main() {
               "https://example.com",
               payjoin.OhttpKeys.fromString(
                   "OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"),
+              null,
               null)
           .save(receiver_persister);
       var uri = receiver.pjUri();

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -84,7 +84,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         raise Exception(f"Unknown receiver state: {receiver}")
 
     def create_receiver_context(self, receiver_address: bitcoinffi.Address, directory: Url, ohttp_keys: OhttpKeys, recv_persister: InMemoryReceiverSessionEventLog) -> Initialized:
-        receiver = UninitializedReceiver().create_session(address=receiver_address, directory=directory.as_string(), ohttp_keys=ohttp_keys, expire_after=None).save(recv_persister)
+        receiver = UninitializedReceiver().create_session(address=receiver_address, directory=directory.as_string(), ohttp_keys=ohttp_keys, expire_after=None, amount=None).save(recv_persister)
         return receiver
 
     async def retrieve_receiver_proposal(self, receiver: Initialized, recv_persister: InMemoryReceiverSessionEventLog, ohttp_relay: Url):

--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -54,6 +54,7 @@ class TestReceiverPersistence(unittest.TestCase):
             address, 
             "https://example.com", 
             payjoin.OhttpKeys.from_string("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"), 
+            None,
             None
         ).save(persister)
         result = payjoin.payjoin_ffi.replay_receiver_event_log(persister)
@@ -83,6 +84,7 @@ class TestSenderPersistence(unittest.TestCase):
             address, 
             "https://example.com", 
             payjoin.OhttpKeys.from_string("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"), 
+            None,
             None
         ).save(persister)
         uri = receiver.pj_uri()

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -236,6 +236,7 @@ impl UninitializedReceiver {
         directory: String,
         ohttp_keys: Arc<OhttpKeys>,
         expire_after: Option<u64>,
+        amount: Option<u64>,
     ) -> InitialReceiveTransition {
         InitialReceiveTransition(Arc::new(RwLock::new(Some(
             payjoin::receive::v2::Receiver::create_session(
@@ -243,6 +244,7 @@ impl UninitializedReceiver {
                 directory,
                 (*ohttp_keys).clone().into(),
                 expire_after.map(Duration::from_secs),
+                amount.map(payjoin::bitcoin::Amount::from_sat),
             ),
         ))))
     }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -657,7 +657,7 @@ mod test {
         let ohttp_keys = OhttpKeys(
             ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
         );
-        let pj_uri = Receiver::create_session(address.clone(), directory, ohttp_keys, None)
+        let pj_uri = Receiver::create_session(address.clone(), directory, ohttp_keys, None, None)
             .save(&NoopSessionPersister::default())
             .expect("receiver should succeed")
             .pj_uri();

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -210,7 +210,7 @@ mod integration {
                     .assume_checked();
                 let noop_persister = NoopSessionPersister::default();
                 let mut bad_initializer =
-                    Receiver::create_session(mock_address, directory, bad_ohttp_keys, None)
+                    Receiver::create_session(mock_address, directory, bad_ohttp_keys, None, None)
                         .save(&noop_persister)?;
                 let (req, _ctx) = bad_initializer.create_poll_request(&ohttp_relay)?;
                 agent
@@ -254,6 +254,7 @@ mod integration {
                     directory.clone(),
                     ohttp_keys.clone(),
                     Some(Duration::from_secs(0)),
+                    None,
                 )
                 .save(&recv_noop_persister)?;
                 match expired_receiver.create_poll_request(&ohttp_relay) {
@@ -309,6 +310,7 @@ mod integration {
                     address.clone(),
                     directory.clone(),
                     ohttp_keys.clone(),
+                    None,
                     None,
                 )
                 .save(&persister)?;
@@ -435,6 +437,7 @@ mod integration {
                     address.clone(),
                     directory.clone(),
                     ohttp_keys.clone(),
+                    None,
                     None,
                 )
                 .save(&recv_persister)?;
@@ -621,9 +624,14 @@ mod integration {
                 let recv_persister = NoopSessionPersister::default();
                 let send_persister = NoopSessionPersister::default();
                 let address = receiver.get_new_address(None, None)?.assume_checked();
-                let mut session =
-                    Receiver::create_session(address, directory.clone(), ohttp_keys.clone(), None)
-                        .save(&recv_persister)?;
+                let mut session = Receiver::create_session(
+                    address,
+                    directory.clone(),
+                    ohttp_keys.clone(),
+                    None,
+                    None,
+                )
+                .save(&recv_persister)?;
 
                 // **********************
                 // Inside the V1 Sender:


### PR DESCRIPTION
Currently application developers are having to apply the amount to the
bip21 uri outside of the API.
https://github.com/payjoin/rust-payjoin/blob/5ecfed745bd33f6d5706f497bdb7662a3a7c9177/payjoin-cli/src/app/v2/mod.rs#L112-L113
This is a convenience that allows amount to be already applied to the
bip21. It also allows us to capture this information in the session
history.

Related ticket: https://github.com/payjoin/rust-payjoin/issues/895