### PR TITLE
Remove mut ohttp keyconfig

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -668,7 +668,7 @@ impl App {
 
     async fn send_payjoin_proposal(
         &self,
-        mut proposal: Receiver<PayjoinProposal>,
+        proposal: Receiver<PayjoinProposal>,
         persister: &ReceiverPersister,
     ) -> Result<()> {
         let (req, ohttp_ctx) = proposal

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -385,7 +385,6 @@ impl Initialized {
         ohttp_relay: String,
     ) -> Result<RequestResponse, ReceiverError> {
         self.0
-            .clone()
             .create_poll_request(ohttp_relay)
             .map(|(req, ctx)| RequestResponse {
                 request: req.into(),

--- a/payjoin/src/core/ohttp.rs
+++ b/payjoin/src/core/ohttp.rs
@@ -14,14 +14,15 @@ pub const PADDED_BHTTP_REQ_BYTES: usize =
     ENCAPSULATED_MESSAGE_BYTES - (N_ENC + N_T + OHTTP_REQ_HEADER_BYTES);
 
 pub fn ohttp_encapsulate(
-    ohttp_keys: &mut ohttp::KeyConfig,
+    ohttp_keys: &ohttp::KeyConfig,
     method: &str,
     target_resource: &str,
     body: Option<&[u8]>,
 ) -> Result<([u8; ENCAPSULATED_MESSAGE_BYTES], ohttp::ClientResponse), OhttpEncapsulationError> {
     use std::fmt::Write;
+    let mut ohttp_keys = ohttp_keys.clone();
 
-    let ctx = ohttp::ClientRequest::from_config(ohttp_keys)?;
+    let ctx = ohttp::ClientRequest::from_config(&mut ohttp_keys)?;
     let url = url::Url::parse(target_resource)?;
     let authority_bytes = url.host().map_or_else(Vec::new, |host| {
         let mut authority = host.to_string();

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -257,7 +257,7 @@ fn extract_err_req(
     }
     let mailbox = mailbox_endpoint(&session_context.directory, &session_context.reply_mailbox_id());
     let (body, ohttp_ctx) = ohttp_encapsulate(
-        &mut session_context.ohttp_keys.0.clone(),
+        &session_context.ohttp_keys.0,
         "POST",
         mailbox.as_str(),
         Some(err.to_json().to_string().as_bytes()),
@@ -339,7 +339,7 @@ pub struct Initialized {}
 impl Receiver<Initialized> {
     /// construct an OHTTP Encapsulated HTTP GET request for the Original PSBT
     pub fn create_poll_request(
-        &mut self,
+        &self,
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, ohttp::ClientResponse), Error> {
         if SystemTime::now() > self.session_context.expiry {
@@ -413,7 +413,7 @@ impl Receiver<Initialized> {
     }
 
     fn fallback_req_body(
-        &mut self,
+        &self,
     ) -> Result<
         ([u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES], ohttp::ClientResponse),
         OhttpEncapsulationError,
@@ -422,12 +422,7 @@ impl Receiver<Initialized> {
             &self.session_context.directory,
             &self.session_context.proposal_mailbox_id(),
         );
-        ohttp_encapsulate(
-            &mut self.session_context.ohttp_keys,
-            "GET",
-            fallback_target.as_str(),
-            None,
-        )
+        ohttp_encapsulate(&self.session_context.ohttp_keys, "GET", fallback_target.as_str(), None)
     }
 
     fn extract_proposal_from_v1(self, response: &str) -> Result<OriginalPayload, ProtocolError> {
@@ -990,7 +985,7 @@ impl Receiver<PayjoinProposal> {
 
     /// Construct an OHTTP Encapsulated HTTP POST request for the Proposal PSBT
     pub fn create_post_request(
-        &mut self,
+        &self,
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, ohttp::ClientResponse), Error> {
         let target_resource: Url;
@@ -1014,7 +1009,7 @@ impl Receiver<PayjoinProposal> {
         }
         tracing::debug!("Payjoin PSBT target: {}", target_resource.as_str());
         let (body, ctx) = ohttp_encapsulate(
-            &mut self.session_context.ohttp_keys,
+            &self.session_context.ohttp_keys,
             method,
             target_resource.as_str(),
             Some(&body),

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -286,14 +286,14 @@ impl Sender<WithReplyKey> {
             self.psbt_ctx.min_fee_rate,
         )?;
         let base_url = self.pj_param.endpoint().clone();
-        let mut ohttp_keys = self.pj_param.ohttp_keys().clone();
+        let ohttp_keys = self.pj_param.ohttp_keys();
         let (request, ohttp_ctx) = extract_request(
             ohttp_relay,
             self.reply_key.clone(),
             body,
             base_url,
             self.pj_param.receiver_pubkey().clone(),
-            &mut ohttp_keys,
+            ohttp_keys,
         )?;
         Ok((
             request,
@@ -359,7 +359,7 @@ pub(crate) fn extract_request(
     body: Vec<u8>,
     url: Url,
     receiver_pubkey: HpkePublicKey,
-    ohttp_keys: &mut OhttpKeys,
+    ohttp_keys: &OhttpKeys,
 ) -> Result<(Request, ClientResponse), CreateRequestError> {
     let ohttp_relay = ohttp_relay.into_url()?;
     let body = encrypt_message_a(
@@ -442,10 +442,9 @@ impl Sender<PollingForProposal> {
             &self.pj_param.receiver_pubkey().clone(),
         )
         .map_err(InternalCreateRequestError::Hpke)?;
-        let mut ohttp_keys = self.pj_param.ohttp_keys().clone();
-        let (body, ohttp_ctx) =
-            ohttp_encapsulate(&mut ohttp_keys, "GET", url.as_str(), Some(&body))
-                .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
+        let ohttp_keys = self.pj_param.ohttp_keys().clone();
+        let (body, ohttp_ctx) = ohttp_encapsulate(&ohttp_keys, "GET", url.as_str(), Some(&body))
+            .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
 
         let url = ohttp_relay.into_url().map_err(InternalCreateRequestError::Url)?;
         Ok((Request::new_v2(&url, &body), ohttp_ctx))

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -237,7 +237,7 @@ mod integration {
                 let mock_address = Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")?
                     .assume_checked();
                 let noop_persister = NoopSessionPersister::default();
-                let mut bad_initializer = ReceiverBuilder::new(
+                let bad_initializer = ReceiverBuilder::new(
                     mock_address,
                     services.directory_url().as_str(),
                     bad_ohttp_keys,
@@ -280,7 +280,7 @@ mod integration {
                 // Inside the Receiver:
                 let address = receiver.new_address()?;
                 // test session with expiry in the past
-                let mut expired_receiver =
+                let expired_receiver =
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
                         .with_expiry(Duration::from_secs(0))
                         .build()
@@ -333,7 +333,7 @@ mod integration {
                 // Inside the Receiver:
                 let address = receiver.new_address()?;
 
-                let mut session =
+                let session =
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
                         .build()
                         .save(&persister)?;
@@ -352,7 +352,7 @@ mod integration {
                     .process_response(response.bytes().await?.to_vec().as_slice(), ctx)
                     .save(&persister)?;
                 // No proposal yet since sender has not responded
-                let mut session =
+                let session =
                     if let OptionalTransitionOutcome::Stasis(current_state) = response_body {
                         current_state
                     } else {
@@ -464,7 +464,7 @@ mod integration {
                 let address = receiver.new_address()?;
 
                 // test session with expiry in the future
-                let mut session =
+                let session =
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
                         .build()
                         .save(&recv_persister)?;
@@ -483,7 +483,7 @@ mod integration {
                     .process_response(response.bytes().await?.to_vec().as_slice(), ctx)
                     .save(&recv_persister)?;
                 // No proposal yet since sender has not responded
-                let mut session =
+                let session =
                     if let OptionalTransitionOutcome::Stasis(current_state) = response_body {
                         current_state
                     } else {
@@ -534,7 +534,7 @@ mod integration {
                 } else {
                     panic!("proposal should exist");
                 };
-                let mut payjoin_proposal = handle_directory_proposal(&receiver, proposal, None)?;
+                let payjoin_proposal = handle_directory_proposal(&receiver, proposal, None)?;
                 let (req, ctx) =
                     payjoin_proposal.create_post_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
@@ -675,7 +675,7 @@ mod integration {
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
                 let recv_persister = NoopSessionPersister::default();
                 let address = receiver.new_address()?;
-                let mut session = ReceiverBuilder::new(
+                let session = ReceiverBuilder::new(
                     address,
                     services.directory_url().as_str(),
                     ohttp_keys.clone(),
@@ -746,7 +746,7 @@ mod integration {
                             panic!("Unexpected response status: {}", response.status())
                         }
                     };
-                    let mut payjoin_proposal =
+                    let payjoin_proposal =
                         handle_directory_proposal(&receiver_clone, proposal, None)
                             .map_err(|e| e.to_string())?;
                     // Respond with payjoin psbt within the time window the sender is willing to wait


### PR DESCRIPTION
It was originally thought that the ohttp keys context included the counter required for AEAD (polychacha) and by providing a mut reference we would be incrementing the counter. However, that does not seem to be the case. Creating a new HPKE sender context using the [same key config yields different results](https://github.com/arminsabouri/ohttp/commit/3ba40b39f738425bd988a27db1a8f3a77fc2129a). Additionally, the recepient ohttp keys context being mut seems to have been a poor design choice upstream. [Removing mut](https://github.com/arminsabouri/ohttp/commit/d4599d6c183aa3de43ed68c39a793c92de529e7c) seems to have no impact by virtue of the tests passing. 

Removing this &mut simplifies our public interface.   

Related ticket: #1084 
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
