### PR TITLE
Replace SystemTime with bitcoin::absolute::Time

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -24,16 +24,6 @@ exclude_re = [
     # payjoin/src/core/send/mod.rs
     "replace < with <= in PsbtContextBuilder::build_recommended", # clamping the fee contribution when the fee equals to the recommended fee does not do anything
 
-    # Async SystemTime comparison
-    # checking if the system time is equal to the expiry is difficult to reasonably test
-    # payjoin/src/core/receive/v2/session.rs and payjoin/src/core/send/v2/session.rs
-    "replace > with >= in replay_event_log",
-    # payjoin/src/core/receive/v2/mod.rs
-    "replace > with >= in Receiver<Initialized>::create_poll_request",
-    "replace > with >= in extract_err_req",
-    # payjoin/src/core/send/v2/mod.rs
-    "replace > with >= in Sender<WithReplyKey>::create_v2_post_request",
-
     # TODO exclusions
     # payjoin/src/core/receive/v1/mod.rs
     "replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -16,6 +16,8 @@ pub mod send;
 pub use request::*;
 pub(crate) mod into_url;
 pub use into_url::{Error as IntoUrlError, IntoUrl};
+#[cfg(feature = "v2")]
+pub mod time;
 pub mod uri;
 pub use uri::{PjParam, PjParseError, PjUri, Uri, UriExt};
 pub use url::{ParseError, Url};

--- a/payjoin/src/core/receive/v2/error.rs
+++ b/payjoin/src/core/receive/v2/error.rs
@@ -5,6 +5,7 @@ use crate::hpke::HpkeError;
 use crate::ohttp::{DirectoryResponseError, OhttpEncapsulationError};
 use crate::receive::error::Error;
 use crate::receive::ProtocolError;
+use crate::time::Time;
 
 /// Error that may occur during a v2 session typestate change
 ///
@@ -26,7 +27,7 @@ pub(crate) enum InternalSessionError {
     /// Url parsing failed
     ParseUrl(crate::into_url::Error),
     /// The session has expired
-    Expired(std::time::SystemTime),
+    Expired(Time),
     /// OHTTP Encapsulation failed
     OhttpEncapsulation(OhttpEncapsulationError),
     /// Hybrid Public Key Encryption failed

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 use serde::{Deserialize, Serialize};
 
 use super::{ReceiveSession, SessionContext};
@@ -45,7 +43,7 @@ where
 
     let history = SessionHistory::new(session_events.clone());
     let ctx = history.session_context();
-    if SystemTime::now() > ctx.expiration {
+    if ctx.expiration.elapsed() {
         // Session has expired: close the session and persist a fatal error
         let err = SessionError(InternalSessionError::Expired(ctx.expiration));
         persister
@@ -334,7 +332,7 @@ mod tests {
     #[test]
     fn test_replaying_session_creation_with_expired_session() -> Result<(), BoxError> {
         let session_context = SessionContext {
-            expiration: SystemTime::now() - Duration::from_secs(1),
+            expiration: (SystemTime::now() - Duration::from_secs(1)).try_into().unwrap(),
             ..SHARED_CONTEXT.clone()
         };
         let test = SessionHistoryTest {

--- a/payjoin/src/core/send/v2/error.rs
+++ b/payjoin/src/core/send/v2/error.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use crate::ohttp::DirectoryResponseError;
+use crate::time::Time;
 
 /// Error returned when request could not be created.
 ///
@@ -15,7 +16,7 @@ pub(crate) enum InternalCreateRequestError {
     Url(crate::into_url::Error),
     Hpke(crate::hpke::HpkeError),
     OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
-    Expiration(std::time::SystemTime),
+    Expired(Time),
 }
 
 impl fmt::Display for CreateRequestError {
@@ -26,7 +27,7 @@ impl fmt::Display for CreateRequestError {
             Url(e) => write!(f, "cannot parse url: {e:#?}"),
             Hpke(e) => write!(f, "v2 error: {e}"),
             OhttpEncapsulation(e) => write!(f, "v2 error: {e}"),
-            Expiration(expiration) => write!(f, "session expired at {expiration:?}"),
+            Expired(_expiration) => write!(f, "session expired"),
         }
     }
 }
@@ -39,7 +40,7 @@ impl std::error::Error for CreateRequestError {
             Url(error) => Some(error),
             Hpke(error) => Some(error),
             OhttpEncapsulation(error) => Some(error),
-            Expiration(_) => None,
+            Expired(_) => None,
         }
     }
 }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -273,8 +273,8 @@ impl Sender<WithReplyKey> {
         &self,
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, V2PostContext), CreateRequestError> {
-        if std::time::SystemTime::now() > self.pj_param.expiration() {
-            return Err(InternalCreateRequestError::Expiration(self.pj_param.expiration()).into());
+        if self.pj_param.expiration().elapsed() {
+            return Err(InternalCreateRequestError::Expired(self.pj_param.expiration()).into());
         }
 
         let mut sanitized_psbt = self.psbt_ctx.original_psbt.clone();
@@ -528,12 +528,13 @@ mod test {
     use super::*;
     use crate::persist::NoopSessionPersister;
     use crate::receive::v2::ReceiverBuilder;
+    use crate::time::Time;
     use crate::OhttpKeys;
 
     const SERIALIZED_BODY_V2: &str = "63484e696450384241484d43414141414159386e757447674a647959475857694245623435486f65396c5747626b78682f36624e694f4a6443447544414141414141442b2f2f2f2f41747956754155414141414146366b554865684a38476e536442554f4f7636756a584c72576d734a5244434867495165414141414141415871525233514a62627a30686e513849765130667074476e2b766f746e656f66544141414141414542494b6762317755414141414146366b55336b34656b47484b57524e6241317256357452356b455644564e4348415163584667415578347046636c4e56676f31575741644e3153594e583874706854414243477343527a424541694238512b41366465702b527a393276687932366c5430416a5a6e3450524c6938426639716f422f434d6b30774967502f526a3250575a3367456a556b546c6844524e415130675877544f3774396e2b563134705a366f6c6a554249514d566d7341616f4e5748564d5330324c6654536530653338384c4e697450613155515a794f6968592b464667414241425941464562324769753663344b4f35595730706677336c4770396a4d55554141413d0a763d32";
 
     fn create_sender_context(
-        expiration: SystemTime,
+        expiration: Time,
     ) -> Result<super::Sender<super::WithReplyKey>, BoxError> {
         let endpoint = Url::parse("http://localhost:1234")?;
         let pj_param = crate::uri::v2::PjParam::new(
@@ -562,7 +563,9 @@ mod test {
 
     #[test]
     fn test_serialize_v2() -> Result<(), BoxError> {
-        let sender = create_sender_context(SystemTime::now() + Duration::from_secs(60))?;
+        let expiration =
+            Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
+        let sender = create_sender_context(expiration)?;
         let body = serialize_v2_body(
             &sender.psbt_ctx.original_psbt,
             sender.psbt_ctx.output_substitution,
@@ -574,8 +577,10 @@ mod test {
     }
 
     #[test]
-    fn test_create_v2_post_request_success() -> Result<(), BoxError> {
-        let sender = create_sender_context(SystemTime::now() + Duration::from_secs(60))?;
+    fn test_extract_v2_success() -> Result<(), BoxError> {
+        let expiration =
+            Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
+        let sender = create_sender_context(expiration)?;
         let ohttp_relay = EXAMPLE_URL.as_str();
         let result = sender.create_v2_post_request(ohttp_relay);
         let (request, context) = result.expect("Result should be ok");
@@ -589,21 +594,19 @@ mod test {
     }
 
     #[test]
-    fn test_create_v2_post_request_fails_when_expired() -> Result<(), BoxError> {
-        let expected_error = "session expired at SystemTime";
-        let sender = create_sender_context(SystemTime::now() - Duration::from_secs(60))?;
+    fn test_extract_v2_fails_when_expired() -> Result<(), BoxError> {
+        // Create a sender with an already expired timestamp
+        let expiration = Time::try_from(SystemTime::now() - Duration::from_secs(1))
+            .expect("time in the past should be representable");
+
+        let sender = create_sender_context(expiration)?;
         let ohttp_relay = EXAMPLE_URL.as_str();
         let result = sender.create_v2_post_request(ohttp_relay);
         assert!(result.is_err(), "Extract v2 expected expiration error, but it succeeded");
 
         match result {
             Ok(_) => panic!("Expected error, got success"),
-            Err(error) => assert_eq!(
-                format!("{error}")
-                    .split_once(" {")
-                    .map_or(format!("{error}"), |(prefix, _)| prefix.to_string()),
-                expected_error
-            ),
+            Err(error) => assert_eq!(format!("{error}"), "session expired",),
         }
         Ok(())
     }

--- a/payjoin/src/core/time.rs
+++ b/payjoin/src/core/time.rs
@@ -1,0 +1,102 @@
+pub use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bitcoin::absolute::Time as BitcoinTime;
+use bitcoin::consensus::encode::{Decodable, Error as EncodeError};
+use bitcoin::consensus::Encodable;
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub(crate) struct Time(BitcoinTime);
+
+impl Time {
+    /// Specify a time some duration from now (e.g. an expiration time).
+    pub(crate) fn from_now(duration: Duration) -> Result<Self, ConversionError> {
+        SystemTime::now().checked_add(duration).unwrap_or(UNIX_EPOCH).try_into()
+    }
+
+    /// Get the current time.
+    pub(crate) fn now() -> Self {
+        Time::try_from(SystemTime::now()).expect("Current time should always be a valid timestamp")
+    }
+
+    /// Create a time value from a u32 UNIX timestamp representation.
+    pub(crate) fn from_unix_seconds(seconds: u32) -> Result<Self, ConversionError> {
+        Ok(Time(BitcoinTime::from_consensus(seconds)?))
+    }
+
+    /// Parse from the Bitcoin consensus encoding of a u32 UNIX timestamp representation.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, ParseTimeError> {
+        use ParseTimeError::*;
+        if bytes.len() != core::mem::size_of::<u32>() {
+            return Err(IncorrectLength(bytes.len()));
+        }
+        let mut cursor = bytes;
+        let seconds = u32::consensus_decode(&mut cursor).map_err(Decode)?;
+        debug_assert!(cursor.is_empty());
+        Time::from_unix_seconds(seconds).map_err(Convert)
+    }
+
+    /// Encode as a Bitcoin consensus encoding of u32 UNIX timestamp.
+    pub(crate) fn to_bytes(self) -> [u8; 4] {
+        let t = self.0.to_consensus_u32();
+
+        let mut buf = [0u8; 4];
+        t.consensus_encode(&mut &mut buf[..]).expect("encoding should never fail because all valid Time values are encodable and u32 has a known width");
+        buf
+    }
+
+    /// Check if the time is in the past.
+    pub(crate) fn elapsed(self) -> bool { self <= Self::now() }
+}
+
+#[derive(Debug)]
+pub struct ConversionError(bitcoin::absolute::ConversionError);
+
+impl std::error::Error for ConversionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+impl std::fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) }
+}
+
+impl From<bitcoin::absolute::ConversionError> for ConversionError {
+    fn from(val: bitcoin::absolute::ConversionError) -> Self { Self(val) }
+}
+
+#[derive(Debug)]
+pub(crate) enum ParseTimeError {
+    IncorrectLength(usize),
+    Decode(EncodeError),
+    Convert(ConversionError),
+}
+
+impl std::error::Error for ParseTimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+impl std::fmt::Display for ParseTimeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use ParseTimeError::*;
+
+        match &self {
+            Decode(e) => write!(f, "invalid bytes: {e}"),
+            Convert(e) => write!(f, "invalid date: {e}"),
+            IncorrectLength(l) => write!(f, "incorrect length: expected 4 bytes, got {l}"),
+        }
+    }
+}
+
+impl TryFrom<SystemTime> for Time {
+    type Error = ConversionError;
+    fn try_from(val: SystemTime) -> Result<Self, ConversionError> {
+        Time::from_unix_seconds(val.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as u32)
+    }
+}
+
+impl TryFrom<Duration> for Time {
+    type Error = ConversionError;
+    fn try_from(val: Duration) -> Result<Self, ConversionError> { Time::from_now(val) }
+}

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -279,7 +279,7 @@ mod integration {
                 // **********************
                 // Inside the Receiver:
                 let address = receiver.new_address()?;
-                // test session with expiry in the past
+                // test session with expiration in the past
                 let expired_receiver =
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
                         .with_expiration(Duration::from_secs(0))
@@ -463,7 +463,7 @@ mod integration {
                 // Inside the Receiver:
                 let address = receiver.new_address()?;
 
-                // test session with expiry in the future
+                // test session with expiration in the future
                 let session =
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
                         .build()


### PR DESCRIPTION
Internally, introduce a newtype wrapping bitcoin::absolute::Time (which
is what BIP 77 specifies) instead of using std::time::SystemTime.

A fallible constructor `Time::from_now(std::time::Duration)` is used to
construct these values from a `Duration`, which is indirectly called by
`with_expiration`. No `IntoTime` trait analogous to `IntoUrl` is included in
this commit, but this could be added there as long as both the
re-exported and the new `Time` type implement it.

Introducing a newtype lets us add additional conversion and arithmetic
functionality later without breaking the API or relying on extension
traits on the bitcoin Time type. Since it is now only `pub(crate)`, the
newtype wrapper's existence is now not entirely justified, as this no
longer re-exports a foreign type in our pub api (previous iterations of
the commit made it pub, replacing the use of `Duration`).


Replaces #1021

Depends on #1082

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
