### PR TITLE
Add lockfile backup to update-lock-files script

### DIFF
--- a/contrib/update-lock-files.sh
+++ b/contrib/update-lock-files.sh
@@ -4,6 +4,28 @@
 
 set -euo pipefail
 
+LOCKFILE="Cargo.lock"
+LOCKDIR=".bak"
+LOCKFILE_BAK="${LOCKDIR}/${LOCKFILE}"
+
+cleanup() {
+    if [ -f "$LOCKFILE_BAK" ]; then
+        mv "$LOCKFILE_BAK" "$LOCKFILE"
+    fi
+    rmdir "$LOCKDIR"
+}
+
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "Another instance is running. If you're sure it's not, remove $LOCKDIR and try again." >&2
+    exit 1
+fi
+
+trap cleanup EXIT
+
+if [ -f "$LOCKFILE" ]; then
+    mv "$LOCKFILE" "$LOCKFILE_BAK"
+fi
+
 for file in Cargo-minimal.lock Cargo-recent.lock; do
     cp -f "$file" Cargo.lock
     cargo check


### PR DESCRIPTION
Add lockfile backup script to `update-lock-files.sh`. This should prevent the Cargo.lock from being overwritten by this script.

Closes #1017 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
