### PR TITLE
Supertrait seal `{send,receive}::..State` traits

### DIFF
--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -177,7 +177,18 @@ impl SenderBuilder {
     }
 }
 
-pub trait State {}
+mod sealed {
+    pub trait State {}
+
+    impl State for super::WithReplyKey {}
+    impl State for super::V2GetContext {}
+}
+
+/// Sealed trait for V2 send session states.
+///
+/// This trait is sealed to prevent external implementations. Only types within this crate
+/// can implement this trait, ensuring type safety and protocol integrity.
+pub trait State: sealed::State {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sender<State> {
@@ -237,8 +248,6 @@ pub struct WithReplyKey {
     /// The secret key to decrypt the receiver's reply.
     pub(crate) reply_key: HpkeSecretKey,
 }
-
-impl State for WithReplyKey {}
 
 impl WithReplyKey {
     fn new(pj_param: PjParam, psbt_ctx: PsbtContext) -> Self {
@@ -403,8 +412,6 @@ pub struct V2GetContext {
     pub(crate) psbt_ctx: PsbtContext,
     pub(crate) reply_key: HpkeSecretKey,
 }
-
-impl State for V2GetContext {}
 
 impl Sender<V2GetContext> {
     /// Construct an OHTTP Encapsulated HTTP GET request for the Proposal PSBT


### PR DESCRIPTION
These traits are in the public API but not for downstream users to implement. Close #747

Here's an article on what the heck that means: https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

