### PR TITLE
Save max fee rate in receiver session context

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -162,6 +162,7 @@ impl AppTrait for App {
         let session =
             ReceiverBuilder::new(address, self.config.v2()?.pj_directory.clone(), ohttp_keys)?
                 .with_amount(amount)
+                .with_max_fee_rate(self.config.max_fee_rate.unwrap_or(FeeRate::BROADCAST_MIN))
                 .build()
                 .save(&persister)?;
 

--- a/payjoin-ffi/src/uri/error.rs
+++ b/payjoin-ffi/src/uri/error.rs
@@ -25,3 +25,7 @@ pub struct UrlParseError(#[from] payjoin::ParseError);
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]
 pub struct IntoUrlError(#[from] payjoin::IntoUrlError);
+
+#[derive(Debug, thiserror::Error, uniffi::Object)]
+#[error(transparent)]
+pub struct FeeRateError(#[from] bitcoin_ffi::error::FeeRateError);


### PR DESCRIPTION
The reference implementation currently overrides the original max fee rate preference when resuming a session. This commit pins the max fee rate preference to the session by persisting it in the session context. When applying fees, if the applications’s fee rate preference has changed, the updated preference takes precedence.

## Pull Request Checklist

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

-- 

Closes http://github.com/payjoin/rust-payjoin/issues/897
Changes were picked off #934 

cc @Johnosezele 