### PR TITLE
Remove internal error when displaying impl error

### DIFF
--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -121,7 +121,7 @@ impl fmt::Display for ReplyableError {
             Self::Payload(e) => e.fmt(f),
             #[cfg(feature = "v1")]
             Self::V1(e) => e.fmt(f),
-            Self::Implementation(e) => write!(f, "Internal Server Error: {e}"),
+            Self::Implementation(_) => write!(f, "Internal Server Error"),
         }
     }
 }

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -1416,9 +1416,6 @@ pub(crate) mod test {
         };
         let other_psbt = Psbt::from_unsigned_tx(empty_tx).expect("Valid unsigned tx");
         let err = provisional.finalize_proposal(|_| Ok(other_psbt.clone())).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Internal Server Error: Invalid payjoin proposal was returned by the wallet"
-        );
+        assert_eq!(err.to_string(), "Internal Server Error");
     }
 }


### PR DESCRIPTION
Implementation errors are typically surfaced from the application, not the API. When we construct the json reply from a replayable error we ensure that the internal error is never part of the reply payload as it could leak un-intended information.

This commit removes the internal error message from the `std::fmt::Display` impl to prevent accidentally revealing the same un-intended information if an application decides to use `JsonReply::new` instead of `.into()`

```rust
    /// Create a new Reply
    pub fn new(error_code: ErrorCode, message: impl fmt::Display) ->Self
```