### PR TITLE
Reduce visibility of `JsonReply::new`

### DIFF
--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -82,7 +82,7 @@ pub struct JsonReply {
 
 impl JsonReply {
     /// Create a new Reply
-    pub fn new(error_code: ErrorCode, message: impl fmt::Display) -> Self {
+    pub(crate) fn new(error_code: ErrorCode, message: impl fmt::Display) -> Self {
         Self { error_code, message: message.to_string(), extra: serde_json::Map::new() }
     }
 


### PR DESCRIPTION
Json replies are carefully crafted to ommit potentially sensative information. Application developers may accidentally stringify implementation errors instead of using the From `ReplayableError` impl if the ctor is pub. 