### PR TITLE
Enforce that `SessionHistory` is created internally

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -139,7 +139,7 @@ pub fn replay_receiver_event_log(
     Ok(ReplayResult { state: state.into(), session_history: session_history.into() })
 }
 
-#[derive(Default, Clone, uniffi::Object)]
+#[derive(Clone, uniffi::Object)]
 pub struct SessionHistory(pub payjoin::receive::v2::SessionHistory);
 
 impl From<payjoin::receive::v2::SessionHistory> for SessionHistory {

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -111,7 +111,7 @@ pub fn replay_sender_event_log(
     Ok(SenderReplayResult { state: state.into(), session_history: session_history.into() })
 }
 
-#[derive(uniffi::Object, Default, Clone)]
+#[derive(uniffi::Object, Clone)]
 pub struct SenderSessionHistory(pub payjoin::send::v2::SessionHistory);
 
 impl From<payjoin::send::v2::SessionHistory> for SenderSessionHistory {


### PR DESCRIPTION
`SessionHistory` should only be created internally. Removing the default impl and replacing it with a pub(crate) new is the simplest way to achieve that.

Related ticket: #1046 

---- 

Note this only gets us a "weak" type saftey net around non-empty session events. We know that they are non-empty bc replaying checks for them. However should they be checked in ::new() or perhaps a `SessionHistoryBuilder` or something else? Im ambivalent. And perhaps we can do this refactoring after 1.0 as this wouldnt break semver. 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
