### PR TITLE
fail CI if python -m unittest exits with failure

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
+      - .github/workflows/python.yml
 env:
   # Override the value from the rust-toolchain file
   # This is necessary because even though the correct toolchain


### PR DESCRIPTION
In CI it appears that `python -m unittest` is failing due to the latest testcontainer crate's async functionality. It's not clear to me why yet, but it complains about the tokio runtime.

This PR only addresses the fact that the failure results in a false negative (as in CI doesn't report the failure as a failed run).