### PR TITLE
Remove optional return types from session history methods

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -363,11 +363,8 @@ impl App {
             Ok(_) => Ok(()),
             Err(e) => {
                 let (_, session_history) = replay_receiver_event_log(persister)?;
-                let pj_uri = match session_history.pj_uri() {
-                    Some(uri) => Some(uri.extras.endpoint().clone()),
-                    None => None,
-                };
-                let ohttp_relay = self.unwrap_relay_or_else_fetch(pj_uri).await?;
+                let pj_uri = session_history.pj_uri().extras.endpoint().clone();
+                let ohttp_relay = self.unwrap_relay_or_else_fetch(Some(pj_uri)).await?;
                 self.handle_recoverable_error(&ohttp_relay, &session_history).await?;
 
                 Err(e)

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -164,9 +164,7 @@ impl TerminalErr {
 #[uniffi::export]
 impl SessionHistory {
     /// Receiver session Payjoin URI
-    pub fn pj_uri(&self) -> Option<Arc<crate::PjUri>> {
-        self.0.pj_uri().map(|pj_uri| Arc::new(pj_uri.into()))
-    }
+    pub fn pj_uri(&self) -> Arc<crate::PjUri> { Arc::new(self.0.pj_uri().into()) }
 
     /// Psbt With fee contributions applied
     pub fn psbt_ready_for_signing(&self) -> Option<Arc<crate::Psbt>> {

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -126,14 +126,10 @@ impl From<SenderSessionHistory> for payjoin::send::v2::SessionHistory {
 
 #[uniffi::export]
 impl SenderSessionHistory {
-    pub fn endpoint(&self) -> Option<Arc<Url>> {
-        self.0.pj_param().map(|pj_param| Arc::new(pj_param.endpoint().into()))
-    }
+    pub fn endpoint(&self) -> Arc<Url> { Arc::new(self.0.pj_param().endpoint().into()) }
 
     /// Fallback transaction from the session if present
-    pub fn fallback_tx(&self) -> Option<Arc<crate::Transaction>> {
-        self.0.fallback_tx().map(|tx| Arc::new(tx.into()))
-    }
+    pub fn fallback_tx(&self) -> Arc<crate::Transaction> { Arc::new(self.0.fallback_tx().into()) }
 }
 
 #[derive(uniffi::Object)]

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -66,8 +66,7 @@ where
         })?;
     }
 
-    let ctx =
-        history.session_context().expect("Session context should be present after the first event");
+    let ctx = history.session_context();
     if SystemTime::now() > ctx.expiry {
         // Session has expired: close the session and persist a fatal error
         let err = SessionError(InternalSessionError::Expired(ctx.expiry));
@@ -93,12 +92,15 @@ pub struct SessionHistory {
 
 impl SessionHistory {
     /// Receiver session Payjoin URI
-    pub fn pj_uri<'a>(&self) -> Option<PjUri<'a>> {
-        self.events.iter().find_map(|event| match event {
-            SessionEvent::Created(session_context) =>
-                Some(crate::receive::v2::pj_uri(session_context, OutputSubstitution::Disabled)),
-            _ => None,
-        })
+    pub fn pj_uri<'a>(&self) -> PjUri<'a> {
+        self.events
+            .iter()
+            .find_map(|event| match event {
+                SessionEvent::Created(session_context) =>
+                    Some(crate::receive::v2::pj_uri(session_context, OutputSubstitution::Disabled)),
+                _ => None,
+            })
+            .expect("Session event log must contain at least one event with pj_uri")
     }
 
     fn get_unchecked_proposal(&self) -> Option<OriginalPayload> {
@@ -152,10 +154,7 @@ impl SessionHistory {
             return Ok(None);
         }
 
-        let session_context = match self.session_context() {
-            Some(session_context) => session_context,
-            None => return Ok(None),
-        };
+        let session_context = self.session_context();
         let json_reply = match self.terminal_error() {
             Some((_, Some(json_reply))) => json_reply,
             _ => return Ok(None),
@@ -170,18 +169,22 @@ impl SessionHistory {
             .any(|event| matches!(event, SessionEvent::UncheckedOriginalPayload { .. }))
     }
 
-    fn session_context(&self) -> Option<SessionContext> {
-        let mut initial_session_context = self.events.iter().find_map(|event| match event {
-            SessionEvent::Created(session_context) => Some(session_context.clone()),
-            _ => None,
-        })?;
+    fn session_context(&self) -> SessionContext {
+        let mut initial_session_context = self
+            .events
+            .iter()
+            .find_map(|event| match event {
+                SessionEvent::Created(session_context) => Some(session_context.clone()),
+                _ => None,
+            })
+            .expect("Session event log must contain at least one event with session_context");
 
         initial_session_context.reply_key = self.events.iter().find_map(|event| match event {
             SessionEvent::UncheckedOriginalPayload { reply_key, .. } => reply_key.clone(),
             _ => None,
         });
 
-        Some(initial_session_context)
+        initial_session_context
     }
 }
 
@@ -597,8 +600,7 @@ mod tests {
         let session_context = SHARED_CONTEXT.clone();
         let events = vec![SessionEvent::Created(session_context.clone())];
 
-        let uri =
-            SessionHistory { events }.pj_uri().expect("SHARED_CONTEXT should contain valid uri");
+        let uri = SessionHistory { events }.pj_uri();
 
         assert_ne!(uri.extras.pj_param.endpoint(), EXAMPLE_URL.clone());
         assert_eq!(uri.extras.output_substitution, OutputSubstitution::Disabled);
@@ -672,8 +674,8 @@ mod tests {
         let err_req_two = session_history_two.extract_err_req(ohttp_relay)?;
         assert!(err_req_two.is_some());
         assert_ne!(
-            session_history_one.session_context().unwrap().reply_key,
-            session_history_two.session_context().unwrap().reply_key
+            session_history_one.session_context().reply_key,
+            session_history_two.session_context().reply_key
         );
 
         Ok(())


### PR DESCRIPTION
After PR #1014 removes the Uninitialized variant and enforces that every SEL must contain at least one event, session history methods no longer need to return `Option<T>` since it guarantee's data availability

## Changes
  - **Sender methods**: `fallback_tx()` and `pj_param()` now return non-optional types
  - **Receiver methods**: `pj_uri()` and `session_context()` now return non-optional types
  - **FFI layer**: Updated method signatures to match
  
  
  Closes #1046 
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
