### PR TITLE
Remove redundant fields from `WantsFeeRange` event

### DIFF
--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -188,11 +188,11 @@ fn interleave_shuffle<T: Clone, R: rand::Rng>(original: &mut Vec<T>, new: &mut [
 /// Call [`Self::commit_inputs`] to proceed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WantsInputs {
-    original_psbt: Psbt,
-    payjoin_psbt: Psbt,
-    params: Params,
-    change_vout: usize,
-    receiver_inputs: Vec<InputPair>,
+    pub(crate) original_psbt: Psbt,
+    pub(crate) payjoin_psbt: Psbt,
+    pub(crate) params: Params,
+    pub(crate) change_vout: usize,
+    pub(crate) receiver_inputs: Vec<InputPair>,
 }
 
 impl WantsInputs {
@@ -359,11 +359,11 @@ impl WantsInputs {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WantsFeeRange {
-    original_psbt: Psbt,
-    payjoin_psbt: Psbt,
-    params: Params,
-    change_vout: usize,
-    receiver_inputs: Vec<InputPair>,
+    pub(crate) original_psbt: Psbt,
+    pub(crate) payjoin_psbt: Psbt,
+    pub(crate) params: Params,
+    pub(crate) change_vout: usize,
+    pub(crate) receiver_inputs: Vec<InputPair>,
 }
 
 impl WantsFeeRange {

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -848,12 +848,22 @@ impl Receiver<WantsInputs> {
     pub fn commit_inputs(self) -> NextStateTransition<SessionEvent, Receiver<WantsFeeRange>> {
         let inner = self.state.inner.clone().commit_inputs();
         NextStateTransition::success(
-            SessionEvent::WantsFeeRange(inner.clone()),
+            SessionEvent::WantsFeeRange(inner.receiver_inputs.clone()),
             Receiver { state: WantsFeeRange { inner }, session_context: self.session_context },
         )
     }
 
-    pub(crate) fn apply_wants_fee_range(self, inner: common::WantsFeeRange) -> ReceiveSession {
+    pub(crate) fn apply_wants_fee_range(
+        self,
+        contributed_inputs: Vec<InputPair>,
+    ) -> ReceiveSession {
+        let inner = common::WantsFeeRange {
+            original_psbt: self.state.inner.original_psbt.clone(),
+            payjoin_psbt: self.state.inner.payjoin_psbt.clone(),
+            params: self.state.inner.params.clone(),
+            change_vout: self.state.inner.change_vout,
+            receiver_inputs: contributed_inputs,
+        };
         let new_state =
             Receiver { state: WantsFeeRange { inner }, session_context: self.session_context };
         ReceiveSession::WantsFeeRange(new_state)

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -5,7 +5,7 @@ use crate::error::{InternalReplayError, ReplayError};
 use crate::output_substitution::OutputSubstitution;
 use crate::persist::SessionPersister;
 use crate::receive::v2::{extract_err_req, InternalSessionError, SessionError};
-use crate::receive::{common, JsonReply, OriginalPayload, PsbtContext};
+use crate::receive::{common, InputPair, JsonReply, OriginalPayload, PsbtContext};
 use crate::{ImplementationError, IntoUrl, PjUri, Request};
 
 /// Replay a receiver event log to get the receiver in its current state [ReceiveSession]
@@ -186,7 +186,7 @@ pub enum SessionEvent {
     OutputsUnknown(),
     WantsOutputs(common::WantsOutputs),
     WantsInputs(common::WantsInputs),
-    WantsFeeRange(common::WantsFeeRange),
+    WantsFeeRange(Vec<InputPair>),
     ProvisionalProposal(PsbtContext),
     PayjoinProposal(bitcoin::Psbt),
     /// Session is invalid. This is a irrecoverable error. Fallback tx should be broadcasted.
@@ -272,7 +272,7 @@ mod tests {
             SessionEvent::OutputsUnknown(),
             SessionEvent::WantsOutputs(wants_outputs.state.inner.clone()),
             SessionEvent::WantsInputs(wants_inputs.state.inner.clone()),
-            SessionEvent::WantsFeeRange(wants_fee_range.state.inner.clone()),
+            SessionEvent::WantsFeeRange(wants_fee_range.state.inner.receiver_inputs.clone()),
             SessionEvent::ProvisionalProposal(provisional_proposal.state.psbt_context.clone()),
             SessionEvent::PayjoinProposal(payjoin_proposal.psbt().clone()),
         ];
@@ -481,7 +481,8 @@ mod tests {
         events.push(SessionEvent::OutputsUnknown());
         events.push(SessionEvent::WantsOutputs(wants_outputs.state.inner.clone()));
         events.push(SessionEvent::WantsInputs(wants_inputs.state.inner.clone()));
-        events.push(SessionEvent::WantsFeeRange(wants_fee_range.state.inner.clone()));
+        events
+            .push(SessionEvent::WantsFeeRange(wants_fee_range.state.inner.receiver_inputs.clone()));
         events.push(SessionEvent::ProvisionalProposal(
             provisional_proposal.state.psbt_context.clone(),
         ));
@@ -557,7 +558,8 @@ mod tests {
         events.push(SessionEvent::OutputsUnknown());
         events.push(SessionEvent::WantsOutputs(wants_outputs.state.inner.clone()));
         events.push(SessionEvent::WantsInputs(wants_inputs.state.inner.clone()));
-        events.push(SessionEvent::WantsFeeRange(wants_fee_range.state.inner.clone()));
+        events
+            .push(SessionEvent::WantsFeeRange(wants_fee_range.state.inner.receiver_inputs.clone()));
         events.push(SessionEvent::ProvisionalProposal(
             provisional_proposal.state.psbt_context.clone(),
         ));


### PR DESCRIPTION
The primary information obtained from `WantsInputs` to `WantsFeeRange` is receiver contributed inputs. The rest of the information can be obtained from the previous state(s).

--
The same transformation can be made on `WantsInputs` and `WantsOutputs`. Looking for a concept ACk/Nack.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
