### PR TITLE
Update directory and ffi toml files where deps were incorrect

### DIFF
--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -29,7 +29,7 @@ hyper-util = { version = "0.1.16", features = ["tokio"] }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0"}
 payjoin = { version = "0.24.0", features = ["directory"], default-features = false }
 redis = { version = "0.32.5", features = ["aio", "tokio-comp"] }
-tokio = { version = "1.23.31", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
 tokio-rustls = { version = "0.26.2", features = ["ring"], default-features = false, optional = true }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -18,7 +18,7 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [build-dependencies]
-uniffi = { version = "0.29.1", features = ["build", "cli"] }
+uniffi = { version = "0.29.4", features = ["build", "cli"] }
 uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", rev = "b6186bc", features = ["build"] }
 
 [dependencies]


### PR DESCRIPTION
There were 2 deps in the directory and ffi where the versions listed were off compared to the rest of the repo.

The offenders 
`payjoin-directory tokio: 1.23.31` (doesn't exist) and
`uniffi: 0.29.1` (the build dep differed from the main)

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
