### PR TITLE
Remove uninitialized session state 

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -352,8 +352,6 @@ impl App {
                     self.finalize_proposal(proposal, persister).await,
                 ReceiveSession::PayjoinProposal(proposal) =>
                     self.send_payjoin_proposal(proposal, persister).await,
-                ReceiveSession::Uninitialized =>
-                    return Err(anyhow!("Uninitialized receiver session")),
                 ReceiveSession::TerminalFailure =>
                     return Err(anyhow!("Terminal receiver session")),
             }

--- a/payjoin-ffi/src/receive/error.rs
+++ b/payjoin-ffi/src/receive/error.rs
@@ -153,4 +153,6 @@ pub struct PsbtInputError(#[from] receive::PsbtInputError);
 /// Error that may occur when a receiver event log is replayed
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]
-pub struct ReceiverReplayError(#[from] receive::v2::ReplayError);
+pub struct ReceiverReplayError(
+    #[from] payjoin::error::ReplayError<receive::v2::ReceiveSession, receive::v2::SessionEvent>,
+);

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -75,7 +75,6 @@ impl ReceiverSessionEvent {
 
 #[derive(Clone, uniffi::Enum)]
 pub enum ReceiveSession {
-    Uninitialized,
     Initialized { inner: Arc<Initialized> },
     UncheckedOriginalPayload { inner: Arc<UncheckedOriginalPayload> },
     MaybeInputsOwned { inner: Arc<MaybeInputsOwned> },
@@ -93,7 +92,6 @@ impl From<payjoin::receive::v2::ReceiveSession> for ReceiveSession {
     fn from(value: payjoin::receive::v2::ReceiveSession) -> Self {
         use payjoin::receive::v2::ReceiveSession;
         match value {
-            ReceiveSession::Uninitialized => Self::Uninitialized,
             ReceiveSession::Initialized(inner) =>
                 Self::Initialized { inner: Arc::new(inner.into()) },
             ReceiveSession::UncheckedOriginalPayload(inner) =>

--- a/payjoin-ffi/src/send/error.rs
+++ b/payjoin-ffi/src/send/error.rs
@@ -85,7 +85,9 @@ pub struct WellKnownError(#[from] send::WellKnownError);
 /// Error that may occur when the sender session event log is replayed
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]
-pub struct SenderReplayError(#[from] send::v2::ReplayError);
+pub struct SenderReplayError(
+    #[from] payjoin::error::ReplayError<send::v2::SendSession, send::v2::SessionEvent>,
+);
 
 /// Error that may occur during state machine transitions
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -68,7 +68,6 @@ impl SenderSessionEvent {
 
 #[derive(Clone, uniffi::Enum)]
 pub enum SendSession {
-    Uninitialized,
     WithReplyKey { inner: Arc<WithReplyKey> },
     V2GetContext { inner: Arc<V2GetContext> },
     ProposalReceived { inner: Arc<Psbt> },
@@ -79,7 +78,6 @@ impl From<payjoin::send::v2::SendSession> for SendSession {
     fn from(value: payjoin::send::v2::SendSession) -> Self {
         use payjoin::send::v2::SendSession;
         match value {
-            SendSession::Uninitialized => Self::Uninitialized,
             SendSession::WithReplyKey(inner) =>
                 Self::WithReplyKey { inner: Arc::new(inner.into()) },
             SendSession::V2GetContext(inner) =>

--- a/payjoin/src/core/error.rs
+++ b/payjoin/src/core/error.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::{error, fmt};
 
 #[derive(Debug)]
@@ -10,7 +11,7 @@ impl ImplementationError {
 }
 
 impl fmt::Display for ImplementationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { std::fmt::Display::fmt(&self.0, f) }
 }
 
 impl error::Error for ImplementationError {
@@ -32,4 +33,48 @@ impl From<&str> for ImplementationError {
         let error = Box::<dyn error::Error + Send + Sync>::from(e);
         ImplementationError::from(error)
     }
+}
+/// Errors that can occur when replaying a session event log
+#[cfg(feature = "v2")]
+#[derive(Debug)]
+pub struct ReplayError<SessionState, SessionEvent>(InternalReplayError<SessionState, SessionEvent>);
+
+#[cfg(feature = "v2")]
+impl<SessionState: Debug, SessionEvent: Debug> std::fmt::Display
+    for ReplayError<SessionState, SessionEvent>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use InternalReplayError::*;
+        match &self.0 {
+            NoEvents => write!(f, "No events found in session"),
+            InvalidEvent(event, session) => match session {
+                Some(session) => write!(f, "Invalid event ({event:?}) for session ({session:?})",),
+                None => write!(f, "Invalid first event ({event:?}) for session",),
+            },
+            PersistenceFailure(e) => write!(f, "Persistence failure: {e}"),
+        }
+    }
+}
+#[cfg(feature = "v2")]
+impl<SessionState: Debug, SessionEvent: Debug> std::error::Error
+    for ReplayError<SessionState, SessionEvent>
+{
+}
+
+#[cfg(feature = "v2")]
+impl<SessionState: Debug, SessionEvent: Debug> From<InternalReplayError<SessionState, SessionEvent>>
+    for ReplayError<SessionState, SessionEvent>
+{
+    fn from(e: InternalReplayError<SessionState, SessionEvent>) -> Self { ReplayError(e) }
+}
+
+#[cfg(feature = "v2")]
+#[derive(Debug)]
+pub(crate) enum InternalReplayError<SessionState, SessionEvent> {
+    /// No events in the event log
+    NoEvents,
+    /// Invalid initial event
+    InvalidEvent(Box<SessionEvent>, Option<Box<SessionState>>),
+    /// Application storage error
+    PersistenceFailure(ImplementationError),
 }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -34,14 +34,14 @@ pub(crate) use error::InternalSessionError;
 pub use error::SessionError;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
-use session::InternalReplayError;
-pub use session::{replay_event_log, ReplayError, SessionEvent, SessionHistory};
+pub use session::{replay_event_log, SessionEvent, SessionHistory};
 use url::Url;
 
 use super::error::{Error, InputContributionError};
 use super::{
     common, InternalPayloadError, JsonReply, OutputSubstitutionError, ProtocolError, SelectionError,
 };
+use crate::error::{InternalReplayError, ReplayError};
 use crate::hpke::{decrypt_message_a, encrypt_message_b, HpkeKeyPair, HpkePublicKey};
 use crate::ohttp::{
     ohttp_encapsulate, process_get_res, process_post_res, OhttpEncapsulationError, OhttpKeys,
@@ -145,7 +145,10 @@ impl ReceiveSession {
         ReceiveSession::Initialized(Receiver { state: Initialized {}, session_context: context })
     }
 
-    fn process_event(self, event: SessionEvent) -> Result<ReceiveSession, ReplayError> {
+    fn process_event(
+        self,
+        event: SessionEvent,
+    ) -> Result<ReceiveSession, ReplayError<Self, SessionEvent>> {
         match (self, event) {
             (
                 ReceiveSession::Initialized(state),


### PR DESCRIPTION
Unintialized should be an unreachable state and we are misusing it today. If one does not have any events in their log and replays then they will receive an uninitilaized receiver. Which is not useful. Not having any events and deciding to  replay an session is most likely a bug in the application and should get an error (`NoEvents`). Additionally, bc sessionState is pub applications have to match on uninitialized when processing their receiver states -- instead you should receive an error when you have no events in your log. The other reason Unintialized existed is to having a starting state when replaying the SEL. Which we can resolve by having a special carve out for the first sessionState (`SessionState::new`).

## Pull Request Checklist

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

