### PR TITLE
Name multi-field SessionEvent variants

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -150,7 +150,7 @@ impl ReceiveSession {
 
             (
                 ReceiveSession::Initialized(state),
-                SessionEvent::UncheckedOriginalPayload((proposal, reply_key)),
+                SessionEvent::UncheckedOriginalPayload { original: proposal, reply_key },
             ) => Ok(state.apply_unchecked_from_payload(proposal, reply_key)?),
 
             (ReceiveSession::UncheckedOriginalPayload(state), SessionEvent::MaybeInputsOwned()) =>
@@ -374,7 +374,10 @@ impl Receiver<Initialized> {
 
         if let Some((proposal, reply_key)) = proposal {
             MaybeFatalTransitionWithNoResults::success(
-                SessionEvent::UncheckedOriginalPayload((proposal.clone(), reply_key.clone())),
+                SessionEvent::UncheckedOriginalPayload {
+                    original: proposal.clone(),
+                    reply_key: reply_key.clone(),
+                },
                 Receiver {
                     state: UncheckedOriginalPayload {
                         original: proposal,


### PR DESCRIPTION
Cherry-picked https://github.com/payjoin/rust-payjoin/commit/f253f44cb5704147155abd773a8926b47f00e0f3 from #1045. Note that I left the `SessionInvalid` variant as an unnamed tuple because that will get addressed separately as part of #793.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
