### PR TITLE
Consume `self` in `PollingForProposal::process_res`

### DIFF
--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -481,7 +481,7 @@ impl PollingForProposal {
         ohttp_ctx: &ClientResponse,
     ) -> PollingForProposalTransition {
         PollingForProposalTransition(Arc::new(RwLock::new(Some(
-            self.0.process_response(response, ohttp_ctx.into()),
+            self.0.clone().process_response(response, ohttp_ctx.into()),
         ))))
     }
 }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -462,7 +462,7 @@ impl Sender<PollingForProposal> {
     /// After this function is called, the sender can sign and finalize the
     /// PSBT and broadcast the resulting Payjoin transaction to the network.
     pub fn process_response(
-        &self,
+        self,
         response: &[u8],
         ohttp_ctx: ohttp::ClientResponse,
     ) -> MaybeSuccessTransitionWithNoResults<


### PR DESCRIPTION
Callers should give up ownership of the sender after calling the typestate transition method.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
