### PR TITLE
Simply return replay error on expiration

### DIFF
--- a/payjoin/src/core/error.rs
+++ b/payjoin/src/core/error.rs
@@ -51,6 +51,7 @@ impl<SessionState: Debug, SessionEvent: Debug> std::fmt::Display
                 Some(session) => write!(f, "Invalid event ({event:?}) for session ({session:?})",),
                 None => write!(f, "Invalid first event ({event:?}) for session",),
             },
+            Expired(time) => write!(f, "Session expired at {time:?}"),
             PersistenceFailure(e) => write!(f, "Persistence failure: {e}"),
         }
     }
@@ -75,6 +76,8 @@ pub(crate) enum InternalReplayError<SessionState, SessionEvent> {
     NoEvents,
     /// Invalid initial event
     InvalidEvent(Box<SessionEvent>, Option<Box<SessionState>>),
+    /// Session is expired
+    Expired(crate::time::Time),
     /// Application storage error
     PersistenceFailure(ImplementationError),
 }


### PR DESCRIPTION
Closes #1049 (by doing the opposite of what the issue title says, see below)

Adhering to the principle that only primary information becomes an event, knowing the session's expiration (in SessionContext) is sufficient and no new information implies no outcome event.

The state machines already adhere by this and only returns an error without resulting in a state transition. This commit applies the same logic to `replay_event_log` for sender and receiver.

Even assuming a non-monotonic system clock, the implication of this change is that a session that was previously considered expired may turn out to not actually be expired, and is allowed to resume.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
