### PR TITLE
Oneline `ProtocolError::V1` `JsonReply` conversion

### DIFF
--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -127,7 +127,7 @@ impl From<&ProtocolError> for JsonReply {
         match e {
             OriginalPayload(e) => e.into(),
             #[cfg(feature = "v1")]
-            V1(e) => e.into(),
+            V1(e) => JsonReply::new(OriginalPsbtRejected, e),
             #[cfg(feature = "v2")]
             V2(_) => JsonReply::new(Unavailable, "Receiver error"),
         }

--- a/payjoin/src/core/receive/v1/error.rs
+++ b/payjoin/src/core/receive/v1/error.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 use std::error;
 
-use crate::receive::JsonReply;
-
 /// Error that occurs during validation of an incoming v1 payjoin request.
 ///
 /// This type provides a stable public API for v1 request validation errors while keeping internal
@@ -34,20 +32,6 @@ impl From<InternalRequestError> for RequestError {
 
 impl From<InternalRequestError> for super::ProtocolError {
     fn from(e: InternalRequestError) -> Self { super::ProtocolError::V1(e.into()) }
-}
-
-impl From<&RequestError> for JsonReply {
-    fn from(e: &RequestError) -> Self {
-        use InternalRequestError::*;
-
-        match &e.0 {
-            MissingHeader(_)
-            | InvalidContentType(_)
-            | InvalidContentLength(_)
-            | ContentLengthMismatch { .. } =>
-                JsonReply::new(crate::error_codes::ErrorCode::OriginalPsbtRejected, e),
-        }
-    }
 }
 
 impl fmt::Display for RequestError {


### PR DESCRIPTION
Since all variants result in the same response, define it at `impl From<&ProtocolError> for JsonReply` in one line.

Cherry-picked https://github.com/payjoin/rust-payjoin/pull/1045/commits/7b6766a8c629e82e3e6b584b82a13382f423d1da