### PR TITLE
Replace SystemTime with bitcoin::absolute::Time

### DIFF
--- a/payjoin/src/core/receive/v2/error.rs
+++ b/payjoin/src/core/receive/v2/error.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use std::error;
 
+use bitcoin::absolute::Time;
+
 use super::Error::V2;
 use crate::hpke::HpkeError;
 use crate::ohttp::{DirectoryResponseError, OhttpEncapsulationError};
@@ -27,7 +29,7 @@ pub(crate) enum InternalSessionError {
     /// Url parsing failed
     ParseUrl(crate::into_url::Error),
     /// The session has expired
-    Expired(std::time::SystemTime),
+    Expired(Time),
     /// OHTTP Encapsulation failed
     OhttpEncapsulation(OhttpEncapsulationError),
     /// Hybrid Public Key Encryption failed

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -1,5 +1,4 @@
-use std::time::SystemTime;
-
+use bitcoin::absolute::Time;
 use serde::{Deserialize, Serialize};
 
 use super::{ReceiveSession, SessionContext};
@@ -35,7 +34,7 @@ impl From<InternalReplayError> for ReplayError {
 #[derive(Debug)]
 pub(crate) enum InternalReplayError {
     /// Session expired
-    SessionExpired(SystemTime),
+    SessionExpired(Time),
     /// Invalid combination of state and event
     InvalidStateAndEvent(Box<ReceiveSession>, Box<SessionEvent>),
     /// Application storage error
@@ -324,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_replaying_unchecked_proposal_expiry() {
-        let now = SystemTime::now();
+        let now = crate::uri::v2::now();
         let context = SessionContext { expiry: now, ..SHARED_CONTEXT.clone() };
         let original = original_from_test_vector();
 

--- a/payjoin/src/core/send/error.rs
+++ b/payjoin/src/core/send/error.rs
@@ -364,6 +364,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "v1")]
     fn test_parse_json() {
         let known_str_error = r#"{"errorCode":"version-unsupported", "message":"custom message here", "supported": [1, 2]}"#;
         match ResponseError::parse(known_str_error) {

--- a/payjoin/src/core/send/v2/error.rs
+++ b/payjoin/src/core/send/v2/error.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 
+use bitcoin::absolute::Time;
+
 use crate::ohttp::DirectoryResponseError;
 
 /// Error returned when request could not be created.
@@ -15,7 +17,7 @@ pub(crate) enum InternalCreateRequestError {
     Url(crate::into_url::Error),
     Hpke(crate::hpke::HpkeError),
     OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
-    Expired(std::time::SystemTime),
+    Expired(Time),
 }
 
 impl fmt::Display for CreateRequestError {

--- a/payjoin/src/core/uri/mod.rs
+++ b/payjoin/src/core/uri/mod.rs
@@ -441,6 +441,7 @@ mod tests {
 
     /// Test that rejects HTTP URLs that are not onion addresses
     #[test]
+    #[cfg(feature = "v1")]
     fn test_http_non_onion_rejected() {
         // HTTP to regular domain should be rejected
         let url = "http://example.com";


### PR DESCRIPTION
**Fixes #893**

## Problem
When roundtrip testing a new concrete `v2::PjParams` struct, `SystemTime`'s nanosecond precision causes test failures. After serializing `SystemTime` into the EX1 u32 expiration parameter and deserializing back, precision is lost and `assert_eq` fails. This highlights a fundamental mismatch between `SystemTime`'s nanosecond precision and the protocol's second-precision requirements.

Additionally, `SystemTime` is not available in WASM environments, limiting the crate's portability.

## Solution
Replace `std::time::SystemTime` with `bitcoin::absolute::Time` throughout the v2 payjoin implementation for the following reasons:

### Why `bitcoin::absolute::Time` over alternatives:

**bitcoin::absolute::Time (Chosen)**
- Wraps a u32 Unix timestamp, matching payjoin's precision exactly
- Maintained by rust-bitcoin team with extensive testing  
- Built-in error handling and conversion methods
- WASM-compatible and already in dependency tree
- Clear semantic meaning and type safety
- Eliminates roundtrip precision loss


## Changes
- **Core refactoring**: Replace all `SystemTime` usage with `bitcoin::absolute::Time`
- **Helper functions**: Add `now()` and `now_as_unix_seconds()` utility functions in `uri::v2` module
- **Type updates**: Convert expiration fields in `SessionContext` and error types to use `Time`
- **Precision fix**: Ensure roundtrip serialization/deserialization maintains exact values
- **WASM compatibility**: Enable usage in WASM environments where `SystemTime` is unavailable

This change eliminates potential conversion issues between different time representations and provides better integration with Bitcoin's timestamp handling patterns used elsewhere in the codebase."

##AI disclosure
i used clause to understand the problem better i also used it to cross check the system::Time implementations in code base i also consulted Claude if the direction is okay

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

