### PR TITLE
Remove references to ReplyableError in tests

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1200,7 +1200,7 @@ pub mod test {
                 error.to_string(),
                 Error::Implementation("mock error".into()).to_string()
             ),
-            _ => panic!("Expected ReplyableError but got unexpected error or Ok"),
+            _ => panic!("Expected Implementation error"),
         }
 
         Ok(())
@@ -1228,7 +1228,7 @@ pub mod test {
                 error.to_string(),
                 Error::Implementation("mock error".into()).to_string()
             ),
-            _ => panic!("Expected ReplyableError but got unexpected error or Ok"),
+            _ => panic!("Expected Implementation error"),
         }
 
         Ok(())
@@ -1259,7 +1259,7 @@ pub mod test {
                 error.to_string(),
                 Error::Implementation("mock error".into()).to_string()
             ),
-            _ => panic!("Expected ReplyableError but got unexpected error or Ok"),
+            _ => panic!("Expected Implementation error"),
         }
 
         Ok(())
@@ -1294,7 +1294,7 @@ pub mod test {
                 error.to_string(),
                 Error::Implementation("mock error".into()).to_string()
             ),
-            _ => panic!("Expected ReplyableError but got unexpected error or Ok"),
+            _ => panic!("Expected Implementation error"),
         }
 
         Ok(())


### PR DESCRIPTION
ReplyableError was removed in ae1832557ede1972d426a9249c85c61f9035baf8

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
