### PR TITLE
Use reply key for replyable errors to v2 senders

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -13,7 +13,7 @@ use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::{Amount, FeeRate};
-use payjoin::receive::v1::{PayjoinProposal, UncheckedProposal};
+use payjoin::receive::v1::{PayjoinProposal, UncheckedOriginalPayload};
 use payjoin::receive::ReplyableError::{self, Implementation, V1};
 use payjoin::send::v1::SenderBuilder;
 use payjoin::{ImplementationError, IntoUrl, Uri, UriExt};
@@ -301,7 +301,7 @@ impl App {
             .await
             .map_err(|e| Implementation(ImplementationError::new(e)))?
             .to_bytes();
-        let proposal = UncheckedProposal::from_request(&body, query_string, headers)?;
+        let proposal = UncheckedOriginalPayload::from_request(&body, query_string, headers)?;
 
         let payjoin_proposal = self.process_v1_proposal(proposal)?;
         let psbt = payjoin_proposal.psbt();
@@ -315,7 +315,7 @@ impl App {
 
     fn process_v1_proposal(
         &self,
-        proposal: UncheckedProposal,
+        proposal: UncheckedOriginalPayload,
     ) -> Result<PayjoinProposal, ReplyableError> {
         let wallet = self.wallet();
 

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -7,8 +7,8 @@ use payjoin::persist::OptionalTransitionOutcome;
 use payjoin::receive::v2::{
     process_err_res, replay_event_log as replay_receiver_event_log, Initialized, MaybeInputsOwned,
     MaybeInputsSeen, OutputsUnknown, PayjoinProposal, ProvisionalProposal, ReceiveSession,
-    Receiver, ReceiverBuilder, SessionHistory, UncheckedProposal, WantsFeeRange, WantsInputs,
-    WantsOutputs,
+    Receiver, ReceiverBuilder, SessionHistory, UncheckedOriginalPayload, WantsFeeRange,
+    WantsInputs, WantsOutputs,
 };
 use payjoin::send::v2::{
     replay_event_log as replay_sender_event_log, SendSession, Sender, SenderBuilder, V2GetContext,
@@ -297,7 +297,7 @@ impl App {
         &self,
         session: Receiver<Initialized>,
         persister: &ReceiverPersister,
-    ) -> Result<Receiver<UncheckedProposal>> {
+    ) -> Result<Receiver<UncheckedOriginalPayload>> {
         let ohttp_relay = self
             .unwrap_relay_or_else_fetch(Some(session.pj_uri().extras.endpoint().clone()))
             .await?;
@@ -333,7 +333,7 @@ impl App {
             match session {
                 ReceiveSession::Initialized(proposal) =>
                     self.read_from_directory(proposal, persister).await,
-                ReceiveSession::UncheckedProposal(proposal) =>
+                ReceiveSession::UncheckedOriginalPayload(proposal) =>
                     self.check_proposal(proposal, persister).await,
                 ReceiveSession::MaybeInputsOwned(proposal) =>
                     self.check_inputs_not_owned(proposal, persister).await,
@@ -393,7 +393,7 @@ impl App {
 
     async fn check_proposal(
         &self,
-        proposal: Receiver<UncheckedProposal>,
+        proposal: Receiver<UncheckedOriginalPayload>,
         persister: &ReceiverPersister,
     ) -> Result<()> {
         let wallet = self.wallet();

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -233,7 +233,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_maybe_inputs_owned(
 }
 
 Future<payjoin.PayjoinProposalReceiveSession> process_unchecked_proposal(
-    payjoin.UncheckedProposal proposal,
+    payjoin.UncheckedOriginalPayload proposal,
     InMemoryReceiverPersister recv_persister) async {
   final unchecked_proposal = proposal
       .checkBroadcastSuitability(null, MempoolAcceptanceCallback(receiver))
@@ -258,7 +258,7 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
   }
   var proposal = res.success();
   return await process_unchecked_proposal(
-      proposal as payjoin.UncheckedProposal, recv_persister);
+      proposal as payjoin.UncheckedOriginalPayload, recv_persister);
 }
 
 Future<payjoin.ReceiveSession?> process_receiver_proposal(
@@ -274,7 +274,7 @@ Future<payjoin.ReceiveSession?> process_receiver_proposal(
     return res;
   }
 
-  if (receiver is payjoin.UncheckedProposalReceiveSession) {
+  if (receiver is payjoin.UncheckedOriginalPayloadReceiveSession) {
     return await process_unchecked_proposal(receiver.inner, recv_persister);
   }
   if (receiver is payjoin.MaybeInputsOwnedReceiveSession) {

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -101,7 +101,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         proposal = res.success()
         return await self.process_unchecked_proposal(proposal, recv_persister)
 
-    async def process_unchecked_proposal(self, proposal: UncheckedProposal, recv_persister: InMemoryReceiverSessionEventLog) :
+    async def process_unchecked_proposal(self, proposal: UncheckedOriginalPayload, recv_persister: InMemoryReceiverSessionEventLog) :
         receiver = proposal.check_broadcast_suitability(None, MempoolAcceptanceCallback(self.receiver)).save(recv_persister)
         return await self.process_maybe_inputs_owned(receiver, recv_persister)
 

--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -18,7 +18,7 @@ use super::optional_parameters::Params;
 use super::{InputPair, OutputSubstitutionError, ReplyableError, SelectionError};
 use crate::output_substitution::OutputSubstitution;
 use crate::psbt::PsbtExt;
-use crate::receive::{InternalPayloadError, Original, PsbtContext};
+use crate::receive::{InternalPayloadError, OriginalPayload, PsbtContext};
 
 /// Typestate which the receiver may substitute or add outputs to.
 ///
@@ -38,11 +38,11 @@ pub struct WantsOutputs {
 }
 
 impl WantsOutputs {
-    /// Create a new [`WantsOutputs`] typestate from an [`Original`] typestate and a list of
+    /// Create a new [`WantsOutputs`] typestate from an [`OriginalPayload`] typestate and a list of
     /// owned outputs.
     ///
     /// The first output in the `owned_vouts` list is used as the `change_vout`.
-    pub(crate) fn new(original: Original, owned_vouts: Vec<usize>) -> Self {
+    pub(crate) fn new(original: OriginalPayload, owned_vouts: Vec<usize>) -> Self {
         Self {
             original_psbt: original.psbt.clone(),
             payjoin_psbt: original.psbt,
@@ -670,7 +670,7 @@ mod tests {
         assert_eq!(original.psbt_fee_rate().unwrap().to_sat_per_vb_floor(), 2);
         // Specify excessive fee rate in sender params
         original_params.min_fee_rate = FeeRate::from_sat_per_vb_unchecked(1000);
-        let updated_original = Original { psbt: original.psbt, params: original_params };
+        let updated_original = OriginalPayload { psbt: original.psbt, params: original_params };
 
         let proposal_psbt = Psbt::from_str(RECEIVER_INPUT_CONTRIBUTION).unwrap();
         let input = InputPair::new(

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -336,12 +336,12 @@ impl PsbtContext {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Original {
+pub struct OriginalPayload {
     psbt: Psbt,
     params: Params,
 }
 
-impl Original {
+impl OriginalPayload {
     // Calculates the fee rate of the original proposal PSBT.
     fn psbt_fee_rate(&self) -> Result<FeeRate, InternalPayloadError> {
         let original_psbt_fee = self.psbt.fee().map_err(|e| {
@@ -475,11 +475,11 @@ pub(crate) mod tests {
     // We should pub(crate) it and moved to a common place.
     const NON_WITNESS_DATA_WEIGHT: Weight = Weight::from_non_witness_data_size(32 + 4 + 4);
 
-    pub(crate) fn original_from_test_vector() -> Original {
+    pub(crate) fn original_from_test_vector() -> OriginalPayload {
         let pairs = url::form_urlencoded::parse(QUERY_PARAMS.as_bytes());
         let params = Params::from_query_pairs(pairs, &[Version::One])
             .expect("Could not parse params from query pairs");
-        Original { psbt: PARSED_ORIGINAL_PSBT.clone(), params }
+        OriginalPayload { psbt: PARSED_ORIGINAL_PSBT.clone(), params }
     }
 
     #[test]

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -71,7 +71,7 @@ impl UncheckedOriginalPayload {
         let (psbt, params) = crate::receive::parse_payload(base64, query, SUPPORTED_VERSIONS)
             .map_err(ReplyableError::Payload)?;
 
-        Ok(Self { original: Original { psbt, params } })
+        Ok(Self { original: OriginalPayload { psbt, params } })
     }
 }
 
@@ -94,7 +94,7 @@ impl UncheckedOriginalPayload {
 /// can go ahead with calling [`Self::assume_interactive_receiver`] to move on to the next typestate.
 #[derive(Debug, Clone)]
 pub struct UncheckedOriginalPayload {
-    original: Original,
+    original: OriginalPayload,
 }
 
 impl UncheckedOriginalPayload {
@@ -136,7 +136,7 @@ impl UncheckedOriginalPayload {
 /// Call [`Self::check_inputs_not_owned`] to proceed.
 #[derive(Debug, Clone)]
 pub struct MaybeInputsOwned {
-    pub(crate) original: Original,
+    pub(crate) original: OriginalPayload,
 }
 
 impl MaybeInputsOwned {
@@ -166,7 +166,7 @@ impl MaybeInputsOwned {
 /// Call [`Self::check_no_inputs_seen_before`] to proceed.
 #[derive(Debug, Clone)]
 pub struct MaybeInputsSeen {
-    original: Original,
+    original: OriginalPayload,
 }
 impl MaybeInputsSeen {
     /// Check that the receiver has never seen the inputs in the original proposal before.
@@ -194,7 +194,7 @@ impl MaybeInputsSeen {
 /// Call [`Self::identify_receiver_outputs`] to proceed.
 #[derive(Debug, Clone)]
 pub struct OutputsUnknown {
-    original: Original,
+    original: OriginalPayload,
 }
 
 impl OutputsUnknown {
@@ -409,14 +409,18 @@ mod tests {
         let pairs = url::form_urlencoded::parse(QUERY_PARAMS.as_bytes());
         let params = Params::from_query_pairs(pairs, &[Version::One])
             .expect("Could not parse params from query pairs");
-        UncheckedOriginalPayload { original: Original { psbt: PARSED_ORIGINAL_PSBT.clone(), params } }
+        UncheckedOriginalPayload {
+            original: OriginalPayload { psbt: PARSED_ORIGINAL_PSBT.clone(), params },
+        }
     }
 
     fn maybe_inputs_owned_from_test_vector() -> MaybeInputsOwned {
         let pairs = url::form_urlencoded::parse(QUERY_PARAMS.as_bytes());
         let params = Params::from_query_pairs(pairs, &[Version::One])
             .expect("Could not parse params from query pairs");
-        MaybeInputsOwned { original: Original { psbt: PARSED_ORIGINAL_PSBT.clone(), params } }
+        MaybeInputsOwned {
+            original: OriginalPayload { psbt: PARSED_ORIGINAL_PSBT.clone(), params },
+        }
     }
 
     fn wants_outputs_from_test_vector(proposal: UncheckedOriginalPayload) -> WantsOutputs {

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -7,7 +7,7 @@
 //!    using [`build_v1_pj_uri`]
 //! 2. Listen for a sender's request on the `pj` endpoint
 //! 3. Parse the request using
-//!    [`UncheckedProposal::from_request()`]
+//!    [`UncheckedOriginalPayload::from_request()`]
 //! 4. Validate the proposal using the `check` methods to guide you.
 //! 5. Assuming the proposal is valid, augment it into a payjoin with the available
 //!    `try_preserving_privacy` and `contribute` methods
@@ -58,7 +58,7 @@ pub fn build_v1_pj_uri<'a>(
     Ok(bitcoin_uri::Uri::with_extras(address.clone(), extras))
 }
 
-impl UncheckedProposal {
+impl UncheckedOriginalPayload {
     pub fn from_request(
         body: &[u8],
         query: &str,
@@ -71,7 +71,7 @@ impl UncheckedProposal {
         let (psbt, params) = crate::receive::parse_payload(base64, query, SUPPORTED_VERSIONS)
             .map_err(ReplyableError::Payload)?;
 
-        Ok(UncheckedProposal { original: Original { psbt, params } })
+        Ok(Self { original: Original { psbt, params } })
     }
 }
 
@@ -93,11 +93,11 @@ impl UncheckedProposal {
 /// If you are implementing an interactive payment receiver, then such checks are not necessary, and you
 /// can go ahead with calling [`Self::assume_interactive_receiver`] to move on to the next typestate.
 #[derive(Debug, Clone)]
-pub struct UncheckedProposal {
+pub struct UncheckedOriginalPayload {
     original: Original,
 }
 
-impl UncheckedProposal {
+impl UncheckedOriginalPayload {
     /// Checks that the original PSBT in the proposal can be broadcasted.
     ///
     /// If the receiver is a non-interactive payment processor (ex. a donation page which generates
@@ -387,7 +387,7 @@ mod tests {
         let validated_request = validate_body(headers.clone(), body);
         assert!(validated_request.is_ok());
 
-        let proposal = UncheckedProposal::from_request(body, QUERY_PARAMS, headers)?;
+        let proposal = UncheckedOriginalPayload::from_request(body, QUERY_PARAMS, headers)?;
 
         let witness_utxo = proposal.original.psbt.inputs[0]
             .witness_utxo
@@ -405,11 +405,11 @@ mod tests {
         Ok(())
     }
 
-    fn unchecked_proposal_from_test_vector() -> UncheckedProposal {
+    fn unchecked_proposal_from_test_vector() -> UncheckedOriginalPayload {
         let pairs = url::form_urlencoded::parse(QUERY_PARAMS.as_bytes());
         let params = Params::from_query_pairs(pairs, &[Version::One])
             .expect("Could not parse params from query pairs");
-        UncheckedProposal { original: Original { psbt: PARSED_ORIGINAL_PSBT.clone(), params } }
+        UncheckedOriginalPayload { original: Original { psbt: PARSED_ORIGINAL_PSBT.clone(), params } }
     }
 
     fn maybe_inputs_owned_from_test_vector() -> MaybeInputsOwned {
@@ -419,7 +419,7 @@ mod tests {
         MaybeInputsOwned { original: Original { psbt: PARSED_ORIGINAL_PSBT.clone(), params } }
     }
 
-    fn wants_outputs_from_test_vector(proposal: UncheckedProposal) -> WantsOutputs {
+    fn wants_outputs_from_test_vector(proposal: UncheckedOriginalPayload) -> WantsOutputs {
         proposal
             .assume_interactive_receiver()
             .check_inputs_not_owned(&mut |_| Ok(false))
@@ -437,7 +437,9 @@ mod tests {
             .expect("Receiver output should be identified")
     }
 
-    fn provisional_proposal_from_test_vector(proposal: UncheckedProposal) -> ProvisionalProposal {
+    fn provisional_proposal_from_test_vector(
+        proposal: UncheckedOriginalPayload,
+    ) -> ProvisionalProposal {
         wants_outputs_from_test_vector(proposal)
             .commit_outputs()
             .commit_inputs()

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -6,7 +6,7 @@ use super::{ReceiveSession, SessionContext};
 use crate::output_substitution::OutputSubstitution;
 use crate::persist::SessionPersister;
 use crate::receive::v2::{extract_err_req, SessionError};
-use crate::receive::{common, JsonReply, Original, PsbtContext};
+use crate::receive::{common, JsonReply, OriginalPayload, PsbtContext};
 use crate::{ImplementationError, IntoUrl, PjUri, Request};
 
 /// Errors that can occur when replaying a receiver event log
@@ -88,7 +88,7 @@ impl SessionHistory {
         })
     }
 
-    fn get_unchecked_proposal(&self) -> Option<Original> {
+    fn get_unchecked_proposal(&self) -> Option<OriginalPayload> {
         self.events.iter().find_map(|event| match event {
             SessionEvent::UncheckedOriginalPayload(proposal) => Some(proposal.0.clone()),
             _ => None,
@@ -175,7 +175,7 @@ impl SessionHistory {
 /// Each event can be used to transition the receiver state machine to a new state
 pub enum SessionEvent {
     Created(SessionContext),
-    UncheckedOriginalPayload((Original, Option<crate::HpkePublicKey>)),
+    UncheckedOriginalPayload((OriginalPayload, Option<crate::HpkePublicKey>)),
     MaybeInputsOwned(),
     MaybeInputsSeen(),
     OutputsUnknown(),

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -173,7 +173,7 @@ mod integration {
         use payjoin::persist::NoopSessionPersister;
         use payjoin::receive::v2::{
             replay_event_log as replay_receiver_event_log, PayjoinProposal, Receiver,
-            ReceiverBuilder, UncheckedProposal,
+            ReceiverBuilder, UncheckedOriginalPayload,
         };
         use payjoin::send::v2::SenderBuilder;
         use payjoin::{OhttpKeys, PjUri, UriExt};
@@ -724,7 +724,7 @@ mod integration {
 
         fn handle_directory_proposal(
             receiver: &bitcoincore_rpc::Client,
-            proposal: Receiver<UncheckedProposal>,
+            proposal: Receiver<UncheckedOriginalPayload>,
             custom_inputs: Option<Vec<InputPair>>,
         ) -> Result<Receiver<PayjoinProposal>, BoxError> {
             let noop_persister = NoopSessionPersister::default();
@@ -1069,7 +1069,7 @@ mod integration {
         custom_inputs: Option<Vec<InputPair>>,
     ) -> Result<String, BoxError> {
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
-        let proposal = payjoin::receive::v1::UncheckedProposal::from_request(
+        let proposal = payjoin::receive::v1::UncheckedOriginalPayload::from_request(
             req.body.as_slice(),
             req.url.query().unwrap_or(""),
             headers,
@@ -1082,7 +1082,7 @@ mod integration {
     }
 
     fn handle_proposal(
-        proposal: payjoin::receive::v1::UncheckedProposal,
+        proposal: payjoin::receive::v1::UncheckedOriginalPayload,
         receiver: &bitcoincore_rpc::Client,
         custom_outputs: Option<Vec<TxOut>>,
         drain_script: Option<&bitcoin::Script>,


### PR DESCRIPTION
Before some relatively recent spec changes, two messages were written to the same mailbox. The error path was not updated to reflect this, so the sender will not receive it (as it is polling a different mailbox), and the receiver further relied on the directory allowing mailbox contents to be overwritable (or at least accepting the POST request).

With this change a replyable error will be sent to the reply key, assuming one was obtained from the first message. If no key can be recovered from the message then there is no point in sending a reply as the peer is not adhering to the protocol.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

