### PR TITLE
Assert uppercase in Bech32 test

### DIFF
--- a/payjoin/src/bech32.rs
+++ b/payjoin/src/bech32.rs
@@ -41,7 +41,8 @@ mod test {
             (hrp.as_str().len() + 1) as f32 + (bytes.len() as f32 * 8.0 / 5.0).ceil()
         );
 
-        // TODO assert uppercase
+        // uppercase ideal for QR code compression
+        assert!(encoded.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()));
 
         // should not error
         let corrupted = encoded + "QQPP";


### PR DESCRIPTION
### Summary
This PR adds an assertion to the Bech32 test to verify that the
encoded string is uppercase, including only ASCII uppercase letters
or the separator '1'.

### What & Why
Previously, the test had a TODO for asserting uppercase. Adding this
assertion ensures the nochecksum module encodes Bech32 strings in
uppercase, improving correctness and consistency.

### AI Assistance Disclosure
I consulted ChatGPT to understand how to write the uppercase
assertion, but the solution and code were authored manually.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/.github/CONTRIBUTING.md#committing-patches)**.
</details>
