### PR TITLE
Display session history in payjoin-cli

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -329,6 +329,8 @@ fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError
         }
         #[cfg(feature = "v2")]
         Commands::Resume => Ok(config),
+        #[cfg(feature = "v2")]
+        Commands::History => Ok(config),
     }
 }
 

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -26,6 +26,8 @@ pub trait App: Send + Sync {
     async fn receive_payjoin(&self, amount: Amount) -> Result<()>;
     #[cfg(feature = "v2")]
     async fn resume_payjoins(&self) -> Result<()>;
+    #[cfg(feature = "v2")]
+    async fn history(&self) -> Result<()>;
 
     fn create_original_psbt(
         &self,

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -111,6 +111,11 @@ impl AppTrait for App {
     async fn resume_payjoins(&self) -> Result<()> {
         unimplemented!("resume_payjoins not implemented for v1");
     }
+
+    #[cfg(feature = "v2")]
+    async fn history(&self) -> Result<()> {
+        unimplemented!("history not implemented for v1");
+    }
 }
 
 impl App {

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -130,6 +130,9 @@ pub enum Commands {
     /// Resume pending payjoins (BIP77/v2 only)
     #[cfg(feature = "v2")]
     Resume,
+    #[cfg(feature = "v2")]
+    /// Show payjoin session history
+    History,
 }
 
 pub fn parse_amount_in_sat(s: &str) -> Result<Amount, ParseAmountError> {

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -71,6 +71,10 @@ async fn main() -> Result<()> {
         Commands::Resume => {
             app.resume_payjoins().await?;
         }
+        #[cfg(feature = "v2")]
+        Commands::History => {
+            app.history().await?;
+        }
     };
 
     Ok(())

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -85,6 +85,13 @@ impl SessionHistory {
             })
             .expect("Session event log must contain at least one event with pj_param")
     }
+
+    pub fn terminal_error(&self) -> Option<String> {
+        self.events.iter().find_map(|event| match event {
+            SessionEvent::SessionInvalid(error) => Some(error.clone()),
+            _ => None,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -37,16 +37,20 @@ where
         }
     }
 
-    let history = SessionHistory::new(session_events);
+    let history = SessionHistory::new(session_events.clone());
     let pj_param = history.pj_param();
     if std::time::SystemTime::now() > pj_param.expiration() {
         // Session has expired: close the session and persist a fatal error
+        let session_event = SessionEvent::SessionInvalid("Session expired".to_string());
         persister
-            .save_event(SessionEvent::SessionInvalid("Session expired".to_string()).into())
+            .save_event(session_event.clone().into())
             .map_err(|e| InternalReplayError::PersistenceFailure(ImplementationError::new(e)))?;
         persister
             .close()
             .map_err(|e| InternalReplayError::PersistenceFailure(ImplementationError::new(e)))?;
+
+        session_events.push(session_event);
+        let history = SessionHistory::new(session_events);
 
         return Ok((SendSession::TerminalFailure, history));
     }
@@ -184,6 +188,7 @@ mod tests {
         events: Vec<SessionEvent>,
         expected_session_history: SessionHistoryExpectedOutcome,
         expected_sender_state: SendSession,
+        expected_error: Option<String>,
     }
 
     fn run_session_history_test(test: SessionHistoryTest) {
@@ -197,6 +202,7 @@ mod tests {
         assert_eq!(sender, test.expected_sender_state);
         assert_eq!(session_history.fallback_tx(), test.expected_session_history.fallback_tx);
         assert_eq!(*session_history.pj_param(), test.expected_session_history.pj_param);
+        assert_eq!(session_history.terminal_error(), test.expected_error);
     }
 
     #[test]
@@ -235,6 +241,7 @@ mod tests {
             events: vec![SessionEvent::CreatedReplyKey(with_reply_key)],
             expected_session_history: SessionHistoryExpectedOutcome { fallback_tx, pj_param },
             expected_sender_state: SendSession::TerminalFailure,
+            expected_error: Some("Session expired".to_string()),
         };
         run_session_history_test(test);
     }
@@ -275,6 +282,7 @@ mod tests {
             events: vec![SessionEvent::CreatedReplyKey(with_reply_key)],
             expected_session_history: SessionHistoryExpectedOutcome { fallback_tx, pj_param },
             expected_sender_state: SendSession::WithReplyKey(sender),
+            expected_error: None,
         };
         run_session_history_test(test);
     }


### PR DESCRIPTION
Couple fixme comments left to squash and boilerplate to reduce in main body of history command. #1036 and should go in first. #1014 should also go in first.

Related ticket: https://github.com/payjoin/rust-payjoin/issues/336

Example output:
```
Session ID   Sender/Receiver       Completed At     Status  
2            Sender                              Not Completed    Waiting for proposal            
3            Sender                              1756924189         Proposal received            
4            Sender                              1756924328         Error: an input in proposed transaction belonging to the sender contains partial signatures
1            Receiver                           1756924189         Payjoin proposal sent            
2            Receiver                           1756924328         Payjoin proposal sent
``` 


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
