### PR TITLE
Replace bitcoincore-rpc with custom reqwest client

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -612,6 +612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "corepc-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7f2faedffc7c654e348e2da6c6416090525c6072979fee9681d620d1d398a4"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,9 +1683,9 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoincore-rpc",
  "clap",
  "config",
+ "corepc-types",
  "dirs",
  "env_logger",
  "http-body-util",
@@ -1689,6 +1700,7 @@ dependencies = [
  "reqwest",
  "rustls 0.22.4",
  "serde",
+ "serde_json",
  "sled",
  "tempfile",
  "tokio",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -612,6 +612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "corepc-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7f2faedffc7c654e348e2da6c6416090525c6072979fee9681d620d1d398a4"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,9 +1683,9 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoincore-rpc",
  "clap",
  "config",
+ "corepc-types",
  "dirs",
  "env_logger",
  "http-body-util",
@@ -1689,6 +1700,7 @@ dependencies = [
  "reqwest",
  "rustls 0.22.4",
  "serde",
+ "serde_json",
  "sled",
  "tempfile",
  "tokio",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -28,9 +28,9 @@ v2 = ["payjoin/v2", "payjoin/io"]
 [dependencies]
 anyhow = "1.0.70"
 async-trait = "0.1"
-bitcoincore-rpc = "0.19.0"
 clap = { version = "~4.0.32", features = ["derive"] }
 config = "0.13.3"
+corepc-types = "0.8.0"
 env_logger = "0.9.0"
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1", features = ["http1", "server"], optional = true }
@@ -39,7 +39,8 @@ hyper-util = { version = "0.1", optional = true }
 log = "0.4.7"
 payjoin = { version = "0.24.0", default-features = false }
 rcgen = { version = "0.11.1", optional = true }
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde_json = "1.0"
 rustls = { version = "0.22.4", optional = true }
 serde = { version = "1.0.160", features = ["derive"] }
 sled = "0.34"

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -1,14 +1,15 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
-use bitcoincore_rpc::bitcoin::Amount;
 use payjoin::bitcoin::psbt::Psbt;
+use payjoin::bitcoin::Amount;
 use payjoin::bitcoin::FeeRate;
 use payjoin::{bitcoin, PjUri};
 use tokio::signal;
 use tokio::sync::watch;
 
 pub mod config;
+pub mod rpc;
 pub mod wallet;
 use crate::app::config::Config;
 use crate::app::wallet::BitcoindWallet;
@@ -58,7 +59,9 @@ fn http_agent(config: &Config) -> Result<reqwest::Client> {
 }
 
 #[cfg(not(feature = "_danger-local-https"))]
-fn http_agent(_config: &Config) -> Result<reqwest::Client> { Ok(reqwest::Client::new()) }
+fn http_agent(_config: &Config) -> Result<reqwest::Client> {
+    Ok(reqwest::Client::new())
+}
 
 #[cfg(feature = "_danger-local-https")]
 fn http_agent_builder(

--- a/payjoin-cli/src/app/rpc.rs
+++ b/payjoin-cli/src/app/rpc.rs
@@ -1,0 +1,181 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use corepc_types::v26::{
+    FinalizePsbt, GetAddressInfo, GetBlockchainInfo, ListUnspentItem, TestMempoolAccept,
+    WalletCreateFundedPsbt, WalletProcessPsbt,
+};
+use payjoin::bitcoin::{Address, Amount, Network, Txid};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Authentication method for Bitcoin Core RPC
+#[derive(Clone, Debug)]
+pub enum Auth {
+    UserPass(String, String),
+    CookieFile(PathBuf),
+}
+
+/// Internal async Bitcoin RPC client using reqwest
+pub struct AsyncBitcoinRpc {
+    client: Client,
+    url: String,
+    auth: Auth,
+}
+
+impl AsyncBitcoinRpc {
+    pub fn new(url: String, auth: Auth) -> Result<Self> {
+        let client =
+            Client::builder().use_rustls_tls().build().context("Failed to create HTTP client")?;
+
+        Ok(Self { client, url, auth })
+    }
+
+    /// Make a JSON-RPC call to Bitcoin Core
+    async fn call_rpc<T>(&self, method: &str, params: Value) -> Result<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let request_body = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1
+        });
+
+        let mut request = self.client.post(&self.url).json(&request_body);
+
+        // Add authentication
+        match &self.auth {
+            Auth::UserPass(user, pass) => {
+                request = request.basic_auth(user, Some(pass));
+            }
+            Auth::CookieFile(path) => {
+                let cookie = std::fs::read_to_string(path)
+                    .with_context(|| format!("Failed to read cookie file: {path:?}"))?;
+                let parts: Vec<&str> = cookie.trim().split(':').collect();
+                if parts.len() != 2 {
+                    return Err(anyhow!("Invalid cookie format"));
+                }
+                request = request.basic_auth(parts[0], Some(parts[1]));
+            }
+        }
+
+        let response = request.send().await.context("Failed to send RPC request")?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("RPC request failed with status: {}", response.status()));
+        }
+
+        let json: RpcResponse<T> = response.json().await.context("Failed to parse RPC response")?;
+
+        match json {
+            RpcResponse::Success { result, .. } => Ok(result),
+            RpcResponse::Error { error, .. } => Err(anyhow!("RPC error: {:?}", error)),
+        }
+    }
+
+    pub async fn wallet_create_funded_psbt(
+        &self,
+        inputs: &[Value],
+        outputs: &HashMap<String, Amount>,
+        locktime: Option<u32>,
+        options: Option<Value>,
+        bip32derivs: Option<bool>,
+    ) -> Result<WalletCreateFundedPsbt> {
+        let params = json!([inputs, outputs, locktime, options, bip32derivs]);
+        self.call_rpc("walletcreatefundedpsbt", params).await
+    }
+
+    pub async fn wallet_process_psbt(
+        &self,
+        psbt: &str,
+        sign: Option<bool>,
+        sighash_type: Option<String>,
+        bip32derivs: Option<bool>,
+    ) -> Result<WalletProcessPsbt> {
+        let params = json!([psbt, sign, sighash_type, bip32derivs]);
+        self.call_rpc("walletprocesspsbt", params).await
+    }
+
+    pub async fn finalize_psbt(&self, psbt: &str, extract: Option<bool>) -> Result<FinalizePsbt> {
+        let params = json!([psbt, extract]);
+        self.call_rpc("finalizepsbt", params).await
+    }
+
+    pub async fn test_mempool_accept(&self, rawtxs: &[String]) -> Result<Vec<TestMempoolAccept>> {
+        let params = json!([rawtxs]);
+        self.call_rpc("testmempoolaccept", params).await
+    }
+
+    pub async fn send_raw_transaction(&self, hex: &[u8]) -> Result<Txid> {
+        use payjoin::bitcoin::hex::DisplayHex;
+        let hex_string = hex.to_lower_hex_string();
+        let params = json!([hex_string]);
+        let txid_string: String = self.call_rpc("sendrawtransaction", params).await?;
+        Ok(txid_string.parse()?)
+    }
+
+    pub async fn get_address_info(&self, address: &Address) -> Result<GetAddressInfo> {
+        let params = json!([address.to_string()]);
+        self.call_rpc("getaddressinfo", params).await
+    }
+
+    pub async fn get_new_address(
+        &self,
+        label: Option<&str>,
+        address_type: Option<&str>,
+    ) -> Result<Address> {
+        let params = json!([label, address_type]);
+        let address_string: String = self.call_rpc("getnewaddress", params).await?;
+        let addr: payjoin::bitcoin::Address<payjoin::bitcoin::address::NetworkUnchecked> =
+            address_string.parse().context("Failed to parse address")?;
+        Ok(addr.assume_checked())
+    }
+
+    pub async fn list_unspent(
+        &self,
+        minconf: Option<u32>,
+        maxconf: Option<u32>,
+        addresses: Option<&[Address]>,
+        include_unsafe: Option<bool>,
+        query_options: Option<Value>,
+    ) -> Result<Vec<ListUnspentItem>> {
+        let addresses_str: Option<Vec<String>> =
+            addresses.map(|addrs| addrs.iter().map(|a| a.to_string()).collect());
+        let params = json!([minconf, maxconf, addresses_str, include_unsafe, query_options]);
+        self.call_rpc("listunspent", params).await
+    }
+
+    pub async fn get_blockchain_info(&self) -> Result<GetBlockchainInfo> {
+        let params = json!([]);
+        self.call_rpc("getblockchaininfo", params).await
+    }
+
+    pub async fn network(&self) -> Result<Network> {
+        let info = self.get_blockchain_info().await?;
+        match info.chain.as_str() {
+            "main" => Ok(Network::Bitcoin),
+            "test" => Ok(Network::Testnet),
+            "regtest" => Ok(Network::Regtest),
+            "signet" => Ok(Network::Signet),
+            other => Err(anyhow!("Unknown network: {}", other)),
+        }
+    }
+}
+
+/// JSON-RPC response envelope
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum RpcResponse<T> {
+    Success { result: T, error: Option<Value>, id: Value },
+    Error { result: Option<Value>, error: RpcError, id: Value },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct RpcError {
+    code: i32,
+    message: String,
+}

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
-use bitcoincore_rpc::bitcoin::Amount;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
@@ -13,6 +12,7 @@ use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use payjoin::bitcoin::psbt::Psbt;
+use payjoin::bitcoin::Amount;
 use payjoin::bitcoin::FeeRate;
 use payjoin::receive::v1::{PayjoinProposal, UncheckedProposal};
 use payjoin::receive::ReplyableError::{self, Implementation, V1};
@@ -56,7 +56,9 @@ impl AppTrait for App {
         Ok(app)
     }
 
-    fn wallet(&self) -> BitcoindWallet { self.wallet.clone() }
+    fn wallet(&self) -> BitcoindWallet {
+        self.wallet.clone()
+    }
 
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()> {
         let uri =
@@ -147,7 +149,7 @@ impl App {
             "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
             listener.local_addr()?
         );
-        println!("{}", pj_uri_string);
+        println!("{pj_uri_string}");
 
         let app = self.clone();
 

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -2,38 +2,41 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::app::rpc::{AsyncBitcoinRpc, Auth};
 use anyhow::{anyhow, Context, Result};
-use bitcoincore_rpc::json::WalletCreateFundedPsbtOptions;
-use bitcoincore_rpc::{Auth, Client, RpcApi};
 use payjoin::bitcoin::consensus::encode::{deserialize, serialize_hex};
 use payjoin::bitcoin::consensus::Encodable;
 use payjoin::bitcoin::psbt::{Input, Psbt};
 use payjoin::bitcoin::{
-    Address, Amount, Denomination, FeeRate, Network, OutPoint, Script, Transaction, TxIn, TxOut,
-    Txid,
+    self, Address, Amount, Denomination, FeeRate, Network, OutPoint, Script, ScriptBuf,
+    Transaction, TxIn, TxOut, Txid,
 };
 use payjoin::receive::InputPair;
+use serde_json::json;
 
-/// Implementation of PayjoinWallet for bitcoind
-#[derive(Clone, Debug)]
+/// Implementation of PayjoinWallet for bitcoind using async RPC client with sync wrapper
+#[derive(Clone)]
 pub struct BitcoindWallet {
-    pub bitcoind: std::sync::Arc<Client>,
+    rpc: Arc<AsyncBitcoinRpc>,
+    runtime_handle: tokio::runtime::Handle,
 }
 
 impl BitcoindWallet {
     pub fn new(config: &crate::app::config::BitcoindConfig) -> Result<Self> {
-        let client = match &config.cookie {
-            Some(cookie) if cookie.as_os_str().is_empty() =>
+        let auth = match &config.cookie {
+            Some(cookie) if cookie.as_os_str().is_empty() => {
                 return Err(anyhow!(
                     "Cookie authentication enabled but no cookie path provided in config.toml"
-                )),
-            Some(cookie) => Client::new(config.rpchost.as_str(), Auth::CookieFile(cookie.into())),
-            None => Client::new(
-                config.rpchost.as_str(),
-                Auth::UserPass(config.rpcuser.clone(), config.rpcpassword.clone()),
-            ),
-        }?;
-        Ok(Self { bitcoind: Arc::new(client) })
+                ))
+            }
+            Some(cookie) => Auth::CookieFile(cookie.into()),
+            None => Auth::UserPass(config.rpcuser.clone(), config.rpcpassword.clone()),
+        };
+
+        let rpc = AsyncBitcoinRpc::new(config.rpchost.to_string(), auth)?;
+        let runtime_handle = tokio::runtime::Handle::current();
+
+        Ok(Self { rpc: Arc::new(rpc), runtime_handle })
     }
 }
 
@@ -50,31 +53,28 @@ impl BitcoindWallet {
         let fee_per_kvb = Amount::from_sat(fee_sat_per_kvb);
         log::debug!("Fee rate sat/kvb: {}", fee_per_kvb.display_in(Denomination::Satoshi));
 
-        let options = WalletCreateFundedPsbtOptions {
-            lock_unspent: Some(lock_unspent),
-            fee_rate: Some(fee_per_kvb),
-            ..Default::default()
-        };
+        let options = json!({
+            "lockUnspents": lock_unspent,
+            "feeRate": fee_per_kvb.to_btc()
+        });
 
-        let psbt = self
-            .bitcoind
-            .wallet_create_funded_psbt(
-                &[], // inputs
-                &outputs,
-                None, // locktime
-                Some(options),
-                None,
-            )
-            .context("Failed to create PSBT")?
-            .psbt;
+        // Sync wrapper around async call
+        let result = self.runtime_handle.block_on(self.rpc.wallet_create_funded_psbt(
+            &[], // inputs
+            &outputs,
+            None, // locktime
+            Some(options),
+            None,
+        ))?;
 
-        let psbt = self
-            .bitcoind
-            .wallet_process_psbt(&psbt, None, None, None)
-            .context("Failed to process PSBT")?
-            .psbt;
+        let processed = self.runtime_handle.block_on(self.rpc.wallet_process_psbt(
+            &result.psbt,
+            None,
+            None,
+            None,
+        ))?;
 
-        Psbt::from_str(&psbt).context("Failed to load PSBT from base64")
+        Psbt::from_str(&processed.psbt).context("Failed to load PSBT from base64")
     }
 
     /// Process a PSBT, validating and signing inputs owned by this wallet
@@ -83,28 +83,37 @@ impl BitcoindWallet {
     pub fn process_psbt(&self, psbt: &Psbt) -> Result<Psbt> {
         let psbt_str = psbt.to_string();
         let processed = self
-            .bitcoind
-            .wallet_process_psbt(&psbt_str, None, None, Some(false))
-            .context("Failed to process PSBT")?
-            .psbt;
-        Psbt::from_str(&processed).context("Failed to parse processed PSBT")
+            .runtime_handle
+            .block_on(self.rpc.wallet_process_psbt(&psbt_str, None, None, Some(false)))
+            .context("Failed to process PSBT")?;
+        Psbt::from_str(&processed.psbt).context("Failed to parse processed PSBT")
     }
 
     /// Finalize a PSBT and extract the transaction
     pub fn finalize_psbt(&self, psbt: &Psbt) -> Result<Transaction> {
         let result = self
-            .bitcoind
-            .finalize_psbt(&psbt.to_string(), Some(true))
+            .runtime_handle
+            .block_on(self.rpc.finalize_psbt(&psbt.to_string(), Some(true)))
             .context("Failed to finalize PSBT")?;
-        let tx = deserialize(&result.hex.ok_or_else(|| anyhow!("Incomplete PSBT"))?)?;
+        let hex_str = result.hex.ok_or_else(|| anyhow!("Incomplete PSBT"))?;
+        use bitcoin::hex::FromHex;
+        let hex_bytes = Vec::<u8>::from_hex(&hex_str).context("Failed to decode hex")?;
+        let tx = deserialize(&hex_bytes)?;
         Ok(tx)
     }
 
     pub fn can_broadcast(&self, tx: &Transaction) -> Result<bool> {
         let raw_tx = serialize_hex(&tx);
-        let mempool_results = self.bitcoind.test_mempool_accept(&[raw_tx])?;
+        let mempool_results =
+            self.runtime_handle.block_on(self.rpc.test_mempool_accept(&[raw_tx]))?;
         match mempool_results.first() {
-            Some(result) => Ok(result.allowed),
+            Some(result) => {
+                if let Some(first_result) = result.results.first() {
+                    Ok(first_result.allowed)
+                } else {
+                    Ok(false)
+                }
+            }
             None => Err(anyhow!("No mempool results returned on broadcast check",)),
         }
     }
@@ -113,18 +122,19 @@ impl BitcoindWallet {
     pub fn broadcast_tx(&self, tx: &Transaction) -> Result<Txid> {
         let mut serialized_tx = Vec::new();
         tx.consensus_encode(&mut serialized_tx)?;
-        self.bitcoind
-            .send_raw_transaction(&serialized_tx)
+        self.runtime_handle
+            .block_on(self.rpc.send_raw_transaction(&serialized_tx))
             .context("Failed to broadcast transaction")
     }
 
     /// Check if a script belongs to this wallet
     pub fn is_mine(&self, script: &Script) -> Result<bool> {
         if let Ok(address) = Address::from_script(script, self.network()?) {
-            self.bitcoind
-                .get_address_info(&address)
-                .map(|info| info.is_mine.unwrap_or(false))
-                .context("Failed to get address info")
+            let info = self
+                .runtime_handle
+                .block_on(self.rpc.get_address_info(&address))
+                .context("Failed to get address info")?;
+            Ok(info.is_mine)
         } else {
             Ok(false)
         }
@@ -132,47 +142,50 @@ impl BitcoindWallet {
 
     /// Get a new address from the wallet
     pub fn get_new_address(&self) -> Result<Address> {
-        self.bitcoind
-            .get_new_address(None, None)
-            .context("Failed to get new address")?
-            .require_network(self.network()?)
-            .context("Invalid network for address")
+        let addr = self
+            .runtime_handle
+            .block_on(self.rpc.get_new_address(None, None))
+            .context("Failed to get new address")?;
+        Ok(addr)
     }
 
     /// List unspent UTXOs
     pub fn list_unspent(&self) -> Result<Vec<InputPair>> {
         let unspent = self
-            .bitcoind
-            .list_unspent(None, None, None, None, None)
+            .runtime_handle
+            .block_on(self.rpc.list_unspent(None, None, None, None, None))
             .context("Failed to list unspent")?;
-        Ok(unspent.into_iter().map(input_pair_from_list_unspent).collect())
+        Ok(unspent.into_iter().map(input_pair_from_corepc).collect())
     }
 
     /// Get the network this wallet is operating on
     pub fn network(&self) -> Result<Network> {
-        self.bitcoind
-            .get_blockchain_info()
+        self.runtime_handle
+            .block_on(self.rpc.network())
             .map_err(|_| anyhow!("Failed to get blockchain info"))
-            .map(|info| info.chain)
     }
 }
 
-pub fn input_pair_from_list_unspent(
-    utxo: bitcoincore_rpc::bitcoincore_rpc_json::ListUnspentResultEntry,
-) -> InputPair {
+pub fn input_pair_from_corepc(utxo: corepc_types::v26::ListUnspentItem) -> InputPair {
     let psbtin = Input {
         // NOTE: non_witness_utxo is not necessary because bitcoin-cli always supplies
         // witness_utxo, even for non-witness inputs
         witness_utxo: Some(TxOut {
-            value: utxo.amount,
-            script_pubkey: utxo.script_pub_key.clone(),
+            value: Amount::from_btc(utxo.amount).expect("Valid amount"),
+            script_pubkey: ScriptBuf::from_hex(&utxo.script_pubkey).expect("Valid script"),
         }),
-        redeem_script: utxo.redeem_script.clone(),
-        witness_script: utxo.witness_script.clone(),
+        redeem_script: utxo
+            .redeem_script
+            .as_ref()
+            .map(|s| ScriptBuf::from_hex(s).expect("Valid script")),
+        witness_script: None, // Not available in this version
         ..Default::default()
     };
     let txin = TxIn {
-        previous_output: OutPoint { txid: utxo.txid, vout: utxo.vout },
+        previous_output: OutPoint {
+            txid: utxo.txid.parse().expect("Valid txid"),
+            vout: utxo.vout as u32,
+        },
         ..Default::default()
     };
     InputPair::new(txin, psbtin, None).expect("Input pair should be valid")

--- a/payjoin-cli/src/db/error.rs
+++ b/payjoin-cli/src/db/error.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-#[cfg(feature = "v2")]
-use bitcoincore_rpc::jsonrpc::serde_json;
 use payjoin::ImplementationError;
 use sled::Error as SledError;
 
@@ -39,9 +37,13 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl From<SledError> for Error {
-    fn from(error: SledError) -> Self { Error::Sled(error) }
+    fn from(error: SledError) -> Self {
+        Error::Sled(error)
+    }
 }
 
 impl From<Error> for ImplementationError {
-    fn from(error: Error) -> Self { ImplementationError::new(error) }
+    fn from(error: Error) -> Self {
+        ImplementationError::new(error)
+    }
 }

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use bitcoincore_rpc::jsonrpc::serde_json;
 use payjoin::bitcoin::hex::DisplayHex;
 use payjoin::persist::SessionPersister;
 use payjoin::receive::v2::SessionEvent as ReceiverSessionEvent;
@@ -20,11 +19,15 @@ pub(crate) struct SessionWrapper<V> {
 pub struct SessionId([u8; 8]);
 
 impl SessionId {
-    pub fn new(id: u64) -> Self { Self(id.to_be_bytes()) }
+    pub fn new(id: u64) -> Self {
+        Self(id.to_be_bytes())
+    }
 }
 
 impl AsRef<[u8]> for SessionId {
-    fn as_ref(&self) -> &[u8] { self.0.as_ref() }
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Eliminates minreq dependency conflict and adds HTTPS support by implementing async RPC client using reqwest and corepc-types.

- Uses project-wide reqwest instead of minreq
- Enables HTTPS connections via rustls
- Implements 9 required RPC methods with sync wrapper
- Supports cookie file and username/password auth

Fixes #350