### PR TITLE
Add test to enforce v1 output substitution disabling in v2

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,32 +11,31 @@ exclude_re = [
 	"Iterator",
 	".*Error",
 
-	# ---------------------Crate-specific exculsions---------------------
-	# Timeout loops
-        # src/receive/v1/mod.rs
-        "interleave_shuffle", # Replacing index += 1 with index *= 1 in a loop causes a timeout due to an infinite loop
+    # ---------------------Crate-specific exculsions---------------------
+    # Timeout loops
+    # src/receive/v1/mod.rs
+    "interleave_shuffle", # Replacing index += 1 with index *= 1 in a loop causes a timeout due to an infinite loop
 
-	# Trivial mutations
-	# These exlusions are allowing code blocks to run with artithmetic involving zero and as a result are no-ops
-	# payjoin/src/core/send/mod.rs
-	"replace < with <= in PsbtContext::check_outputs",
-	"replace > with >= in PsbtContext::check_fees",
-	# payjoin/src/core/send/mod.rs
-	"replace < with <= in PsbtContextBuilder::build_recommended", # clamping the fee contribution when the fee equals to the recommended fee does not do anything
+    # Trivial mutations
+    # These exlusions are allowing code blocks to run with artithmetic involving zero and as a result are no-ops
+    # payjoin/src/core/send/mod.rs
+    "replace < with <= in PsbtContext::check_outputs",
+    "replace > with >= in PsbtContext::check_fees",
+    # payjoin/src/core/send/mod.rs
+    "replace < with <= in PsbtContextBuilder::build_recommended", # clamping the fee contribution when the fee equals to the recommended fee does not do anything
 
-	# Async SystemTime comparison
-        # checking if the system time is equal to the expiry is difficult to reasonably test
-	# payjoin/src/core/receive/v2/mod.rs
-	"replace < with <= in Receiver<Initialized>::apply_unchecked_from_payload",
-        "replace > with >= in Receiver<Initialized>::create_poll_request",
-	"replace > with >= in extract_err_req",
-	# payjoin/src/core/send/v2/mod.rs
-	"replace > with >= in Sender<WithReplyKey>::create_v2_post_request",
+    # Async SystemTime comparison
+    # checking if the system time is equal to the expiry is difficult to reasonably test
+    # payjoin/src/core/receive/v2/mod.rs
+    "replace < with <= in Receiver<Initialized>::apply_unchecked_from_payload",
+    "replace > with >= in Receiver<Initialized>::create_poll_request",
+    "replace > with >= in extract_err_req",
+    # payjoin/src/core/send/v2/mod.rs
+    "replace > with >= in Sender<WithReplyKey>::create_v2_post_request",
 
-	# TODO exclusions
-	# payjoin/src/core/receive/v1/mod.rs
-	"replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is
-	# payjoin/src/core/send/mod.rs
-	"replace match guard proposed_txout.script_pubkey == original_output.script_pubkey with true in PsbtContext::check_outputs", # This non-deterministic mutation has a possible test to catch it
-	"replace == with != in Receiver<Initialized>::unchecked_from_payload", #This mutant is something we intend to address in issue #948
+    # TODO exclusions
+    # payjoin/src/core/receive/v1/mod.rs
+    "replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is
+    # payjoin/src/core/send/mod.rs
+    "replace match guard proposed_txout.script_pubkey == original_output.script_pubkey with true in PsbtContext::check_outputs", # This non-deterministic mutation has a possible test to catch it
 ]


### PR DESCRIPTION
This test ensures that output substitution is always disabled for v1 proposals in the v2 receive logic, as required by BIP-78. It kills the mutant described in issue #946 by failing if the enforcement logic is inverted. This guards against regressions and enforces the spec.