### PR TITLE
Rename `V2GetContext` to `PollingForProposal`

### DIFF
--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -345,7 +345,7 @@ void main() {
       var response = await agent.post(Uri.parse(request.request.url.asString()),
           headers: {"Content-Type": request.request.contentType},
           body: request.request.body);
-      payjoin.V2GetContext send_ctx = req_ctx
+      payjoin.PollingForProposal send_ctx = req_ctx
           .processResponse(response.bodyBytes, request.context)
           .save(sender_persister);
       // POST Original PSBT

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -165,7 +165,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
                 headers={"Content-Type": request.request.content_type},
                 content=request.request.body
             )
-            send_ctx: V2GetContext = req_ctx.process_response(response.content, request.context).save(sender_persister)
+            send_ctx: PollingForProposal = req_ctx.process_response(response.content, request.context).save(sender_persister)
             # POST Original PSBT
 
             # **********************

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -1,7 +1,7 @@
 use super::WithReplyKey;
 use crate::error::{InternalReplayError, ReplayError};
 use crate::persist::SessionPersister;
-use crate::send::v2::{SendSession, V2GetContext};
+use crate::send::v2::{PollingForProposal, SendSession};
 use crate::uri::v2::PjParam;
 use crate::ImplementationError;
 
@@ -103,7 +103,7 @@ pub enum SessionEvent {
     /// Sender was created with a HPKE key pair
     CreatedReplyKey(WithReplyKey),
     /// Sender POST'd the original PSBT, and waiting to receive a Proposal PSBT using GET context
-    V2GetContext(V2GetContext),
+    PollingForProposal(PollingForProposal),
     /// Sender received a Proposal PSBT
     ProposalReceived(bitcoin::Psbt),
     /// Invalid session
@@ -152,7 +152,7 @@ mod tests {
             reply_key: keypair.0.clone(),
         };
 
-        let v2_get_context = V2GetContext {
+        let polling_for_proposal = PollingForProposal {
             pj_param: pj_param.clone(),
             psbt_ctx: PsbtContext {
                 original_psbt: PARSED_ORIGINAL_PSBT.clone(),
@@ -166,7 +166,7 @@ mod tests {
 
         let test_cases = vec![
             SessionEvent::CreatedReplyKey(sender_with_reply_key.clone()),
-            SessionEvent::V2GetContext(v2_get_context.clone()),
+            SessionEvent::PollingForProposal(polling_for_proposal.clone()),
             SessionEvent::ProposalReceived(PARSED_ORIGINAL_PSBT.clone()),
             SessionEvent::SessionInvalid("error message".to_string()),
         ];


### PR DESCRIPTION
`V2GetContext` is not an informative name for this typestate. This commit finds and replaces all instances with `PollingForProposal`.


Closes: #1067 
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
