### PR TITLE
Reduce visibility of state transition types

### DIFF
--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -180,7 +180,7 @@ where
 }
 
 /// A transition that always results in a state transition.
-pub struct NextStateTransition<Event, NextState>(pub(crate) AcceptNextState<Event, NextState>);
+pub struct NextStateTransition<Event, NextState>(AcceptNextState<Event, NextState>);
 
 impl<Event, NextState> NextStateTransition<Event, NextState> {
     #[inline]
@@ -227,7 +227,7 @@ impl<Event, NextState, Err> MaybeBadInitInputsTransition<Event, NextState, Err> 
 }
 
 /// Wrapper that marks the progression of a state machine
-pub struct AcceptNextState<Event, NextState>(pub(crate) Event, pub(crate) NextState);
+pub struct AcceptNextState<Event, NextState>(Event, NextState);
 /// Wrapper that marks the success of a state machine with a value that was returned
 struct AcceptCompleted<SuccessValue>(SuccessValue);
 


### PR DESCRIPTION
These inner types were pub(crate)'ed so tests can access the next state by passing persisting. However, using the noop persister can achieve the same thing while reducing boilerplate.

cc'ing @benalleng bc I think you originally contributed the tests I modified