### PR TITLE
Use "expiration" instead of "expiry"

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -266,8 +266,8 @@ impl ReceiverBuilder {
         Self(self.0.clone().with_amount(Amount::from_sat(amount_sats)))
     }
 
-    pub fn with_expiry(&self, expiry: u64) -> Self {
-        Self(self.0.clone().with_expiry(Duration::from_secs(expiry)))
+    pub fn with_expiration(&self, expiration: u64) -> Self {
+        Self(self.0.clone().with_expiration(Duration::from_secs(expiration)))
     }
 
     /// Set the maximum effective fee rate the receiver is willing to pay for their own input/output contributions

--- a/payjoin/src/core/receive/v2/error.rs
+++ b/payjoin/src/core/receive/v2/error.rs
@@ -51,7 +51,7 @@ impl fmt::Display for SessionError {
 
         match &self.0 {
             ParseUrl(e) => write!(f, "URL parsing failed: {e}"),
-            Expired(expiry) => write!(f, "Session expired at {expiry:?}"),
+            Expired(expiration) => write!(f, "Session expired at {expiration:?}"),
             OhttpEncapsulation(e) => write!(f, "OHTTP Encapsulation Error: {e}"),
             Hpke(e) => write!(f, "Hpke decryption failed: {e}"),
             DirectoryResponse(e) => write!(f, "Directory response error: {e}"),

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -45,9 +45,9 @@ where
 
     let history = SessionHistory::new(session_events.clone());
     let ctx = history.session_context();
-    if SystemTime::now() > ctx.expiry {
+    if SystemTime::now() > ctx.expiration {
         // Session has expired: close the session and persist a fatal error
-        let err = SessionError(InternalSessionError::Expired(ctx.expiry));
+        let err = SessionError(InternalSessionError::Expired(ctx.expiration));
         persister
             .save_event(SessionEvent::SessionInvalid(err.to_string(), None).into())
             .map_err(|e| InternalReplayError::PersistenceFailure(ImplementationError::new(e)))?;
@@ -334,7 +334,7 @@ mod tests {
     #[test]
     fn test_replaying_session_creation_with_expired_session() -> Result<(), BoxError> {
         let session_context = SessionContext {
-            expiry: SystemTime::now() - Duration::from_secs(1),
+            expiration: SystemTime::now() - Duration::from_secs(1),
             ..SHARED_CONTEXT.clone()
         };
         let test = SessionHistoryTest {

--- a/payjoin/src/core/send/v2/error.rs
+++ b/payjoin/src/core/send/v2/error.rs
@@ -15,7 +15,7 @@ pub(crate) enum InternalCreateRequestError {
     Url(crate::into_url::Error),
     Hpke(crate::hpke::HpkeError),
     OhttpEncapsulation(crate::ohttp::OhttpEncapsulationError),
-    Expired(std::time::SystemTime),
+    Expiration(std::time::SystemTime),
 }
 
 impl fmt::Display for CreateRequestError {
@@ -26,7 +26,7 @@ impl fmt::Display for CreateRequestError {
             Url(e) => write!(f, "cannot parse url: {e:#?}"),
             Hpke(e) => write!(f, "v2 error: {e}"),
             OhttpEncapsulation(e) => write!(f, "v2 error: {e}"),
-            Expired(expiry) => write!(f, "session expired at {expiry:?}"),
+            Expiration(expiration) => write!(f, "session expired at {expiration:?}"),
         }
     }
 }
@@ -39,7 +39,7 @@ impl std::error::Error for CreateRequestError {
             Url(error) => Some(error),
             Hpke(error) => Some(error),
             OhttpEncapsulation(error) => Some(error),
-            Expired(_) => None,
+            Expiration(_) => None,
         }
     }
 }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -274,7 +274,7 @@ impl Sender<WithReplyKey> {
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, V2PostContext), CreateRequestError> {
         if std::time::SystemTime::now() > self.pj_param.expiration() {
-            return Err(InternalCreateRequestError::Expired(self.pj_param.expiration()).into());
+            return Err(InternalCreateRequestError::Expiration(self.pj_param.expiration()).into());
         }
 
         let mut sanitized_psbt = self.psbt_ctx.original_psbt.clone();
@@ -596,7 +596,7 @@ mod test {
         let sender = create_sender_context(SystemTime::now() - Duration::from_secs(60))?;
         let ohttp_relay = EXAMPLE_URL.as_str();
         let result = sender.create_v2_post_request(ohttp_relay);
-        assert!(result.is_err(), "Extract v2 expected expiry error, but it succeeded");
+        assert!(result.is_err(), "Extract v2 expected expiration error, but it succeeded");
 
         match result {
             Ok(_) => panic!("Expected error, got success"),

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -468,7 +468,7 @@ mod tests {
         set_exp(&mut url, &exp_time);
         assert_eq!(url.fragment(), Some("EX1C4UC6ES"));
 
-        assert_eq!(exp(&url).expect("Expiry has been set but is missing on get"), exp_time);
+        assert_eq!(exp(&url).expect("Expiration has been set but is missing on get"), exp_time);
     }
 
     #[test]

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -282,7 +282,7 @@ mod integration {
                 // test session with expiry in the past
                 let mut expired_receiver =
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
-                        .with_expiry(Duration::from_secs(0))
+                        .with_expiration(Duration::from_secs(0))
                         .build()
                         .save(&recv_noop_persister)?;
                 match expired_receiver.create_poll_request(services.ohttp_relay_url().as_str()) {


### PR DESCRIPTION
Our codebase goes back and forth between "expiry" and "expiration". Expiry is prefered as its used in BIP-77.

Closes: #1065 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
