### PR TITLE
not all integration tests depend on both v1 and v2 support

### DIFF
--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "v1", feature = "v2"))]
 mod integration {
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -163,7 +162,8 @@ mod integration {
         }
     }
 
-    #[cfg(all(feature = "io", feature = "v2", feature = "_manual-tls"))]
+    // not all needs v1
+    #[cfg(all(feature = "io", feature = "v2", feature = "v1", feature = "_manual-tls"))]
     mod v2 {
         use std::sync::Arc;
         use std::time::Duration;


### PR DESCRIPTION
This PR simplifies the feature gating of the integration tests so that more of them can run if only v1 support is enabled.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

