### PR TITLE
One expiration error: Separate session replay & protocol operation

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -26,8 +26,9 @@ exclude_re = [
 
     # Async SystemTime comparison
     # checking if the system time is equal to the expiry is difficult to reasonably test
+    # payjoin/src/core/receive/v2/session.rs and payjoin/src/core/send/v2/session.rs
+    "replace > with >= in replay_event_log",
     # payjoin/src/core/receive/v2/mod.rs
-    "replace < with <= in Receiver<Initialized>::apply_unchecked_from_payload",
     "replace > with >= in Receiver<Initialized>::create_poll_request",
     "replace > with >= in extract_err_req",
     # payjoin/src/core/send/v2/mod.rs

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,13 +11,13 @@ exclude_re = [
 	"Iterator",
 	".*Error",
 
-    # ---------------------Crate-specific exculsions---------------------
+    # ---------------------Crate-specific exclusions ---------------------
     # Timeout loops
     # src/receive/v1/mod.rs
     "interleave_shuffle", # Replacing index += 1 with index *= 1 in a loop causes a timeout due to an infinite loop
 
     # Trivial mutations
-    # These exlusions are allowing code blocks to run with artithmetic involving zero and as a result are no-ops
+    # These exclusions are allowing code blocks to run with arithmetic involving zero and as a result are no-ops
     # payjoin/src/core/send/mod.rs
     "replace < with <= in PsbtContext::check_outputs",
     "replace > with >= in PsbtContext::check_fees",

--- a/payjoin/src/core/receive/v2/error.rs
+++ b/payjoin/src/core/receive/v2/error.rs
@@ -11,7 +11,7 @@ use crate::receive::ProtocolError;
 /// This is currently opaque type because we aren't sure which variants will stay.
 /// You can only display it.
 #[derive(Debug)]
-pub struct SessionError(InternalSessionError);
+pub struct SessionError(pub(super) InternalSessionError);
 
 impl From<InternalSessionError> for SessionError {
     fn from(value: InternalSessionError) -> Self { SessionError(value) }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -472,11 +472,6 @@ impl Receiver<Initialized> {
         event: OriginalPayload,
         reply_key: Option<HpkePublicKey>,
     ) -> Result<ReceiveSession, InternalReplayError> {
-        if self.state.context.expiry < SystemTime::now() {
-            // Session is expired, close the session
-            return Err(InternalReplayError::SessionExpired(self.state.context.expiry));
-        }
-
         let new_state = Receiver {
             state: UncheckedOriginalPayload {
                 original: event,

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -206,6 +206,8 @@ pub enum SessionEvent {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use payjoin_test_utils::{BoxError, EXAMPLE_URL};
 
     use super::*;
@@ -333,6 +335,24 @@ mod tests {
                 state: Initialized { context: session_context },
             }),
         };
+        run_session_history_test(test)
+    }
+
+    #[test]
+    fn test_replaying_session_creation_with_expired_session() -> Result<(), BoxError> {
+        let session_context = SessionContext {
+            expiry: SystemTime::now() - Duration::from_secs(1),
+            ..SHARED_CONTEXT.clone()
+        };
+        let test = SessionHistoryTest {
+            events: vec![SessionEvent::Created(session_context.clone())],
+            expected_session_history: SessionHistoryExpectedOutcome {
+                psbt_with_fee_contributions: None,
+                fallback_tx: None,
+            },
+            expected_receiver_state: ReceiveSession::TerminalFailure,
+        };
+        // TODO: should check for the expired error message off the session history
         run_session_history_test(test)
     }
 

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -565,7 +565,7 @@ mod test {
     }
 
     #[test]
-    fn test_extract_v2_success() -> Result<(), BoxError> {
+    fn test_create_v2_post_request_success() -> Result<(), BoxError> {
         let sender = create_sender_context(SystemTime::now() + Duration::from_secs(60))?;
         let ohttp_relay = EXAMPLE_URL.clone();
         let result = sender.create_v2_post_request(ohttp_relay);
@@ -580,7 +580,7 @@ mod test {
     }
 
     #[test]
-    fn test_extract_v2_fails_when_expired() -> Result<(), BoxError> {
+    fn test_create_v2_post_request_fails_when_expired() -> Result<(), BoxError> {
         let expected_error = "session expired at SystemTime";
         let sender = create_sender_context(SystemTime::now() - Duration::from_secs(60))?;
         let ohttp_relay = EXAMPLE_URL.clone();


### PR DESCRIPTION
Do not throw an Expired error as a ReplayError variant. An expired
session does indicate an error with replay. Rather, a replay of an
expired session that has not yet reached a terminal state will produce
an error when it follows protocol and tries to create a request. That
error will create a SessionEvent::SessionInvalid (or whatever that type
turns into after follow ups) which will later be replayed by the state
machine.

This separates the concerns of the protocol from the session replay and
more accurately reflects the protocol operation. This lets us record to
what extent the protocol actually was able to operate before expiration
since all of the events will be replayed up to the terminal expiration
event.


I noticed that the receiver's final post was not checking expiration, so
I added and tested that as well after removing the replay expiration
test.

Make SessionError(pub(super) InternalSessionError) so that the error
variant can be used in matches in unit tests.

I did use claude-4-sonnet to write the skeleton of the `fn test_create_post_request_fails_when_expired(` so that I didn't have to fetch all of the boilerplate. After it was done I used ctrl+k in-file llm edit with gpt-4o to "prune this" to reduce some redundancy and generated comments. Then, because the robot generated assertions against the Display impl of the error I rewrote the assert statements to match against the exact variant I expected. so that the test was as precise as possible.

## Pull Request Checklist

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

