### PR TITLE
Run all tests in macOS CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,11 +39,5 @@ jobs:
         run: bash ./scripts/generate_bindings.sh
 
       - name: Run tests
-        # Skip integration test on macOS due to Docker issues
-        run: |
-          if [[ "${{ matrix.os }}" = "macos-latest" ]]; then
-            dart test "test/test_payjoin_unit_test.dart"
-          else
-            dart test
-          fi
+        run: dart test
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,10 +45,4 @@ jobs:
         run: pip install ./dist/*.whl
 
       - name: "Run tests"
-        # Skip integration test on macOS due to Docker issues
-        run: |
-          if [[ "${{ matrix.os }}" = "macos-latest" ]]; then
-            python -m unittest test/test_payjoin_unit_test.py -v
-          else
-            python -m unittest -v
-          fi
+        run: python -m unittest -v

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -46,7 +46,6 @@ pub fn init_tracing() {
 
 pub struct TestServices {
     cert: Certificate,
-    /// redis is an implicit dependency of the directory service
     directory: (u16, Option<JoinHandle<Result<(), BoxSendSyncError>>>),
     ohttp_relay: (u16, Option<JoinHandle<Result<(), BoxSendSyncError>>>),
     http_agent: Arc<Client>,


### PR DESCRIPTION
Previously integration tests failed to run in CI due to Docker issues, but now Docker is no longer needed since the redis dependency has been removed.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
