### PR TITLE
Introduce SessionEvent::Closed

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -955,7 +955,17 @@ impl From<payjoin::receive::v2::Receiver<payjoin::receive::v2::PayjoinProposal>>
 
 #[derive(uniffi::Object)]
 pub struct PayjoinProposalTransition(
-    Arc<RwLock<Option<payjoin::persist::MaybeSuccessTransition<(), payjoin::receive::Error>>>>,
+    Arc<
+        RwLock<
+            Option<
+                payjoin::persist::MaybeSuccessTransition<
+                    payjoin::receive::v2::SessionEvent,
+                    (),
+                    payjoin::receive::Error,
+                >,
+            >,
+        >,
+    >,
 );
 
 #[uniffi::export]

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -185,6 +185,9 @@ impl ReceiveSession {
             ) => Ok(state.apply_payjoin_proposal(payjoin_proposal)),
 
             (_, SessionEvent::SessionInvalid(_, _)) => Ok(ReceiveSession::TerminalFailure),
+
+            (current_state, SessionEvent::Closed) => Ok(current_state),
+
             (current_state, event) => Err(InternalReplayError::InvalidEvent(
                 Box::new(event),
                 Some(Box::new(current_state)),
@@ -1046,11 +1049,11 @@ impl Receiver<PayjoinProposal> {
         self,
         res: &[u8],
         ohttp_context: ohttp::ClientResponse,
-    ) -> MaybeSuccessTransition<(), Error> {
+    ) -> MaybeSuccessTransition<SessionEvent, (), Error> {
         match process_post_res(res, ohttp_context)
             .map_err(|e| InternalSessionError::DirectoryResponse(e).into())
         {
-            Ok(_) => MaybeSuccessTransition::success(()),
+            Ok(_) => MaybeSuccessTransition::success(SessionEvent::Closed, ()),
             Err(e) => MaybeSuccessTransition::transient(e),
         }
     }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -51,6 +51,7 @@ use crate::persist::{
     MaybeFatalTransition, MaybeFatalTransitionWithNoResults, MaybeSuccessTransition,
     MaybeTransientTransition, NextStateTransition,
 };
+use crate::receive::v2::session::SessionOutcome;
 use crate::receive::{parse_payload, InputPair, OriginalPayload, PsbtContext};
 use crate::time::Time;
 use crate::uri::ShortId;
@@ -186,7 +187,7 @@ impl ReceiveSession {
 
             (_, SessionEvent::SessionInvalid(_, _)) => Ok(ReceiveSession::TerminalFailure),
 
-            (current_state, SessionEvent::Closed) => Ok(current_state),
+            (current_state, SessionEvent::Closed(_)) => Ok(current_state),
 
             (current_state, event) => Err(InternalReplayError::InvalidEvent(
                 Box::new(event),
@@ -1053,7 +1054,8 @@ impl Receiver<PayjoinProposal> {
         match process_post_res(res, ohttp_context)
             .map_err(|e| InternalSessionError::DirectoryResponse(e).into())
         {
-            Ok(_) => MaybeSuccessTransition::success(SessionEvent::Closed, ()),
+            Ok(_) =>
+                MaybeSuccessTransition::success(SessionEvent::Closed(SessionOutcome::Success), ()),
             Err(e) => MaybeSuccessTransition::transient(e),
         }
     }

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -172,9 +172,9 @@ impl SessionHistory {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 /// Represents a piece of information that the receiver has obtained from the session
 /// Each event can be used to transition the receiver state machine to a new state
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SessionEvent {
     Created(SessionContext),
     UncheckedOriginalPayload {
@@ -194,7 +194,20 @@ pub enum SessionEvent {
     /// Reason being in some cases we still want to preserve the error b/c we can action on it. For now this is a terminal state and there is nothing to replay and is saved to be displayed.
     /// b/c its a terminal state and there is nothing to replay. So serialization will be lossy and that is fine.
     SessionInvalid(String, Option<JsonReply>),
-    Closed,
+    Closed(SessionOutcome),
+}
+
+/// Represents all possible outcomes for a closed Payjoin session
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SessionOutcome {
+    /// Payjoin completed successfully
+    /// TODO: this should include the sender's witnesses once tx monitoring is implemented
+    /// (this will ensure the payjoin txid can be computed)
+    Success,
+    /// Payjoin failed to complete due to a counterparty deviation from the protocol
+    Failure,
+    /// Payjoin was cancelled by the user
+    Cancel,
 }
 
 #[cfg(test)]

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -194,6 +194,7 @@ pub enum SessionEvent {
     /// Reason being in some cases we still want to preserve the error b/c we can action on it. For now this is a terminal state and there is nothing to replay and is saved to be displayed.
     /// b/c its a terminal state and there is nothing to replay. So serialization will be lossy and that is fine.
     SessionInvalid(String, Option<JsonReply>),
+    Closed,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The first commit introduces the `Closed` session event. The second commit introduces `Closed(SessionOutcome)` which can be a Success, Failure, or Abort with a provided reason (e.g. for manual closures by implementers).

 This PR only uses the `Success` reason when a response is successfully processed, but #1061 should update this to close the session only once a payjoin tx was actually detected. #1060 will use the Failure reason for closing sessions after an error has been handled. We'll also want to expose a method for implementers to close a session with a custom reason in another follow-up.

There is some overlap between this change and #1075 since this also modifies `MaybeSuccessTransition` cc @arminsabouri

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
