### PR TITLE
Pull session context out of receiver state

### DIFF
--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -227,10 +227,8 @@ mod tests {
 
     fn unchecked_receiver_from_test_vector() -> Receiver<UncheckedOriginalPayload> {
         Receiver {
-            state: UncheckedOriginalPayload {
-                original: original_from_test_vector(),
-                session_context: SHARED_CONTEXT.clone(),
-            },
+            state: UncheckedOriginalPayload { original: original_from_test_vector() },
+            session_context: SHARED_CONTEXT.clone(),
         }
     }
 
@@ -337,7 +335,8 @@ mod tests {
                 fallback_tx: None,
             },
             expected_receiver_state: ReceiveSession::Initialized(Receiver {
-                state: Initialized { context: session_context },
+                state: Initialized {},
+                session_context,
             }),
         };
         run_session_history_test(test)
@@ -380,10 +379,8 @@ mod tests {
                 fallback_tx: None,
             },
             expected_receiver_state: ReceiveSession::UncheckedOriginalPayload(Receiver {
-                state: UncheckedOriginalPayload {
-                    original,
-                    session_context: SessionContext { reply_key, ..session_context },
-                },
+                state: UncheckedOriginalPayload { original },
+                session_context: SessionContext { reply_key, ..session_context },
             }),
         };
         run_session_history_test(test)
@@ -408,10 +405,8 @@ mod tests {
                 fallback_tx: None,
             },
             expected_receiver_state: ReceiveSession::UncheckedOriginalPayload(Receiver {
-                state: UncheckedOriginalPayload {
-                    original,
-                    session_context: SessionContext { reply_key, ..session_context },
-                },
+                state: UncheckedOriginalPayload { original },
+                session_context: SessionContext { reply_key, ..session_context },
             }),
         };
         run_session_history_test(test)
@@ -444,10 +439,8 @@ mod tests {
                 fallback_tx: Some(expected_fallback),
             },
             expected_receiver_state: ReceiveSession::MaybeInputsOwned(Receiver {
-                state: MaybeInputsOwned {
-                    original,
-                    session_context: SessionContext { reply_key, ..session_context },
-                },
+                state: MaybeInputsOwned { original },
+                session_context: SessionContext { reply_key, ..session_context },
             }),
         };
         run_session_history_test(test)
@@ -517,8 +510,8 @@ mod tests {
             expected_receiver_state: ReceiveSession::ProvisionalProposal(Receiver {
                 state: ProvisionalProposal {
                     psbt_context: provisional_proposal.state.psbt_context.clone(),
-                    session_context: SessionContext { reply_key, ..session_context },
                 },
+                session_context: SessionContext { reply_key, ..session_context },
             }),
         };
         run_session_history_test(test)
@@ -592,10 +585,8 @@ mod tests {
                 fallback_tx: Some(expected_fallback),
             },
             expected_receiver_state: ReceiveSession::PayjoinProposal(Receiver {
-                state: PayjoinProposal {
-                    psbt: payjoin_proposal.psbt().clone(),
-                    session_context: SessionContext { reply_key, ..session_context },
-                },
+                state: PayjoinProposal { psbt: payjoin_proposal.psbt().clone() },
+                session_context: SessionContext { reply_key, ..session_context },
             }),
         };
         run_session_history_test(test)


### PR DESCRIPTION
Session context is a shared field for every reciever typestate and should be a common field in the top level `Receiver` struct. One nice side affect of this change is the session events won't include duplicated data.

-- 
Cursor auto complete was used. 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
