### PR TITLE
Remove unnecessary URI accessors from public api

### DIFF
--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -10,7 +10,6 @@ use crate::ohttp::ClientResponse;
 use crate::request::Request;
 use crate::send::error::{SenderPersistedError, SenderReplayError};
 use crate::uri::PjUri;
-use crate::Url;
 
 pub mod error;
 
@@ -124,8 +123,6 @@ impl From<SenderSessionHistory> for payjoin::send::v2::SessionHistory {
 
 #[uniffi::export]
 impl SenderSessionHistory {
-    pub fn endpoint(&self) -> Arc<Url> { Arc::new(self.0.pj_param().endpoint().into()) }
-
     /// Fallback transaction from the session if present
     pub fn fallback_tx(&self) -> Arc<crate::Transaction> { Arc::new(self.0.fallback_tx().into()) }
 }

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -142,13 +142,16 @@ impl PjParam {
         Ok(Self::new(url, id, ex, oh, rk))
     }
 
+    /// The receiver's ephemeral public key. This field is accessible outside of
+    /// the crate so that applications can ensure the value hasn't been
+    /// previously seen, as it should not be reused across different sessions.
     pub fn receiver_pubkey(&self) -> &HpkePublicKey { &self.receiver_pubkey }
 
-    pub fn ohttp_keys(&self) -> &OhttpKeys { &self.ohttp_keys }
+    pub(crate) fn ohttp_keys(&self) -> &OhttpKeys { &self.ohttp_keys }
 
-    pub fn expiration(&self) -> std::time::SystemTime { self.expiration }
+    pub(crate) fn expiration(&self) -> std::time::SystemTime { self.expiration }
 
-    pub fn endpoint(&self) -> Url {
+    pub(crate) fn endpoint(&self) -> Url {
         let mut endpoint = self.directory.clone().join(&self.id.to_string()).unwrap();
         set_receiver_pubkey(&mut endpoint, &self.receiver_pubkey);
         set_ohttp(&mut endpoint, &self.ohttp_keys);


### PR DESCRIPTION
These accessors are only needed internally in the crate.

The receiver pubkey is still pub because payjoin-cli (as should other implementations) checks for reuse and uses the pubkey to uniquely identify sessions when resuming.

This is following up on @DanGould's observation, but I couldn't find the comment or even remember if it was in a call or on github.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
