### PR TITLE
Add receiver pk to session metadata

### DIFF
--- a/payjoin-cli/src/db/mod.rs
+++ b/payjoin-cli/src/db/mod.rs
@@ -37,6 +37,7 @@ impl Database {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS send_sessions (
                 session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                receiver_pubkey BLOB NOT NULL,
                 completed_at INTEGER
             )",
             [],


### PR DESCRIPTION
This allows the refrence to find a resumable session without having to replay each session. And removes a misuse of pj endpoint when trying to filter resumable sessions.

Related ticket: https://github.com/payjoin/rust-payjoin/issues/336

---- 
Could also do something similar for the receiver where you first generate an ephemeral session id, generate your HPKE keypair then find and replace the session id -- but that is ugly. A much better approach would be a receiver builder model where you first generate the key pair and other parts of the session context and then build(session_persister(short_id)). Builder model is also more attractive bc we are also expanding the session context with optional fields (#933 #920 )  

## Pull Request Checklist

Please confirm the following before requesting review:

- [X] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

