### PR TITLE
Render PR checklist in details to hide it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-## Pull Request Checklist
+<details>
+  <summary>Pull Request Checklist</summary>
 
 Please confirm the following before requesting review:
 
@@ -6,4 +7,4 @@ Please confirm the following before requesting review:
   AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
   in the body of this PR.
 - [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
-
+</details>


### PR DESCRIPTION
This way the checklist is still displayed for a reviewer checking for it, but it doesn't uglify every PR body. And it's just as noticeable for PR authors. I did use gpt5 to recall that `<details>` / `<summary>` was the right syntax for this.

You can check that it renders properly in github by using the template in this body before it's merged:

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

