### PR TITLE
Add config saving to payjoin-cli

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
+ "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
+ "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -51,8 +51,11 @@ url = { version = "2.5.4", features = ["serde"] }
 dirs = "6.0.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+toml = "0.5.11"
 
 [dev-dependencies]
 nix = { version = "0.30.1", features = ["aio", "process", "signal"] }
 payjoin-test-utils = { version = "0.0.1" }
 tempfile = "3.20.0"
+
+

--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -132,6 +132,8 @@ Congratulations! You've completed a version 2 payjoin, which can be used for che
 
 Config options can be passed from the command line, or manually edited in a `config.toml` file within the directory you run `payjoin-cli` from.
 
+You can persist command-line flags into a configuration file. If a config file exists in the current working directory it will be used; otherwise, one in the default directory is used. This behavior is enabled via the `--set-config` flag.
+
 See the
 [example.config.toml](https://github.com/payjoin/rust-payjoin/blob/fde867b93ede767c9a50913432a73782a94ef40b/payjoin-cli/example.config.toml)
 for inspiration.

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -76,6 +76,10 @@ pub struct Cli {
     #[arg(long = "pj-directory", help = "The directory to store payjoin requests", value_parser = value_parser!(Url))]
     pub pj_directory: Option<Url>,
 
+    #[cfg(feature = "v2")]
+    #[arg(long = "set-config", help = "Save current configuration parameters to config.toml", value_parser = value_parser!(bool))]
+    pub set_config: bool,
+
     #[cfg(feature = "_manual-tls")]
     #[arg(long = "root-certificate", help = "Specify a TLS certificate to be added as a root", value_parser = value_parser!(PathBuf))]
     pub root_certificate: Option<PathBuf>,

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -20,6 +20,11 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_target(true).with_level(true).with_env_filter(env_filter).init();
 
     let cli = Cli::parse();
+
+    #[cfg(feature = "v2")]
+    if cli.set_config {
+        Config::save_config(&cli)?;
+    }
     let config = Config::new(&cli)?;
 
     #[allow(clippy::if_same_then_else)]


### PR DESCRIPTION
# Summary 
This Pr adds the ability to  save  commandline arguement relevant to the config file into a config.toml file in the present directory if anyone exist or into the default xdg-compliant directory .

This pr close #896 