### PR TITLE
Not --all-features test suite

### DIFF
--- a/payjoin/contrib/test.sh
+++ b/payjoin/contrib/test.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+features=("v1" "v2")
+
 cargo test --locked --package payjoin --verbose --all-features --lib
 cargo test --locked --package payjoin --verbose --all-features --test integration
+
+for feature in "${features[@]}"; do
+    cargo test --locked --package payjoin --verbose --no-default-features --features "$feature" --lib
+    cargo test --locked --package payjoin --verbose --no-default-features --features "$feature" --test integration
+done

--- a/payjoin/src/core/send/error.rs
+++ b/payjoin/src/core/send/error.rs
@@ -403,12 +403,11 @@ impl WellKnownError {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
-    use super::*;
-
     #[test]
+    #[cfg(feature = "v1")]
     fn test_parse_json() {
+        use super::*;
+
         let known_str_error = r#"{"errorCode":"version-unsupported", "message":"custom message here", "supported": [1, 2]}"#;
         match ResponseError::parse(known_str_error) {
             ResponseError::WellKnown(e) => {
@@ -426,7 +425,7 @@ mod tests {
             ResponseError::parse(unrecognized_error),
             ResponseError::Unrecognized { .. }
         ));
-        let invalid_json_error = json!({
+        let invalid_json_error = serde_json::json!({
             "err": "random",
             "message": "This version of payjoin is not supported."
         });

--- a/payjoin/src/core/uri/mod.rs
+++ b/payjoin/src/core/uri/mod.rs
@@ -268,41 +268,12 @@ mod tests {
     }
 
     #[test]
-    fn test_missing_amount() {
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://testnet.demo.btcpayserver.org/BTC/pj";
-        assert!(Uri::try_from(uri).is_ok(), "missing amount should be ok");
-    }
-
-    #[test]
     fn test_unencrypted() {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1&pj=http://example.com";
         assert!(Uri::try_from(uri).is_err(), "unencrypted connection");
 
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1&pj=ftp://foo.onion";
         assert!(Uri::try_from(uri).is_err(), "unencrypted connection");
-    }
-
-    #[test]
-    fn test_valid_uris() {
-        let https = "https://example.com";
-        let onion = "http://vjdpwgybvubne5hda6v4c5iaeeevhge6jvo3w2cl6eocbwwvwxp7b7qd.onion";
-
-        let base58 = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX";
-        let bech32_upper = "BITCOIN:TB1Q6D3A2W975YNY0ASUVD9A67NER4NKS58FF0Q8G4";
-        let bech32_lower = "bitcoin:tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
-
-        for address in [base58, bech32_upper, bech32_lower].iter() {
-            for pj in [https, onion].iter() {
-                let uri_with_amount = format!("{address}?amount=1&pj={pj}");
-                assert!(Uri::try_from(uri_with_amount).is_ok());
-
-                let uri_without_amount = format!("{address}?pj={pj}");
-                assert!(Uri::try_from(uri_without_amount).is_ok());
-
-                let uri_shuffled_params = format!("{address}?pj={pj}&amount=1");
-                assert!(Uri::try_from(uri_shuffled_params).is_ok());
-            }
-        }
     }
 
     #[test]
@@ -317,25 +288,9 @@ mod tests {
     }
 
     #[test]
-    fn test_supported() {
-        assert!(
-            Uri::try_from(
-                "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
-                   &pjos=0&pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"
-            )
-            .unwrap()
-            .extras
-            .pj_is_supported(),
-            "Uri expected a success with a well formatted pj extras, but it failed"
-        );
-    }
-
-    #[test]
     fn test_pj_param_unknown() {
         use bitcoin_uri::de::DeserializationState as _;
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pj=HTTPS://EXAMPLE.COM/TXJCGKTKXLUUZ%23EX1C4UC6ES-OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV";
         let pjuri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
         let serialized_params = pjuri.extras.serialize_params();
         let pjos_key = serialized_params.clone().next().expect("Missing pjos key").0;
@@ -348,113 +303,6 @@ mod tests {
         assert!(
             !state.is_param_known("unknown_param"),
             "An unknown_param should not match 'pj' or 'pjos'"
-        );
-    }
-
-    #[test]
-    fn test_pj_duplicate_params() {
-        let uri =
-            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pjos=1&pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
-        let pjuri = Uri::try_from(uri);
-        assert!(matches!(
-            pjuri,
-            Err(bitcoin_uri::de::Error::Extras(PjParseError(
-                InternalPjParseError::DuplicateParams("pjos")
-            )))
-        ));
-        let uri =
-            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC&pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
-        let pjuri = Uri::try_from(uri);
-        assert!(matches!(
-            pjuri,
-            Err(bitcoin_uri::de::Error::Extras(PjParseError(
-                InternalPjParseError::DuplicateParams("pj")
-            )))
-        ));
-    }
-
-    #[test]
-    fn test_serialize_pjos() {
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=HTTPS://EXAMPLE.COM/%23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
-        let expected_is_disabled = "pjos=0";
-        let expected_is_enabled = "pjos=1";
-        let mut pjuri = Uri::try_from(uri)
-            .expect("Invalid uri")
-            .assume_checked()
-            .check_pj_supported()
-            .expect("Could not parse pj extras");
-
-        pjuri.extras.output_substitution = OutputSubstitution::Disabled;
-        assert!(
-            pjuri.to_string().contains(expected_is_disabled),
-            "Pj uri should contain param: {expected_is_disabled}, but it did not"
-        );
-
-        pjuri.extras.output_substitution = OutputSubstitution::Enabled;
-        assert!(
-            !pjuri.to_string().contains(expected_is_enabled),
-            "Pj uri should elide param: {expected_is_enabled}, but it did not"
-        );
-    }
-
-    #[test]
-    fn test_deserialize_pjos() {
-        // pjos=0 should disable output substitution
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com&pjos=0";
-        let parsed = Uri::try_from(uri).unwrap();
-        match parsed.extras {
-            MaybePayjoinExtras::Supported(extras) =>
-                assert_eq!(extras.output_substitution, OutputSubstitution::Disabled),
-            _ => panic!("Expected Supported PayjoinExtras"),
-        }
-
-        // pjos=1 should allow output substitution
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com&pjos=1";
-        let parsed = Uri::try_from(uri).unwrap();
-        match parsed.extras {
-            MaybePayjoinExtras::Supported(extras) =>
-                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled),
-            _ => panic!("Expected Supported PayjoinExtras"),
-        }
-
-        // Elided pjos=1 should allow output substitution
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com";
-        let parsed = Uri::try_from(uri).unwrap();
-        match parsed.extras {
-            MaybePayjoinExtras::Supported(extras) =>
-                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled),
-            _ => panic!("Expected Supported PayjoinExtras"),
-        }
-    }
-
-    /// Test that rejects HTTP URLs that are not onion addresses
-    #[test]
-    fn test_http_non_onion_rejected() {
-        // HTTP to regular domain should be rejected
-        let url = "http://example.com";
-        let result = PjParam::parse(url);
-        assert!(
-            matches!(result, Err(PjParseError(InternalPjParseError::UnsecureEndpoint))),
-            "Expected UnsecureEndpoint error for HTTP to non-onion domain"
-        );
-
-        // HTTPS to subdomain should be accepted
-        let url = "https://example.com";
-        let result = PjParam::parse(url);
-        assert!(
-            matches!(result, Ok(PjParam::V1(_))),
-            "Expected PjParam::V1 for HTTPS to non-onion domain without fragment"
-        );
-
-        // HTTP to domain ending in .onion should be accepted
-        let url = "http://example.onion";
-        let result = PjParam::parse(url);
-        assert!(
-            matches!(result, Ok(PjParam::V1(_))),
-            "Expected PjParam::V1 for HTTP to onion domain without fragment"
         );
     }
 }

--- a/payjoin/src/core/uri/v1.rs
+++ b/payjoin/src/core/uri/v1.rs
@@ -30,3 +30,180 @@ impl std::fmt::Display for PjParam {
         self.0.fmt(f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use payjoin_test_utils::BoxError;
+
+    use super::*;
+    use crate::uri::MaybePayjoinExtras;
+    use crate::{OutputSubstitution, PjParam, Uri, UriExt};
+
+    #[test]
+    fn test_missing_amount() {
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://testnet.demo.btcpayserver.org/BTC/pj";
+        assert!(Uri::try_from(uri).is_ok(), "missing amount should be ok");
+    }
+
+    #[test]
+    fn test_valid_uris() {
+        let https = "https://example.com";
+        let onion = "http://vjdpwgybvubne5hda6v4c5iaeeevhge6jvo3w2cl6eocbwwvwxp7b7qd.onion";
+
+        let base58 = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX";
+        let bech32_upper = "BITCOIN:TB1Q6D3A2W975YNY0ASUVD9A67NER4NKS58FF0Q8G4";
+        let bech32_lower = "bitcoin:tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+
+        for address in [base58, bech32_upper, bech32_lower].iter() {
+            for pj in [https, onion].iter() {
+                let uri_with_amount = format!("{address}?amount=1&pj={pj}");
+                assert!(Uri::try_from(uri_with_amount).is_ok());
+
+                let uri_without_amount = format!("{address}?pj={pj}");
+                assert!(Uri::try_from(uri_without_amount).is_ok());
+
+                let uri_shuffled_params = format!("{address}?pj={pj}&amount=1");
+                assert!(Uri::try_from(uri_shuffled_params).is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn test_supported() {
+        assert!(
+            Uri::try_from(
+                "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
+                   &pjos=0&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"
+            )
+            .unwrap()
+            .extras
+            .pj_is_supported(),
+            "Uri expected a success with a well formatted pj extras, but it failed"
+        );
+    }
+
+    #[test]
+    fn test_v1_failed_url_fragment() -> Result<(), BoxError> {
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
+                   &pjos=0&pj=HTTPS://EXAMPLE.COM/missing_short_id\
+                   %23oh1qypm5jxyns754y4r45qwe336qfx6zr8dqgvqculvztv20tfveydmfqc";
+        let extras = Uri::try_from(uri).unwrap().extras;
+        match extras {
+            crate::uri::MaybePayjoinExtras::Supported(extras) => {
+                assert!(matches!(extras.pj_param, crate::uri::PjParam::V1(_)));
+            }
+            _ => panic!("Expected v1 pjparam"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_pj_duplicate_params() {
+        let uri =
+            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pjos=1&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let pjuri = Uri::try_from(uri);
+        assert!(matches!(
+            pjuri,
+            Err(bitcoin_uri::de::Error::Extras(PjParseError(
+                InternalPjParseError::DuplicateParams("pjos")
+            )))
+        ));
+        let uri =
+            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC&pj=HTTPS://EXAMPLE.COM/\
+                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let pjuri = Uri::try_from(uri);
+        assert!(matches!(
+            pjuri,
+            Err(bitcoin_uri::de::Error::Extras(PjParseError(
+                InternalPjParseError::DuplicateParams("pj")
+            )))
+        ));
+    }
+
+    #[test]
+    fn test_serialize_pjos() {
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=HTTPS://EXAMPLE.COM/%23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+        let expected_is_disabled = "pjos=0";
+        let expected_is_enabled = "pjos=1";
+        let mut pjuri = Uri::try_from(uri)
+            .expect("Invalid uri")
+            .assume_checked()
+            .check_pj_supported()
+            .expect("Could not parse pj extras");
+
+        pjuri.extras.output_substitution = OutputSubstitution::Disabled;
+        assert!(
+            pjuri.to_string().contains(expected_is_disabled),
+            "Pj uri should contain param: {expected_is_disabled}, but it did not"
+        );
+
+        pjuri.extras.output_substitution = OutputSubstitution::Enabled;
+        assert!(
+            !pjuri.to_string().contains(expected_is_enabled),
+            "Pj uri should elide param: {expected_is_enabled}, but it did not"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_pjos() {
+        // pjos=0 should disable output substitution
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com&pjos=0";
+        let parsed = Uri::try_from(uri).unwrap();
+        match parsed.extras {
+            MaybePayjoinExtras::Supported(extras) =>
+                assert_eq!(extras.output_substitution, OutputSubstitution::Disabled),
+            _ => panic!("Expected Supported PayjoinExtras"),
+        }
+
+        // pjos=1 should allow output substitution
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com&pjos=1";
+        let parsed = Uri::try_from(uri).unwrap();
+        match parsed.extras {
+            MaybePayjoinExtras::Supported(extras) =>
+                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled),
+            _ => panic!("Expected Supported PayjoinExtras"),
+        }
+
+        // Elided pjos=1 should allow output substitution
+        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://example.com";
+        let parsed = Uri::try_from(uri).unwrap();
+        match parsed.extras {
+            MaybePayjoinExtras::Supported(extras) =>
+                assert_eq!(extras.output_substitution, OutputSubstitution::Enabled),
+            _ => panic!("Expected Supported PayjoinExtras"),
+        }
+    }
+
+    /// Test that rejects HTTP URLs that are not onion addresses
+    #[test]
+    fn test_http_non_onion_rejected() {
+        // HTTP to regular domain should be rejected
+        let url = "http://example.com";
+        let result = PjParam::parse(url);
+        assert!(
+            matches!(result, Err(PjParseError(InternalPjParseError::UnsecureEndpoint))),
+            "Expected UnsecureEndpoint error for HTTP to non-onion domain"
+        );
+
+        // HTTPS to subdomain should be accepted
+        let url = "https://example.com";
+        let result = PjParam::parse(url);
+        assert!(
+            matches!(result, Ok(PjParam::V1(_))),
+            "Expected PjParam::V1 for HTTPS to non-onion domain without fragment"
+        );
+
+        // HTTP to domain ending in .onion should be accepted
+        let url = "http://example.onion";
+        let result = PjParam::parse(url);
+        assert!(
+            matches!(result, Ok(PjParam::V1(_))),
+            "Expected PjParam::V1 for HTTP to onion domain without fragment"
+        );
+    }
+}

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -545,15 +545,15 @@ mod tests {
     #[test]
     fn test_valid_v2_url_fragment_on_bip21() {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
-                   &pjos=0&pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
+                   &pjos=0&pj=HTTPS://EXAMPLE.COM/TXJCGKTKXLUUZ\
+                   %23EX1C4UC6ES-OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV";
         let pjuri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
         assert!(ohttp(&Url::parse(&pjuri.extras.endpoint()).expect("Could not parse url")).is_ok());
         assert_eq!(format!("{pjuri}"), uri);
 
         let reordered = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
-                   &pj=HTTPS://EXAMPLE.COM/\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC\
+                   &pj=HTTPS://EXAMPLE.COM/TXJCGKTKXLUUZ\
+                   %23EX1C4UC6ES-OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV\
                    &pjos=0";
         let pjuri =
             Uri::try_from(reordered).unwrap().assume_checked().check_pj_supported().unwrap();
@@ -562,21 +562,10 @@ mod tests {
     }
 
     #[test]
-    fn test_failed_url_fragment() -> Result<(), BoxError> {
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
-                   &pjos=0&pj=HTTPS://EXAMPLE.COM/missing_short_id\
-                   %23oh1qypm5jxyns754y4r45qwe336qfx6zr8dqgvqculvztv20tfveydmfqc";
-        let extras = Uri::try_from(uri).unwrap().extras;
-        match extras {
-            crate::uri::MaybePayjoinExtras::Supported(extras) => {
-                assert!(matches!(extras.pj_param, crate::uri::PjParam::V1(_)));
-            }
-            _ => panic!("Expected v1 pjparam"),
-        }
-
+    fn test_v2_failed_url_fragment() -> Result<(), BoxError> {
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
                    &pjos=0&pj=HTTPS://EXAMPLE.COM/TXJCGKTKXLUUZ\
-                   %23oh1qypm5jxyns754y4r45qwe336qfx6zr8dqgvqculvztv20tfveydmfqc";
+                   %23ex1c4uc6es-oh1qypm5jxyns754y4r45qwe336qfx6zr8dqgvqculvztv20tfveydmfqc-rk1q0djs3vvdxwqqtlq8022qgxsx7ml9phz6edsf6akewqg758jps2ev";
         assert!(matches!(
             Uri::try_from(uri),
             Err(bitcoin_uri::de::Error::Extras(crate::uri::PjParseError(
@@ -586,7 +575,7 @@ mod tests {
 
         let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
                    &pjos=0&pj=HTTPS://EXAMPLE.COM/TXJCGKTKXLUUZ\
-                   %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQc";
+                   %23EX1C4UC6ES-OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2Ev";
         assert!(matches!(
             Uri::try_from(uri),
             Err(bitcoin_uri::de::Error::Extras(crate::uri::PjParseError(

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -7,20 +7,25 @@ mod integration {
     use bitcoin::policy::DEFAULT_MIN_RELAY_TX_FEE;
     use bitcoin::psbt::{Input as PsbtInput, Psbt};
     use bitcoin::{Amount, FeeRate, OutPoint, TxIn, TxOut, Weight};
+    #[cfg(feature = "v1")]
     use payjoin::receive::v1::build_v1_pj_uri;
     use payjoin::receive::InputPair;
-    use payjoin::{ImplementationError, OutputSubstitution, PjUri, Request, Uri, Url};
+    use payjoin::{ImplementationError, PjUri, Request, Uri};
+    #[cfg(feature = "v1")]
+    use payjoin::{OutputSubstitution, Url};
     use payjoin_test_utils::corepc_node::vtype::ListUnspentItem;
     use payjoin_test_utils::corepc_node::AddressType;
     use payjoin_test_utils::{corepc_node, init_bitcoind_sender_receiver, init_tracing, BoxError};
     use serde_json::json;
 
+    #[cfg(feature = "v1")]
     const EXAMPLE_URL: &str = "https://example.com";
     /// Transaction weight components for fee calculation
     /// Useful resource: https://bitcoin.stackexchange.com/a/84006
     const TX_HEADER_LEGACY_WEIGHT: u64 = 40;
     const TX_HEADER_WEIGHT: u64 = 42;
     const P2PKH_INPUT_WEIGHT: u64 = 592;
+    #[cfg(feature = "v1")]
     const NESTED_P2WPKH_INPUT_WEIGHT: u64 = 364;
     const P2WPKH_INPUT_WEIGHT: u64 = 272;
     const P2TR_INPUT_WEIGHT: u64 = 230;
@@ -188,13 +193,14 @@ mod integration {
         }
     }
 
-    // not all needs v1
-    #[cfg(all(feature = "io", feature = "v2", feature = "v1", feature = "_manual-tls"))]
+    #[cfg(all(feature = "io", feature = "v2", feature = "_manual-tls"))]
     mod v2 {
+        #[cfg(feature = "v1")]
         use std::sync::Arc;
         use std::time::Duration;
 
         use bitcoin::{Address, Transaction};
+        #[cfg(feature = "v1")]
         use http::StatusCode;
         use payjoin::persist::OptionalTransitionOutcome;
         use payjoin::receive::v2::{
@@ -207,7 +213,9 @@ mod integration {
         use payjoin_test_utils::{
             BoxSendSyncError, InMemoryPersister, SessionPersister, TestServices,
         };
-        use reqwest::{Client, Response};
+        #[cfg(feature = "v1")]
+        use reqwest::Client;
+        use reqwest::Response;
 
         use super::*;
 
@@ -914,6 +922,7 @@ mod integration {
             Ok((broadcasted_transaction, monitoring_payment))
         }
 
+        #[cfg(feature = "v1")]
         #[test]
         fn v2_to_v1() -> Result<(), BoxError> {
             init_tracing();
@@ -975,6 +984,7 @@ mod integration {
             Ok(())
         }
 
+        #[cfg(feature = "v1")]
         #[tokio::test]
         async fn v1_to_v2() -> Result<(), BoxSendSyncError> {
             init_tracing();
@@ -1476,6 +1486,7 @@ mod integration {
 
     // Receiver receive and process original_psbt from a sender
     // In production it it will come in as an HTTP request (over ssl or onion)
+    #[cfg(feature = "v1")]
     fn handle_v1_pj_request(
         req: Request,
         headers: impl payjoin::receive::v1::Headers,
@@ -1497,6 +1508,7 @@ mod integration {
         Ok(psbt.to_string())
     }
 
+    #[cfg(feature = "v1")]
     fn handle_proposal(
         proposal: payjoin::receive::v1::UncheckedOriginalPayload,
         receiver: &corepc_node::Client,
@@ -1625,12 +1637,15 @@ mod integration {
         InputPair::new(txin, psbtin, expected_weight).expect("Input pair should be valid")
     }
 
+    #[cfg(feature = "v1")]
     struct HeaderMock(HashMap<String, String>);
 
+    #[cfg(feature = "v1")]
     impl payjoin::receive::v1::Headers for HeaderMock {
         fn get_header(&self, key: &str) -> Option<&str> { self.0.get(key).map(|e| e.as_str()) }
     }
 
+    #[cfg(feature = "v1")]
     impl HeaderMock {
         fn new(body: &[u8], content_type: &str) -> HeaderMock {
             let mut h = HashMap::new();


### PR DESCRIPTION
Got everything compiling, however based on the current cfg flag layout in the integration tests, all the tests are run when v1 is enabled and none of the tests run when v2 is enabled

Closes #1019

Edit: because `payjoin-test-utils` already relies on `payjoin = { features = ["io", "_manual-tls"] }` and `io` pulls in `v2` it is difficult to fully separate the `v1` and `v2` integration tests to be properly feature gated but I did everything I could to just make sure that we test with both `v1` and `v2` and that there are no errors or compiler warnings when running without `--all-features`

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
  
  I had chatgpt help me clean up some clones in the `SenderBuilder` while i was transitioning over to the `NoopSessionPersister`
  
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
