### PR TITLE
Optimize SessionPersister trait for better ownership semantics

### DIFF
--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -54,14 +54,14 @@ impl SessionPersister for SenderPersister {
     type InternalStorageError = crate::db::error::Error;
     fn save_event(
         &self,
-        event: &SenderSessionEvent,
+        event: SenderSessionEvent,
     ) -> std::result::Result<(), Self::InternalStorageError> {
         let send_tree = self.db.0.open_tree("send_sessions")?;
         let key = self.session_id.as_ref();
         let session = send_tree.get(key)?.expect("key should exist");
         let mut session_wrapper: SessionWrapper<SenderSessionEvent> =
             serde_json::from_slice(&session).map_err(Error::Deserialize)?;
-        session_wrapper.events.push(event.clone());
+        session_wrapper.events.push(event);
         let value = serde_json::to_vec(&session_wrapper).map_err(Error::Serialize)?;
         send_tree.insert(key, value.as_slice())?;
 
@@ -125,7 +125,7 @@ impl SessionPersister for ReceiverPersister {
 
     fn save_event(
         &self,
-        event: &ReceiverSessionEvent,
+        event: ReceiverSessionEvent,
     ) -> std::result::Result<(), Self::InternalStorageError> {
         let recv_tree = self.db.0.open_tree("recv_sessions")?;
         let key = self.session_id.as_ref();
@@ -133,7 +133,7 @@ impl SessionPersister for ReceiverPersister {
             recv_tree.get(key)?.ok_or(Error::NotFound(key.to_vec().to_lower_hex_string()))?;
         let mut session_wrapper: SessionWrapper<ReceiverSessionEvent> =
             serde_json::from_slice(&session).map_err(Error::Deserialize)?;
-        session_wrapper.events.push(event.clone());
+        session_wrapper.events.push(event);
         let value = serde_json::to_vec(&session_wrapper).map_err(Error::Serialize)?;
         recv_tree.insert(key, value.as_slice())?;
         recv_tree.flush()?;

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1048,8 +1048,8 @@ impl payjoin::persist::SessionPersister for CallbackPersisterAdapter {
     type SessionEvent = payjoin::receive::v2::SessionEvent;
     type InternalStorageError = ForeignError;
 
-    fn save_event(&self, event: &Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
-        let uni_event: ReceiverSessionEvent = event.clone().into();
+    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
+        let uni_event: ReceiverSessionEvent = event.into();
         self.callback_persister
             .save(uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?)
     }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -498,8 +498,8 @@ impl payjoin::persist::SessionPersister for CallbackPersisterAdapter {
     type SessionEvent = payjoin::send::v2::SessionEvent;
     type InternalStorageError = ForeignError;
 
-    fn save_event(&self, event: &Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
-        let event: SenderSessionEvent = event.clone().into();
+    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
+        let event: SenderSessionEvent = event.into();
         self.callback_persister
             .save(event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?)
     }

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -235,7 +235,7 @@ mod tests {
     fn run_session_history_test(test: SessionHistoryTest) -> Result<(), BoxError> {
         let persister = InMemoryTestPersister::<SessionEvent>::default();
         for event in test.events {
-            persister.save_event(&event)?;
+            persister.save_event(event)?;
         }
 
         let (receiver, session_history) = replay_event_log(&persister)?;


### PR DESCRIPTION
Part of #402 - Take arguments by reference where possible

Optimize SessionPersister trait for better ownership semantics
- Change save_event signature from &Self::SessionEvent to Self::SessionEvent
- Implement Arc optimization for InMemoryTestPersister
- Update all trait implementers across CLI and FFI modules
- Optimize session replay to eliminate duplicate conversions and sender clones
- Remove 19 unnecessary clones from persist operations

All tests passing 