### PR TITLE
Remove apt commands from bindings generate script

### DIFF
--- a/payjoin-ffi/python/scripts/generate_bindings.sh
+++ b/payjoin-ffi/python/scripts/generate_bindings.sh
@@ -11,8 +11,6 @@ if [[ "$OS" == "Darwin" ]]; then
     python3 --version
     pip install -r requirements.txt -r requirements-dev.txt
 elif [[ "$OS" == "Linux" ]]; then
-    sudo apt update
-    sudo apt install -y build-essential python3-dev
     LIBNAME=libpayjoin_ffi.so
     PYBIN=$(dirname $(which python))
     PYBIN="$PYBIN" 


### PR DESCRIPTION
We don't actually use apt in this script. And its possible apt is not the prefered package manager of the distro.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

