### PR TITLE
remove duplicate short CLI flag

### DIFF
--- a/payjoin-directory/src/cli.rs
+++ b/payjoin-directory/src/cli.rs
@@ -21,7 +21,6 @@ pub struct Cli {
 
     #[arg(
         long,
-        short = 'p',
         env = "PJ_METRIC_PORT",
         default_value = "9090",
         help = "The port to bind for prometheus metrics export"


### PR DESCRIPTION
This fixes a bug introduced in the last rebase of #927, which only manifests when using `--help`.

This should have a regression test, but one is not included in this PR, see #1023

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

