### PR TITLE
Check for spendable UTXOs before payjoin operations

### DIFF
--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -34,6 +34,13 @@ pub trait App: Send + Sync {
         amount: Amount,
         fee_rate: FeeRate,
     ) -> Result<Psbt> {
+        // Check if wallet has spendable UTXOs before attempting to create PSBT
+        if !self.wallet().has_spendable_utxos()? {
+            return Err(anyhow::anyhow!(
+                "No spendable UTXOs available in wallet. Please ensure your wallet has confirmed funds."
+            ));
+        }
+
         // wallet_create_funded_psbt requires a HashMap<address: String, Amount>
         let mut outputs = HashMap::with_capacity(1);
         outputs.insert(address.to_string(), amount);

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -378,6 +378,15 @@ fn try_contributing_inputs(
     let candidate_inputs =
         wallet.list_unspent().map_err(|e| ImplementationError::from(e.into_boxed_dyn_error()))?;
 
+    if candidate_inputs.is_empty() {
+        return Err(ImplementationError::from(
+            anyhow::anyhow!(
+                "No spendable UTXOs available in wallet. Please fund your wallet before resuming this session"
+            )
+            .into_boxed_dyn_error(),
+        ));
+    }
+
     let selected_input =
         payjoin.try_preserving_privacy(candidate_inputs).map_err(ImplementationError::new)?;
 

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -473,6 +473,12 @@ impl App {
         let wallet = self.wallet();
         let candidate_inputs = wallet.list_unspent()?;
 
+        if candidate_inputs.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No spendable UTXOs available in wallet. Cannot contribute inputs to payjoin."
+            ));
+        }
+
         let selected_input = proposal.try_preserving_privacy(candidate_inputs)?;
         let proposal =
             proposal.contribute_inputs(vec![selected_input])?.commit_inputs().save(persister)?;

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -164,6 +164,12 @@ impl BitcoindWallet {
         Ok(unspent.into_iter().map(input_pair_from_corepc).collect())
     }
 
+    /// Check if wallet has any spendable UTXOs
+    pub fn has_spendable_utxos(&self) -> Result<bool> {
+        let unspent = self.list_unspent()?;
+        Ok(!unspent.is_empty())
+    }
+
     /// Get the network this wallet is operating on
     pub fn network(&self) -> Result<Network> {
         tokio::task::block_in_place(|| {


### PR DESCRIPTION
This PR improves error handling when a wallet has no UTXOs.
Previously, attempting to send or receive without UTXOs returned a generic Error: Obtained failure status(500): Internal Server Error.
This change lets the code now performs UTXO checks and provides informative error messages for both send and receive operations.
This makes failures more user-friendly and easier to debug.
Closes #1070 
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
