### PR TITLE
Remove url::Url from return values in public api

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -137,7 +137,8 @@ impl App {
         let addr = SocketAddr::from(([0, 0, 0, 0], port));
         let listener = TcpListener::bind(addr).await?;
 
-        let mut endpoint = self.config.v1()?.pj_endpoint.clone();
+        let mut endpoint =
+            url::Url::parse(self.config.v1()?.pj_endpoint.as_str()).expect("could not parse Url");
 
         // If --port 0 is specified, a free port is chosen, so we need to set it
         // on the endpoint which must not have a port.

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -72,7 +72,7 @@ impl AppTrait for App {
         let body = String::from_utf8(req.body.clone()).unwrap();
         println!("Sending fallback request to {}", &req.url);
         let response = http
-            .post(req.url)
+            .post(req.url.as_str())
             .header("Content-Type", req.content_type)
             .body(body.clone())
             .send()

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -168,7 +168,7 @@ impl AppTrait for App {
                 let body = String::from_utf8(req.body.clone()).unwrap();
                 println!("Sending fallback request to {}", &req.url);
                 let response = http
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(body.clone())
                     .send()
@@ -734,7 +734,7 @@ impl App {
 
     async fn post_request(&self, req: payjoin::Request) -> Result<reqwest::Response> {
         let http = http_agent(&self.config)?;
-        http.post(req.url)
+        http.post(req.url.as_str())
             .header("Content-Type", req.content_type)
             .body(req.body)
             .send()

--- a/payjoin-ffi/dart/README.md
+++ b/payjoin-ffi/dart/README.md
@@ -12,7 +12,7 @@ git clone https://github.com/payjoin/rust-payjoin.git
 cd rust-payjoin/payjoin-ffi/dart
 
 # Generate the bindings (use the script appropriate for your platform)
-bash ./scripts/generate_<platform>.sh
+bash ./scripts/generate_bindings.sh
 
 # Run all tests
 dart test

--- a/payjoin-ffi/src/lib.rs
+++ b/payjoin-ffi/src/lib.rs
@@ -22,5 +22,5 @@ pub use crate::request::Request;
 pub use crate::send::*;
 #[cfg(feature = "_test-utils")]
 pub use crate::test_utils::*;
-pub use crate::uri::{PjUri, Uri, Url};
+pub use crate::uri::{PjUri, Uri};
 uniffi::setup_scaffolding!();

--- a/payjoin-ffi/src/lib.rs
+++ b/payjoin-ffi/src/lib.rs
@@ -22,5 +22,5 @@ pub use crate::request::Request;
 pub use crate::send::*;
 #[cfg(feature = "_test-utils")]
 pub use crate::test_utils::*;
-pub use crate::uri::{PjUri, Uri};
+pub use crate::uri::{PjUri, Uri, Url};
 uniffi::setup_scaffolding!();

--- a/payjoin-ffi/src/request.rs
+++ b/payjoin-ffi/src/request.rs
@@ -1,11 +1,15 @@
+use std::sync::Arc;
+
+use crate::uri::Url;
+
 ///Represents data that needs to be transmitted to the receiver.
 ///You need to send this request over HTTP(S) to the receiver.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct Request {
     /// URL to send the request to.
     ///
-    /// This is a URL string - you will need to parse it before you can pass it to `reqwest` or a similar library.
-    pub url: String,
+    /// This is a payjoin URL wrapper - you will need to get the full url out before you can pass it to `reqwest` or a similar library.
+    pub url: Arc<Url>,
 
     /// The `Content-Type` header to use for the request.
     ///
@@ -20,6 +24,10 @@ pub struct Request {
 
 impl From<payjoin::Request> for Request {
     fn from(value: payjoin::Request) -> Self {
-        Self { url: value.url, content_type: value.content_type.to_string(), body: value.body }
+        Self {
+            url: Arc::new(value.url.into()),
+            content_type: value.content_type.to_string(),
+            body: value.body,
+        }
     }
 }

--- a/payjoin-ffi/src/request.rs
+++ b/payjoin-ffi/src/request.rs
@@ -1,15 +1,11 @@
-use std::sync::Arc;
-
-use crate::uri::Url;
-
 ///Represents data that needs to be transmitted to the receiver.
 ///You need to send this request over HTTP(S) to the receiver.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct Request {
     /// URL to send the request to.
     ///
-    /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Arc<Url>,
+    /// This is a URL string - you will need to parse it before you can pass it to `reqwest` or a similar library.
+    pub url: String,
 
     /// The `Content-Type` header to use for the request.
     ///
@@ -24,10 +20,6 @@ pub struct Request {
 
 impl From<payjoin::Request> for Request {
     fn from(value: payjoin::Request) -> Self {
-        Self {
-            url: Arc::new(value.url.into()),
-            content_type: value.content_type.to_string(),
-            body: value.body,
-        }
+        Self { url: value.url, content_type: value.content_type.to_string(), body: value.body }
     }
 }

--- a/payjoin-ffi/src/test_utils.rs
+++ b/payjoin-ffi/src/test_utils.rs
@@ -13,6 +13,8 @@ use serde_json::Value;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
+use crate::Url;
+
 lazy_static! {
     static ref RUNTIME: Arc<std::sync::Mutex<Runtime>> =
         Arc::new(std::sync::Mutex::new(Runtime::new().expect("Failed to create Tokio runtime")));
@@ -126,9 +128,13 @@ impl TestServices {
         runtime.block_on(async { self.0.lock().await.cert() })
     }
 
-    pub fn directory_url(&self) -> String {
+    pub fn directory_url(&self) -> Url {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.directory_url().to_string() })
+        runtime.block_on(async {
+            payjoin::Url::try_from(self.0.lock().await.directory_url().to_string())
+                .expect("Could not parse Url")
+                .into()
+        })
     }
 
     pub fn take_directory_handle(&self) -> JoinHandle {
@@ -137,14 +143,22 @@ impl TestServices {
             .block_on(async { JoinHandle(Arc::new(self.0.lock().await.take_directory_handle())) })
     }
 
-    pub fn ohttp_relay_url(&self) -> String {
+    pub fn ohttp_relay_url(&self) -> Url {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.ohttp_relay_url().to_string() })
+        runtime.block_on(async {
+            payjoin::Url::try_from(self.0.lock().await.ohttp_relay_url().to_string())
+                .expect("Could not parse Url")
+                .into()
+        })
     }
 
-    pub fn ohttp_gateway_url(&self) -> String {
+    pub fn ohttp_gateway_url(&self) -> Url {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.ohttp_gateway_url().to_string() })
+        runtime.block_on(async {
+            payjoin::Url::try_from(self.0.lock().await.ohttp_gateway_url().to_string())
+                .expect("Could not parse Url")
+                .into()
+        })
     }
 
     pub fn take_ohttp_relay_handle(&self) -> JoinHandle {

--- a/payjoin-ffi/src/test_utils.rs
+++ b/payjoin-ffi/src/test_utils.rs
@@ -13,8 +13,6 @@ use serde_json::Value;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
-use crate::Url;
-
 lazy_static! {
     static ref RUNTIME: Arc<std::sync::Mutex<Runtime>> =
         Arc::new(std::sync::Mutex::new(Runtime::new().expect("Failed to create Tokio runtime")));
@@ -128,9 +126,9 @@ impl TestServices {
         runtime.block_on(async { self.0.lock().await.cert() })
     }
 
-    pub fn directory_url(&self) -> Url {
+    pub fn directory_url(&self) -> String {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.directory_url().into() })
+        runtime.block_on(async { self.0.lock().await.directory_url().to_string() })
     }
 
     pub fn take_directory_handle(&self) -> JoinHandle {
@@ -139,14 +137,14 @@ impl TestServices {
             .block_on(async { JoinHandle(Arc::new(self.0.lock().await.take_directory_handle())) })
     }
 
-    pub fn ohttp_relay_url(&self) -> Url {
+    pub fn ohttp_relay_url(&self) -> String {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.ohttp_relay_url().into() })
+        runtime.block_on(async { self.0.lock().await.ohttp_relay_url().to_string() })
     }
 
-    pub fn ohttp_gateway_url(&self) -> Url {
+    pub fn ohttp_gateway_url(&self) -> String {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.ohttp_gateway_url().into() })
+        runtime.block_on(async { self.0.lock().await.ohttp_gateway_url().to_string() })
     }
 
     pub fn take_ohttp_relay_handle(&self) -> JoinHandle {
@@ -191,7 +189,7 @@ pub fn init_bitcoind_sender_receiver() -> Result<Arc<BitcoindEnv>, FfiError> {
 }
 
 #[uniffi::export]
-pub fn example_url() -> Url { EXAMPLE_URL.clone().into() }
+pub fn example_url() -> String { EXAMPLE_URL.to_string() }
 
 #[uniffi::export]
 pub fn query_params() -> String { QUERY_PARAMS.to_string() }

--- a/payjoin-ffi/src/uri/error.rs
+++ b/payjoin-ffi/src/uri/error.rs
@@ -20,7 +20,7 @@ impl From<String> for PjNotSupported {
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]
-pub struct UrlParseError(#[from] payjoin::ParseError);
+pub struct UrlParseError(#[from] url::ParseError);
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]

--- a/payjoin-ffi/src/uri/mod.rs
+++ b/payjoin-ffi/src/uri/mod.rs
@@ -73,24 +73,3 @@ impl PjUri {
 
     pub fn as_string(&self) -> String { self.0.clone().to_string() }
 }
-
-impl From<payjoin::Url> for Url {
-    fn from(value: payjoin::Url) -> Self { Self(value) }
-}
-
-impl From<Url> for payjoin::Url {
-    fn from(value: Url) -> Self { value.0 }
-}
-
-#[derive(Clone, Debug, uniffi::Object)]
-pub struct Url(payjoin::Url);
-
-#[uniffi::export]
-impl Url {
-    #[uniffi::constructor]
-    pub fn parse(input: String) -> Result<Url, UrlParseError> {
-        payjoin::Url::parse(input.as_str()).map_err(Into::into).map(Self)
-    }
-    pub fn query(&self) -> Option<String> { self.0.query().map(|x| x.to_string()) }
-    pub fn as_string(&self) -> String { self.0.to_string() }
-}

--- a/payjoin-ffi/src/uri/mod.rs
+++ b/payjoin-ffi/src/uri/mod.rs
@@ -73,3 +73,29 @@ impl PjUri {
 
     pub fn as_string(&self) -> String { self.0.clone().to_string() }
 }
+
+impl From<payjoin::Url> for Url {
+    fn from(value: payjoin::Url) -> Self { Self(value) }
+}
+
+impl From<Url> for payjoin::Url {
+    fn from(value: Url) -> Self { value.0 }
+}
+
+#[derive(Clone, Debug, uniffi::Object)]
+pub struct Url(payjoin::Url);
+
+#[uniffi::export]
+impl Url {
+    #[uniffi::constructor]
+    pub fn parse(input: String) -> Result<Url, UrlParseError> {
+        payjoin::Url::try_from(input).map(Self).map_err(Into::into)
+    }
+    pub fn query(&self) -> Option<String> {
+        url::Url::parse(self.0.as_str())
+            .expect("could not parse Url")
+            .query()
+            .map(|x| x.to_string())
+    }
+    pub fn as_string(&self) -> String { self.0.to_string() }
+}

--- a/payjoin/src/core/into_url.rs
+++ b/payjoin/src/core/into_url.rs
@@ -1,4 +1,8 @@
-use url::{ParseError, Url};
+use std::convert::TryFrom;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use url::ParseError;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -25,6 +29,26 @@ impl From<ParseError> for Error {
 
 type Result<T> = core::result::Result<T, Error>;
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(try_from = "String")]
+pub struct Url(pub(crate) url::Url);
+
+impl Url {
+    pub fn as_str(&self) -> &str { self.0.as_ref() }
+
+    fn parse(s: &str) -> std::result::Result<Self, url::ParseError> { url::Url::parse(s).map(Url) }
+}
+
+impl TryFrom<String> for Url {
+    type Error = url::ParseError;
+
+    fn try_from(s: String) -> std::result::Result<Self, Self::Error> { Url::parse(&s) }
+}
+
+impl fmt::Display for Url {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.as_str()) }
+}
+
 /// Try to convert some type into a [`Url`].
 ///
 /// This trait is "sealed", such that only types within payjoin can
@@ -34,6 +58,8 @@ type Result<T> = core::result::Result<T, Error>;
 /// see <https://docs.rs/reqwest/latest/reqwest/trait.IntoUrl.html>
 pub trait IntoUrl: IntoUrlSealed {}
 
+impl IntoUrl for Url {}
+impl IntoUrl for &Url {}
 impl IntoUrl for &str {}
 impl IntoUrl for &String {}
 impl IntoUrl for String {}
@@ -47,25 +73,25 @@ pub trait IntoUrlSealed {
 }
 
 impl IntoUrlSealed for &Url {
-    fn into_url(self) -> Result<Url> { self.clone().into_url() }
+    fn into_url(self) -> Result<Url> { Ok(self.clone()) }
 
-    fn as_str(&self) -> &str { self.as_ref() }
+    fn as_str(&self) -> &str { self.0.as_ref() }
 }
 
 impl IntoUrlSealed for Url {
     fn into_url(self) -> Result<Url> {
-        if self.has_host() {
+        if self.0.has_host() {
             Ok(self)
         } else {
             Err(Error::BadScheme)
         }
     }
 
-    fn as_str(&self) -> &str { self.as_ref() }
+    fn as_str(&self) -> &str { self.0.as_ref() }
 }
 
 impl IntoUrlSealed for &str {
-    fn into_url(self) -> Result<Url> { Url::parse(self)?.into_url() }
+    fn into_url(self) -> Result<Url> { Ok(Url(url::Url::parse(self)?)) }
 
     fn as_str(&self) -> &str { self }
 }
@@ -84,52 +110,52 @@ impl IntoUrlSealed for String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::core::into_url::{IntoUrlSealed, Url};
 
     #[test]
     fn http_uri_scheme_is_allowed() {
         let url = "http://localhost".into_url().unwrap();
-        assert_eq!(url.scheme(), "http");
+        assert_eq!(url.0.scheme(), "http");
     }
 
     #[test]
     fn https_uri_scheme_is_allowed() {
         let url = "https://localhost".into_url().unwrap();
-        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.0.scheme(), "https");
     }
 
     #[test]
     fn into_url_file_scheme() {
-        let err = "file:///etc/hosts".into_url().unwrap_err();
+        let err = Url::parse("file:///etc/hosts").unwrap().into_url().unwrap_err();
         assert_eq!(err.to_string(), "URL scheme is not allowed");
     }
 
     #[test]
     fn into_url_blob_scheme() {
-        let err = "blob:https://example.com".into_url().unwrap_err();
+        let err = Url::parse("blob:https://example.com").unwrap().into_url().unwrap_err();
         assert_eq!(err.to_string(), "URL scheme is not allowed");
     }
 
     #[test]
     fn into_url_conversions() {
         let input = "http://localhost/";
-        let url = Url::parse(input).unwrap();
+        let url = Url(url::Url::parse(input).unwrap());
 
         let url_ref = &url;
-        assert_eq!(url_ref.as_str(), url.as_ref());
-        assert_eq!(IntoUrlSealed::as_str(url_ref), url.as_ref());
-        assert_eq!(IntoUrlSealed::as_str(&url_ref), url.as_ref());
+        assert_eq!(url_ref.as_str(), url.0.as_ref());
+        assert_eq!(IntoUrlSealed::as_str(url_ref), url.0.as_ref());
+        assert_eq!(IntoUrlSealed::as_str(&url_ref), url.0.as_ref());
 
         let url_str: &str = input;
-        assert_eq!(url_str, url.as_ref());
-        assert_eq!(IntoUrlSealed::as_str(&url_str), url.as_ref());
+        assert_eq!(url_str, url.0.as_ref());
+        assert_eq!(IntoUrlSealed::as_str(&url_str), url.0.as_ref());
 
         let url_string: String = input.to_string();
-        assert_eq!(url_string, url.as_ref());
-        assert_eq!(IntoUrlSealed::as_str(&url_string), url.as_ref());
+        assert_eq!(url_string, url.0.as_ref());
+        assert_eq!(IntoUrlSealed::as_str(&url_string), url.0.as_ref());
 
         let url_string_ref: &String = &input.to_string();
-        assert_eq!(url_string_ref, url.as_ref());
-        assert_eq!(IntoUrlSealed::as_str(&url_string_ref), url.as_ref());
+        assert_eq!(url_string_ref, url.0.as_ref());
+        assert_eq!(IntoUrlSealed::as_str(&url_string_ref), url.0.as_ref());
     }
 }

--- a/payjoin/src/core/io.rs
+++ b/payjoin/src/core/io.rs
@@ -19,7 +19,7 @@ pub async fn fetch_ohttp_keys(
     ohttp_relay: impl IntoUrl,
     payjoin_directory: impl IntoUrl,
 ) -> Result<OhttpKeys, Error> {
-    let ohttp_keys_url = payjoin_directory.into_url()?.join("/.well-known/ohttp-gateway")?;
+    let ohttp_keys_url = payjoin_directory.into_url()?.0.join("/.well-known/ohttp-gateway")?;
     let proxy = Proxy::all(ohttp_relay.into_url()?.as_str())?;
     let client = Client::builder().proxy(proxy).build()?;
     let res = client
@@ -47,7 +47,7 @@ pub async fn fetch_ohttp_keys_with_cert(
     payjoin_directory: impl IntoUrl,
     cert_der: Vec<u8>,
 ) -> Result<OhttpKeys, Error> {
-    let ohttp_keys_url = payjoin_directory.into_url()?.join("/.well-known/ohttp-gateway")?;
+    let ohttp_keys_url = payjoin_directory.into_url()?.0.join("/.well-known/ohttp-gateway")?;
     let proxy = Proxy::all(ohttp_relay.into_url()?.as_str())?;
     let client = Client::builder()
         .use_rustls_tls()

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -15,12 +15,11 @@ mod request;
 pub mod send;
 pub use request::*;
 pub(crate) mod into_url;
-pub use into_url::{Error as IntoUrlError, IntoUrl};
+pub use into_url::{Error as IntoUrlError, IntoUrl, Url};
 #[cfg(feature = "v2")]
 pub mod time;
 pub mod uri;
 pub use uri::{PjParam, PjParseError, PjUri, Uri, UriExt};
-pub use url::{ParseError, Url};
 pub(crate) mod error_codes;
 
 pub(crate) mod output_substitution;

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -54,7 +54,7 @@ use crate::receive::v2::session::SessionOutcome;
 use crate::receive::{parse_payload, InputPair, OriginalPayload, PsbtContext};
 use crate::time::Time;
 use crate::uri::ShortId;
-use crate::{ImplementationError, IntoUrl, IntoUrlError, Request, Version};
+use crate::{ImplementationError, IntoUrl, IntoUrlError, Request, Url, Version};
 
 mod error;
 mod session;
@@ -268,7 +268,7 @@ fn extract_err_req(
         Some(err.to_json().to_string().as_bytes()),
     )
     .map_err(InternalSessionError::OhttpEncapsulation)?;
-    let req = Request::new_v2(session_context.full_relay_url(ohttp_relay)?.as_str(), &body);
+    let req = Request::new_v2(&Url(session_context.full_relay_url(ohttp_relay)?), &body);
     Ok((req, ohttp_ctx))
 }
 
@@ -357,8 +357,7 @@ impl Receiver<Initialized> {
         }
         let (body, ohttp_ctx) =
             self.fallback_req_body().map_err(InternalSessionError::OhttpEncapsulation)?;
-        let req =
-            Request::new_v2(self.session_context.full_relay_url(ohttp_relay)?.as_str(), &body);
+        let req = Request::new_v2(&Url(self.session_context.full_relay_url(ohttp_relay)?), &body);
         Ok((req, ohttp_ctx))
     }
 
@@ -1057,8 +1056,7 @@ impl Receiver<PayjoinProposal> {
             Some(&body),
         )?;
 
-        let req =
-            Request::new_v2(self.session_context.full_relay_url(ohttp_relay)?.as_str(), &body);
+        let req = Request::new_v2(&Url(self.session_context.full_relay_url(ohttp_relay)?), &body);
         Ok((req, ctx))
     }
 

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -619,7 +619,7 @@ mod tests {
 
         let uri = SessionHistory { events }.pj_uri();
 
-        assert_ne!(uri.extras.pj_param.endpoint(), EXAMPLE_URL.clone());
+        assert_ne!(uri.extras.pj_param.endpoint().0, EXAMPLE_URL.clone());
         assert_eq!(uri.extras.output_substitution, OutputSubstitution::Disabled);
 
         Ok(())

--- a/payjoin/src/core/request.rs
+++ b/payjoin/src/core/request.rs
@@ -1,4 +1,3 @@
-use url::Url;
 #[cfg(feature = "v1")]
 const V1_REQ_CONTENT_TYPE: &str = "text/plain";
 
@@ -12,8 +11,8 @@ const V2_REQ_CONTENT_TYPE: &str = "message/ohttp-req";
 pub struct Request {
     /// URL to send the request to.
     ///
-    /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Url,
+    /// This is a URL string - you will need to parse it before you can pass it to `reqwest` or a similar library.
+    pub url: String,
 
     /// The `Content-Type` header to use for the request.
     ///
@@ -29,16 +28,16 @@ pub struct Request {
 impl Request {
     /// Construct a new v1 request.
     #[cfg(feature = "v1")]
-    pub(crate) fn new_v1(url: &Url, body: &[u8]) -> Self {
-        Self { url: url.clone(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
+    pub(crate) fn new_v1(url: &str, body: &[u8]) -> Self {
+        Self { url: url.to_string(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 
     /// Construct a new v2 request.
     #[cfg(feature = "v2")]
     pub(crate) fn new_v2(
-        url: &Url,
+        url: &str,
         body: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES],
     ) -> Self {
-        Self { url: url.clone(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
+        Self { url: url.to_string(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 }

--- a/payjoin/src/core/request.rs
+++ b/payjoin/src/core/request.rs
@@ -1,3 +1,5 @@
+use crate::Url;
+
 #[cfg(feature = "v1")]
 const V1_REQ_CONTENT_TYPE: &str = "text/plain";
 
@@ -11,8 +13,8 @@ const V2_REQ_CONTENT_TYPE: &str = "message/ohttp-req";
 pub struct Request {
     /// URL to send the request to.
     ///
-    /// This is a URL string - you will need to parse it before you can pass it to `reqwest` or a similar library.
-    pub url: String,
+    /// This is a payjoin URL wrapper - you will need to get the full url out before you can pass it to `reqwest` or a similar library.
+    pub url: Url,
 
     /// The `Content-Type` header to use for the request.
     ///
@@ -28,16 +30,16 @@ pub struct Request {
 impl Request {
     /// Construct a new v1 request.
     #[cfg(feature = "v1")]
-    pub(crate) fn new_v1(url: &str, body: &[u8]) -> Self {
-        Self { url: url.to_string(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
+    pub(crate) fn new_v1(url: &Url, body: &[u8]) -> Self {
+        Self { url: url.clone(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 
     /// Construct a new v2 request.
     #[cfg(feature = "v2")]
     pub(crate) fn new_v2(
-        url: &str,
+        url: &Url,
         body: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES],
     ) -> Self {
-        Self { url: url.to_string(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
+        Self { url: url.clone(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 }

--- a/payjoin/src/core/send/mod.rs
+++ b/payjoin/src/core/send/mod.rs
@@ -20,7 +20,6 @@ use bitcoin::psbt::Psbt;
 use bitcoin::{Amount, FeeRate, Script, ScriptBuf, TxOut, Weight};
 pub use error::{BuildSenderError, ResponseError, ValidationError, WellKnownError};
 pub(crate) use error::{InternalBuildSenderError, InternalProposalError, InternalValidationError};
-use url::Url;
 
 use crate::output_substitution::OutputSubstitution;
 use crate::psbt::PsbtExt;
@@ -650,12 +649,12 @@ fn determine_fee_contribution(
 }
 
 fn serialize_url(
-    endpoint: Url,
+    endpoint: url::Url,
     output_substitution: OutputSubstitution,
     fee_contribution: Option<AdditionalFeeContribution>,
     min_fee_rate: FeeRate,
     version: Version,
-) -> Url {
+) -> url::Url {
     let mut url = endpoint;
     url.query_pairs_mut().append_pair("v", &version.to_string());
     if output_substitution == OutputSubstitution::Disabled {
@@ -687,7 +686,6 @@ mod test {
         BoxError, PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL,
         PARSED_PAYJOIN_PROPOSAL_WITH_SENDER_INFO,
     };
-    use url::Url;
 
     use super::*;
     use crate::output_substitution::OutputSubstitution;
@@ -1044,42 +1042,42 @@ mod test {
     #[test]
     fn test_disable_output_substitution_query_param() -> Result<(), BoxError> {
         let url = serialize_url(
-            Url::parse("http://localhost")?,
+            url::Url::parse("http://localhost")?,
             OutputSubstitution::Disabled,
             None,
             FeeRate::ZERO,
             Version::Two,
         );
-        assert_eq!(url, Url::parse("http://localhost?v=2&disableoutputsubstitution=true")?);
+        assert_eq!(url, url::Url::parse("http://localhost?v=2&disableoutputsubstitution=true")?);
 
         let url = serialize_url(
-            Url::parse("http://localhost")?,
+            url::Url::parse("http://localhost")?,
             OutputSubstitution::Enabled,
             None,
             FeeRate::ZERO,
             Version::Two,
         );
-        assert_eq!(url, Url::parse("http://localhost?v=2")?);
+        assert_eq!(url, url::Url::parse("http://localhost?v=2")?);
         Ok(())
     }
 
     #[test]
     fn test_min_feerate_query_param() -> Result<(), BoxError> {
         let url = serialize_url(
-            Url::parse("http://localhost")?,
+            url::Url::parse("http://localhost")?,
             OutputSubstitution::Enabled,
             None,
             FeeRate::from_sat_per_vb(10).expect("Could not parse feerate"),
             Version::Two,
         );
-        assert_eq!(url, Url::parse("http://localhost?v=2&minfeerate=10")?);
+        assert_eq!(url, url::Url::parse("http://localhost?v=2&minfeerate=10")?);
         Ok(())
     }
 
     #[test]
     fn test_additional_fee_contribution_query_param() -> Result<(), BoxError> {
         let url = serialize_url(
-            Url::parse("http://localhost")?,
+            url::Url::parse("http://localhost")?,
             OutputSubstitution::Enabled,
             Some(AdditionalFeeContribution { max_amount: Amount::from_sat(1000), vout: 0 }),
             FeeRate::ZERO,
@@ -1087,7 +1085,7 @@ mod test {
         );
         assert_eq!(
             url,
-            Url::parse(
+            url::Url::parse(
                 "http://localhost?v=2&additionalfeeoutputindex=0&maxadditionalfeecontribution=1000"
             )?
         );

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -177,7 +177,7 @@ impl Sender {
         clear_unneeded_fields(&mut sanitized_psbt);
         let body = sanitized_psbt.to_string().as_bytes().to_vec();
         (
-            Request::new_v1(url.as_str(), &body),
+            Request::new_v1(&Url(url), &body),
             V1Context {
                 psbt_context: PsbtContext {
                     original_psbt: self.psbt_ctx.original_psbt.clone(),

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -381,7 +381,7 @@ pub(crate) fn extract_request(
     let full_ohttp_relay = ohttp_relay
         .join(&format!("/{directory_base}"))
         .map_err(|e| InternalCreateRequestError::Url(e.into()))?;
-    let request = Request::new_v2(full_ohttp_relay.as_str(), &body);
+    let request = Request::new_v2(&Url(full_ohttp_relay), &body);
     Ok((request, ohttp_ctx))
 }
 
@@ -453,7 +453,7 @@ impl Sender<PollingForProposal> {
             .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
 
         let url = ohttp_relay.into_url().map_err(InternalCreateRequestError::Url)?.0;
-        Ok((Request::new_v2(url.as_str(), &body), ohttp_ctx))
+        Ok((Request::new_v2(&Url(url), &body), ohttp_ctx))
     }
 
     /// Processes the response for the final GET message from the sender client

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -212,7 +212,7 @@ mod tests {
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap();
         let reply_key = HpkeKeyPair::gen_keypair();
-        let endpoint = sender.endpoint().clone();
+        let endpoint = sender.endpoint().0.clone();
         let id = crate::uri::ShortId::try_from(&b"12345670"[..]).expect("valid short id");
         let expiration =
             (std::time::SystemTime::now() - std::time::Duration::from_secs(1)).try_into().unwrap();
@@ -256,7 +256,7 @@ mod tests {
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap();
         let reply_key = HpkeKeyPair::gen_keypair();
-        let endpoint = sender.endpoint().clone();
+        let endpoint = sender.endpoint().0.clone();
         let fallback_tx = sender.psbt_ctx.original_psbt.clone().extract_tx_unchecked_fee_rate();
         let id = crate::uri::ShortId::try_from(&b"12345670"[..]).expect("valid short id");
         let expiration =

--- a/payjoin/src/core/uri/mod.rs
+++ b/payjoin/src/core/uri/mod.rs
@@ -4,10 +4,10 @@ use std::borrow::Cow;
 
 use bitcoin::address::NetworkChecked;
 pub use error::PjParseError;
-use url::Url;
 
 #[cfg(feature = "v2")]
 pub(crate) use crate::directory::ShortId;
+use crate::into_url::Url;
 use crate::output_substitution::OutputSubstitution;
 use crate::uri::error::InternalPjParseError;
 
@@ -29,7 +29,7 @@ pub enum PjParam {
 
 impl PjParam {
     pub fn parse(endpoint: impl super::IntoUrl) -> Result<Self, PjParseError> {
-        let endpoint = endpoint.into_url().map_err(InternalPjParseError::IntoUrl)?;
+        let endpoint = endpoint.into_url().map_err(InternalPjParseError::IntoUrl)?.0;
 
         #[cfg(feature = "v2")]
         match v2::PjParam::parse(endpoint.clone()) {
@@ -63,8 +63,8 @@ impl std::fmt::Display for PjParam {
         // normalizing to uppercase enables QR alphanumeric mode encoding
         // unfortunately Url normalizes these to be lowercase
         let endpoint = self.endpoint();
-        let scheme = endpoint.scheme();
-        let host = endpoint.host_str().expect("host must be set");
+        let scheme = endpoint.0.scheme();
+        let host = endpoint.0.host_str().expect("host must be set");
         let endpoint_str = self
             .endpoint()
             .as_str()

--- a/payjoin/src/core/uri/v1.rs
+++ b/payjoin/src/core/uri/v1.rs
@@ -1,17 +1,16 @@
 //! Payjoin v1 URI functionality
 
-use url::Url;
-
 use super::PjParseError;
+use crate::into_url::{self, Url};
 use crate::uri::error::InternalPjParseError;
 
 /// Payjoin v1 parameter containing the endpoint URL
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct PjParam(Url);
+pub struct PjParam(url::Url);
 
 impl PjParam {
     /// Parse a new v1 PjParam from a URL
-    pub(super) fn parse(url: Url) -> Result<Self, PjParseError> {
+    pub(super) fn parse(url: url::Url) -> Result<Self, PjParseError> {
         if url.scheme() == "https"
             || url.scheme() == "http" && url.domain().unwrap_or_default().ends_with(".onion")
         {
@@ -22,7 +21,7 @@ impl PjParam {
     }
 
     /// Get the endpoint URL
-    pub(crate) fn endpoint(&self) -> Url { self.0.clone() }
+    pub(crate) fn endpoint(&self) -> Url { into_url::Url(self.0.clone()) }
 }
 
 impl std::fmt::Display for PjParam {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -247,7 +247,7 @@ mod integration {
                 let (req, _ctx) =
                     bad_initializer.create_poll_request(services.ohttp_relay_url().as_str())?;
                 agent
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(req.body)
                     .send()
@@ -342,7 +342,7 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(req.body)
                     .send()
@@ -373,8 +373,12 @@ mod integration {
                     .save(&sender_persister)?;
                 let (Request { url, body, content_type, .. }, _send_ctx) =
                     req_ctx.create_v2_post_request(services.ohttp_relay_url().as_str())?;
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(url.as_str())
+                    .header("Content-Type", content_type)
+                    .body(body)
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
                 // POST Original PSBT
@@ -386,7 +390,7 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(req.body)
                     .send()
@@ -424,7 +428,7 @@ mod integration {
                     .extract_err_req(services.ohttp_relay_url().as_str())?
                     .expect("error request should exist");
                 let err_response = agent
-                    .post(err_req.url)
+                    .post(err_req.url.as_str())
                     .header("Content-Type", err_req.content_type)
                     .body(err_req.body)
                     .send()
@@ -473,7 +477,7 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(req.body)
                     .send()
@@ -504,8 +508,12 @@ mod integration {
                     .save(&send_persister)?;
                 let (Request { url, body, content_type, .. }, send_ctx) =
                     req_ctx.create_v2_post_request(services.ohttp_relay_url().as_str())?;
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(url.as_str())
+                    .header("Content-Type", content_type)
+                    .body(body)
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
                 let send_ctx = req_ctx
@@ -520,7 +528,7 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(req.body)
                     .send()
@@ -538,7 +546,7 @@ mod integration {
                 let (req, ctx) =
                     payjoin_proposal.create_post_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
+                    .post(req.url.as_str())
                     .header("Content-Type", req.content_type)
                     .body(req.body)
                     .send()
@@ -553,8 +561,12 @@ mod integration {
                 // Replay post fallback to get the response
                 let (Request { url, body, content_type, .. }, ohttp_ctx) =
                     send_ctx.create_poll_request(services.ohttp_relay_url().as_str())?;
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(url.as_str())
+                    .header("Content-Type", content_type)
+                    .body(body)
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 let response = send_ctx
                     .process_response(&response.bytes().await?, ohttp_ctx)
@@ -703,7 +715,7 @@ mod integration {
                     req_ctx.create_v1_post_request();
                 tracing::info!("send fallback v1 to offline receiver fail");
                 let res = agent
-                    .post(url.clone())
+                    .post(url.as_str())
                     .header("Content-Type", content_type)
                     .body(body.clone())
                     .send()
@@ -721,7 +733,7 @@ mod integration {
                     let proposal = loop {
                         let (req, ctx) = session.create_poll_request(&ohttp_relay)?;
                         let response = agent_clone
-                            .post(req.url)
+                            .post(req.url.as_str())
                             .header("Content-Type", req.content_type)
                             .body(req.body)
                             .send()
@@ -753,7 +765,7 @@ mod integration {
                     // this response would be returned as http response to the sender
                     let (req, ctx) = payjoin_proposal.create_post_request(ohttp_relay)?;
                     let response = agent_clone
-                        .post(req.url)
+                        .post(req.url.as_str())
                         .header("Content-Type", req.content_type)
                         .body(req.body)
                         .send()
@@ -768,8 +780,12 @@ mod integration {
                 // **********************
                 // send fallback v1 to online receiver
                 tracing::info!("send fallback v1 to online receiver should succeed");
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(url.as_str())
+                    .header("Content-Type", content_type)
+                    .body(body)
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
 
@@ -1169,7 +1185,7 @@ mod integration {
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
         let proposal = payjoin::receive::v1::UncheckedOriginalPayload::from_request(
             req.body.as_slice(),
-            url::Url::parse(&req.url)?.query().unwrap_or(""),
+            url::Url::parse(req.url.as_str())?.query().unwrap_or(""),
             headers,
         )?;
         let proposal =

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -1169,7 +1169,7 @@ mod integration {
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
         let proposal = payjoin::receive::v1::UncheckedOriginalPayload::from_request(
             req.body.as_slice(),
-            req.url.query().unwrap_or(""),
+            url::Url::parse(&req.url)?.query().unwrap_or(""),
             headers,
         )?;
         let proposal =


### PR DESCRIPTION
This adds a payjoin Url with an IntoUrl interface that prevents The Url dep from being publicly accessible in our Api.

consulted chat gpt on some of the type conversion errors I ran into along the way.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
