### PR TITLE
Receiever Monitor Typestate

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,target,Cargo.toml,Cargo.lock,Cargo-minimal.lock,Cargo-recent.lock
-ignore-words-list = crate,ser
+ignore-words-list = crate,ser,ot

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -153,6 +153,7 @@ pub fn init_bitcoind() -> Result<corepc_node::Node, BoxError> {
     let bitcoind_exe = corepc_node::exe_path()?;
     let mut conf = corepc_node::Conf::default();
     conf.view_stdout = tracing::enabled!(target: "corepc", Level::TRACE);
+    // conf.args.push("-txindex");
     let bitcoind = corepc_node::Node::with_conf(bitcoind_exe, &conf)?;
     Ok(bitcoind)
 }


### PR DESCRIPTION

<img width="1024" height="1024" alt="Payjoin Monitor" src="https://github.com/user-attachments/assets/45d3a85f-4653-4b89-83e8-22308080035e" />


A payjoin session is closed once there is nothing more to do in the
protocol but wait for expiry, or confirmation of one of the possible
transactions to settle the outcome.

This commit introduces a monitoring typestate as the final receiver
typestate. Monitoring checks for the confirmation of session
relevant transactions. Concretely we check for:
* The payjoin proposal via txid if all inputs are segwit.
* The fallback tx via txid.
* The payjoin proposal via spent outpoints if at least one input is not
  segwit.
* Any spent outpoint which would indicate a double spend of an outpoint
  that was used in the payjoin.

The typestate accepts two fallbacks:
* `transaction_exists(txid)`
* `outpoint_spent(outpoint)`

If a broadcasted payjoin proposal was detected the session will close
and the success event will include the sender `scriptsig` and/or
`witness`. Fallbacks and double spends will also close the session and
the event logged will include which condition closed the session.

Related to #807 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
