### PR TITLE
Simplify session id pj cli

### DIFF
--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -8,7 +8,7 @@ use rusqlite::params;
 use super::*;
 
 #[derive(Debug, Clone)]
-pub struct SessionId(i64);
+pub(crate) struct SessionId(i64);
 
 impl core::ops::Deref for SessionId {
     type Target = i64;


### PR DESCRIPTION
Both sender and receiver use the same i64 row id as their "session id". There is really no need for an enum representation.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

