### PR TITLE
Remove redis from directory docker-compose

### DIFF
--- a/payjoin-directory/docker-compose.yml
+++ b/payjoin-directory/docker-compose.yml
@@ -27,22 +27,9 @@ services:
     image: dangould/payjoin-directory:0.0.1
     environment:
       RUST_LOG: "trace"
-      PJ_DB_HOST: "redis:6379"
       PJ_DIR_PORT: "8080"
-    depends_on:
-      - redis
-    networks:
-      - payjoin-network
-
-  redis:
-    image: redis:latest
-    volumes:
-      - redis-data:/data
     networks:
       - payjoin-network
 
 networks:
   payjoin-network:
-
-volumes:
-  redis-data:


### PR DESCRIPTION
Redis is no longer needed to run the directory service.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
