### PR TITLE
Remove redundant Vec clones in HPKE encrypt functions

### DIFF
--- a/payjoin/src/core/hpke.rs
+++ b/payjoin/src/core/hpke.rs
@@ -189,7 +189,7 @@ pub fn encrypt_message_a(
     let ciphertext = encryption_context.seal(&plaintext, &[])?;
     let mut message_a = ellswift_bytes_from_encapped_key(&encapsulated_key)?.to_vec();
     message_a.extend(&ciphertext);
-    Ok(message_a.to_vec())
+    Ok(message_a)
 }
 
 pub fn decrypt_message_a(
@@ -241,7 +241,7 @@ pub fn encrypt_message_b(
     let ciphertext = encryption_context.seal(plaintext, &[])?;
     let mut message_b = ellswift_bytes_from_encapped_key(&encapsulated_key)?.to_vec();
     message_b.extend(&ciphertext);
-    Ok(message_b.to_vec())
+    Ok(message_b)
 }
 
 pub fn decrypt_message_b(


### PR DESCRIPTION
Part of #402 

Replace .to_vec() calls with direct returns in encrypt_message_a and encrypt_message_b since message_a/message_b are already Vec<u8> and not used after the return statement.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

