### PR TITLE
Remove redundant fields from `WantsOutputs` event

### DIFF
--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -34,7 +34,7 @@ pub struct WantsOutputs {
     payjoin_psbt: Psbt,
     params: Params,
     change_vout: usize,
-    owned_vouts: Vec<usize>,
+    pub(crate) owned_vouts: Vec<usize>,
 }
 
 impl WantsOutputs {

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -728,14 +728,15 @@ impl Receiver<OutputsUnknown> {
                 }
             },
         };
-        let inner = common::WantsOutputs::new(self.state.original, owned_vouts);
+        let inner = common::WantsOutputs::new(self.state.original, owned_vouts.clone());
         MaybeFatalTransition::success(
-            SessionEvent::WantsOutputs(inner.clone()),
+            SessionEvent::WantsOutputs(owned_vouts),
             Receiver { state: WantsOutputs { inner }, session_context: self.session_context },
         )
     }
 
-    pub(crate) fn apply_wants_outputs(self, inner: common::WantsOutputs) -> ReceiveSession {
+    pub(crate) fn apply_wants_outputs(self, owned_vouts: Vec<usize>) -> ReceiveSession {
+        let inner = common::WantsOutputs::new(self.state.original, owned_vouts);
         let new_state =
             Receiver { state: WantsOutputs { inner }, session_context: self.session_context };
         ReceiveSession::WantsOutputs(new_state)

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -184,7 +184,7 @@ pub enum SessionEvent {
     MaybeInputsOwned(),
     MaybeInputsSeen(),
     OutputsUnknown(),
-    WantsOutputs(common::WantsOutputs),
+    WantsOutputs(Vec<usize>),
     WantsInputs(common::WantsInputs),
     WantsFeeRange(Vec<InputPair>),
     ProvisionalProposal(PsbtContext),
@@ -270,7 +270,7 @@ mod tests {
             SessionEvent::MaybeInputsOwned(),
             SessionEvent::MaybeInputsSeen(),
             SessionEvent::OutputsUnknown(),
-            SessionEvent::WantsOutputs(wants_outputs.state.inner.clone()),
+            SessionEvent::WantsOutputs(wants_outputs.state.inner.owned_vouts.clone()),
             SessionEvent::WantsInputs(wants_inputs.state.inner.clone()),
             SessionEvent::WantsFeeRange(wants_fee_range.state.inner.receiver_inputs.clone()),
             SessionEvent::ProvisionalProposal(provisional_proposal.state.psbt_context.clone()),
@@ -479,7 +479,7 @@ mod tests {
         events.push(SessionEvent::MaybeInputsOwned());
         events.push(SessionEvent::MaybeInputsSeen());
         events.push(SessionEvent::OutputsUnknown());
-        events.push(SessionEvent::WantsOutputs(wants_outputs.state.inner.clone()));
+        events.push(SessionEvent::WantsOutputs(wants_outputs.state.inner.owned_vouts.clone()));
         events.push(SessionEvent::WantsInputs(wants_inputs.state.inner.clone()));
         events
             .push(SessionEvent::WantsFeeRange(wants_fee_range.state.inner.receiver_inputs.clone()));
@@ -556,7 +556,7 @@ mod tests {
         events.push(SessionEvent::MaybeInputsOwned());
         events.push(SessionEvent::MaybeInputsSeen());
         events.push(SessionEvent::OutputsUnknown());
-        events.push(SessionEvent::WantsOutputs(wants_outputs.state.inner.clone()));
+        events.push(SessionEvent::WantsOutputs(wants_outputs.state.inner.owned_vouts.clone()));
         events.push(SessionEvent::WantsInputs(wants_inputs.state.inner.clone()));
         events
             .push(SessionEvent::WantsFeeRange(wants_fee_range.state.inner.receiver_inputs.clone()));


### PR DESCRIPTION
The primary information obtained from `OutputsUnknown` to `WantsOutputs` is the index of the receiver outputs. The rest of the information can be obtained from the previous state(s).

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
