### PR TITLE
Add missing uniffi exports

### DIFF
--- a/payjoin-ffi/src/io.rs
+++ b/payjoin-ffi/src/io.rs
@@ -21,6 +21,7 @@ pub mod error {
 ///
 /// * `payjoin_directory`: The payjoin directory from which to fetch the ohttp keys.  This
 ///   directory stores and forwards payjoin client payloads.
+#[uniffi::export]
 pub async fn fetch_ohttp_keys(
     ohttp_relay: &str,
     payjoin_directory: &str,

--- a/payjoin-ffi/src/uri/mod.rs
+++ b/payjoin-ffi/src/uri/mod.rs
@@ -6,7 +6,7 @@ use payjoin::bitcoin::address::NetworkChecked;
 use payjoin::UriExt;
 
 pub mod error;
-#[derive(Clone)]
+#[derive(Clone, uniffi::Object)]
 pub struct Uri(payjoin::Uri<'static, NetworkChecked>);
 impl From<Uri> for payjoin::Uri<'static, NetworkChecked> {
     fn from(value: Uri) -> Self { value.0 }
@@ -16,7 +16,9 @@ impl From<payjoin::Uri<'static, NetworkChecked>> for Uri {
     fn from(value: payjoin::Uri<'static, NetworkChecked>) -> Self { Uri(value) }
 }
 
+#[uniffi::export]
 impl Uri {
+    #[uniffi::constructor]
     pub fn parse(uri: String) -> Result<Self, PjParseError> {
         match payjoin::Uri::from_str(uri.as_str()) {
             Ok(e) => Ok(e.assume_checked().into()),


### PR DESCRIPTION
`fetch_ohttp_keys` and `Uri::parse` need to be callable in foreign languages.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

