### PR TITLE
Change return type of `apply_unchecked_from_payload`

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -151,7 +151,7 @@ impl ReceiveSession {
             (
                 ReceiveSession::Initialized(state),
                 SessionEvent::UncheckedOriginalPayload { original: proposal, reply_key },
-            ) => Ok(state.apply_unchecked_from_payload(proposal, reply_key)?),
+            ) => Ok(state.apply_unchecked_from_payload(proposal, reply_key)),
 
             (ReceiveSession::UncheckedOriginalPayload(state), SessionEvent::MaybeInputsOwned()) =>
                 Ok(state.apply_maybe_inputs_owned()),
@@ -474,7 +474,7 @@ impl Receiver<Initialized> {
         self,
         event: OriginalPayload,
         reply_key: Option<HpkePublicKey>,
-    ) -> Result<ReceiveSession, InternalReplayError> {
+    ) -> ReceiveSession {
         let new_state = Receiver {
             state: UncheckedOriginalPayload {
                 original: event,
@@ -482,7 +482,7 @@ impl Receiver<Initialized> {
             },
         };
 
-        Ok(ReceiveSession::UncheckedOriginalPayload(new_state))
+        ReceiveSession::UncheckedOriginalPayload(new_state)
     }
 }
 


### PR DESCRIPTION
This method does not need to return a `Result` as it never errors.
Follow up from #1036 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
