### PR TITLE
Fix apply_fee_range error handling

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -935,15 +935,7 @@ impl Receiver<WantsFeeRange> {
         {
             Ok(inner) => inner,
             Err(e) => {
-                // FIXME: follow up by returning a terminal error rather than replyable error
-                let payload_error = super::PayloadError::from(e);
-                return MaybeFatalTransition::fatal(
-                    SessionEvent::SessionInvalid(
-                        payload_error.to_string(),
-                        Some(JsonReply::from(&payload_error)),
-                    ),
-                    ProtocolError::OriginalPayload(payload_error),
-                );
+                return MaybeFatalTransition::transient(ProtocolError::OriginalPayload(e.into()));
             }
         };
         MaybeFatalTransition::success(


### PR DESCRIPTION
The FIXME comment says this should return a terminal error, but as far as I can tell the only way that method fails is if the receiver's fee contributions would exceed their specified `max_effective_fee`. By making this a transient error we allow a receiver to try applying fee contributions again with a different feerate.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
