### PR TITLE
Reduce visibility of `session_context` method

### DIFF
--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -143,7 +143,7 @@ impl SessionHistory {
         Ok(Some((req, ctx)))
     }
 
-    pub fn session_context(&self) -> Option<&SessionContext> {
+    fn session_context(&self) -> Option<&SessionContext> {
         self.events.iter().find_map(|event| match event {
             SessionEvent::Created(session_context) => Some(session_context),
             _ => None,


### PR DESCRIPTION
Integrations do not need access to the entire session context. For anything specific, we can create one-off methods.

## Pull Request Checklist

Please confirm the following before requesting review:

- [X] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

