### PR TITLE
Use default dev profile for development in ffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,6 @@
 members = ["payjoin", "payjoin-cli", "payjoin-directory", "payjoin-test-utils", "payjoin-ffi"]
 resolver = "2"
 
-[profile.release-smaller]
-inherits = "release"
-opt-level = 'z'
-lto = true
-codegen-units = 1
-strip = true
-
 [patch.crates-io]
 payjoin = { path = "payjoin" }
 payjoin-directory = { path = "payjoin-directory" }

--- a/payjoin-ffi/dart/scripts/generate_bindings.sh
+++ b/payjoin-ffi/dart/scripts/generate_bindings.sh
@@ -19,29 +19,29 @@ fi
 
 cd ../
 echo "Generating payjoin dart..."
-cargo build --features _test-utils --profile release
-cargo run --features _test-utils --profile release --bin uniffi-bindgen -- --library ../target/release/$LIBNAME --language dart --out-dir dart/lib/
+cargo build --features _test-utils --profile dev
+cargo run --features _test-utils --profile dev --bin uniffi-bindgen -- --library ../target/debug/$LIBNAME --language dart --out-dir dart/lib/
 
 if [[ "$OS" == "Darwin" ]]; then
     echo "Generating native binaries..."
     rustup target add aarch64-apple-darwin x86_64-apple-darwin
     # This is a test script the actual release should not include the test utils feature
-    cargo build --profile release-smaller --target aarch64-apple-darwin --features _test-utils &
-    cargo build --profile release-smaller --target x86_64-apple-darwin --features _test-utils &
+    cargo build --profile dev --target aarch64-apple-darwin --features _test-utils &
+    cargo build --profile dev --target x86_64-apple-darwin --features _test-utils &
     wait
 
     echo "Building macos fat library"
     lipo -create -output dart/$LIBNAME \
-        ../target/aarch64-apple-darwin/release-smaller/$LIBNAME \
-        ../target/x86_64-apple-darwin/release-smaller/$LIBNAME
+        ../target/aarch64-apple-darwin/debug/$LIBNAME \
+        ../target/x86_64-apple-darwin/debug/$LIBNAME
 else
     echo "Generating native binaries..."
     rustup target add x86_64-unknown-linux-gnu
     # This is a test script the actual release should not include the test utils feature
-    cargo build --profile release-smaller --target x86_64-unknown-linux-gnu --features _test-utils
+    cargo build --profile dev --target x86_64-unknown-linux-gnu --features _test-utils
 
     echo "Copying payjoin_ffi binary"
-    cp ../target/x86_64-unknown-linux-gnu/release-smaller/$LIBNAME dart/$LIBNAME
+    cp ../target/x86_64-unknown-linux-gnu/debug/$LIBNAME dart/$LIBNAME
 fi
 
 echo "All done!"

--- a/payjoin-ffi/python/scripts/generate_bindings.sh
+++ b/payjoin-ffi/python/scripts/generate_bindings.sh
@@ -23,30 +23,30 @@ fi
 
 cd ../
 # This is a test script the actual release should not include the test utils feature
-cargo build --features _test-utils --profile release 
-cargo run --features _test-utils --profile release --bin uniffi-bindgen generate --library ../target/release/$LIBNAME --language python --out-dir python/src/payjoin/
+cargo build --features _test-utils --profile dev 
+cargo run --features _test-utils --profile dev --bin uniffi-bindgen generate --library ../target/debug/$LIBNAME --language python --out-dir python/src/payjoin/
 
 if [[ "$OS" == "Darwin" ]]; then
     echo "Generating native binaries..."
     rustup target add aarch64-apple-darwin x86_64-apple-darwin
     # This is a test script the actual release should not include the test utils feature
-    cargo build --profile release-smaller --target aarch64-apple-darwin --features _test-utils &
-    cargo build --profile release-smaller --target x86_64-apple-darwin --features _test-utils &
+    cargo build --profile dev --target aarch64-apple-darwin --features _test-utils &
+    cargo build --profile dev --target x86_64-apple-darwin --features _test-utils &
     wait
 
     echo "Building macos fat library"
     lipo -create -output python/src/payjoin/$LIBNAME \
-        ../target/aarch64-apple-darwin/release-smaller/$LIBNAME \
-        ../target/x86_64-apple-darwin/release-smaller/$LIBNAME
+        ../target/aarch64-apple-darwin/debug/$LIBNAME \
+        ../target/x86_64-apple-darwin/debug/$LIBNAME
 
 else
     echo "Generating native binaries..."
     rustup target add x86_64-unknown-linux-gnu
     # This is a test script the actual release should not include the test utils feature
-    cargo build --profile release-smaller --target x86_64-unknown-linux-gnu --features _test-utils
+    cargo build --profile dev --target x86_64-unknown-linux-gnu --features _test-utils
 
     echo "Copying payjoin_ffi binary"
-    cp ../target/x86_64-unknown-linux-gnu/release-smaller/$LIBNAME python/src/payjoin/$LIBNAME
+    cp ../target/x86_64-unknown-linux-gnu/debug/$LIBNAME python/src/payjoin/$LIBNAME
 fi
 
 echo "All done!"


### PR DESCRIPTION
Before we had a custom release-smaller profile that had some custom features better suited for an actual release.

Instead we can use the default dev profile for everyday development and CI workflows and only use the release based profile for official releases.

Closes #1008

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] A **human** has reviewed every single line of this code before opening the PR (no auto-generated, unreviewed LLM/robot submissions).
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

