### PR TITLE
Remove the url crate dep from payjoin-test-utils

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2363,7 +2363,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2363,7 +2363,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -234,8 +234,8 @@ mod e2e {
 
             let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
 
-            let directory = &services.directory_url().to_string();
-            let ohttp_relay = &services.ohttp_relay_url().to_string();
+            let directory = &services.directory_url();
+            let ohttp_relay = &services.ohttp_relay_url();
 
             let cli_receive_initiator = Command::new(payjoin_cli)
                 .arg("--root-certificate")
@@ -527,7 +527,7 @@ mod e2e {
                 .arg("--db-path")
                 .arg(&sender_db_path)
                 .arg("--ohttp-relays")
-                .arg(services.ohttp_relay_url().to_string())
+                .arg(services.ohttp_relay_url())
                 .arg("send")
                 .arg(&bip21)
                 .arg("--fee-rate")

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -244,9 +244,9 @@ Future<payjoin.PayjoinProposalReceiveSession> process_unchecked_proposal(
 Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
     payjoin.Initialized receiver,
     InMemoryReceiverPersister recv_persister,
-    payjoin.Url ohttp_relay) async {
+    String ohttp_relay) async {
   var agent = http.Client();
-  var request = receiver.createPollRequest(ohttp_relay.asString());
+  var request = receiver.createPollRequest(ohttp_relay);
   var response = await agent.post(Uri.parse(request.request.url.asString()),
       headers: {"Content-Type": request.request.contentType},
       body: request.request.body);
@@ -268,7 +268,7 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
 Future<payjoin.ReceiveSession?> process_receiver_proposal(
     payjoin.ReceiveSession receiver,
     InMemoryReceiverPersister recv_persister,
-    payjoin.Url ohttp_relay) async {
+    String ohttp_relay) async {
   if (receiver is payjoin.InitializedReceiveSession) {
     var res = await retrieve_receiver_proposal(
         receiver.inner, recv_persister, ohttp_relay);
@@ -319,7 +319,7 @@ void main() {
       var services = payjoin.TestServices.initialize();
 
       services.waitForServicesReady();
-      var directory = services.directoryUrl().asString();
+      var directory = services.directoryUrl();
       var ohttp_keys = services.fetchOhttpKeys();
       var ohttp_relay = services.ohttpRelayUrl();
       var agent = http.Client();
@@ -345,7 +345,7 @@ void main() {
           .buildRecommended(1000)
           .save(sender_persister);
       payjoin.RequestV2PostContext request =
-          req_ctx.createV2PostRequest(ohttp_relay.asString());
+          req_ctx.createV2PostRequest(ohttp_relay);
       var response = await agent.post(Uri.parse(request.request.url.asString()),
           headers: {"Content-Type": request.request.contentType},
           body: request.request.body);
@@ -369,7 +369,7 @@ void main() {
       payjoin.PayjoinProposal proposal =
           (payjoin_proposal as payjoin.PayjoinProposalReceiveSession).inner;
       payjoin.RequestResponse request_response =
-          proposal.createPostRequest(ohttp_relay.asString());
+          proposal.createPostRequest(ohttp_relay);
       var fallback_response = await agent.post(
           Uri.parse(request_response.request.url.asString()),
           headers: {"Content-Type": request_response.request.contentType},
@@ -382,7 +382,7 @@ void main() {
       // Sender checks, isngs, finalizes, extracts, and broadcasts
       // Replay post fallback to get the response
       payjoin.RequestOhttpContext ohttp_context_request =
-          send_ctx.createPollRequest(ohttp_relay.asString());
+          send_ctx.createPollRequest(ohttp_relay);
       var final_response = await agent.post(
           Uri.parse(ohttp_context_request.request.url.asString()),
           headers: {"Content-Type": ohttp_context_request.request.contentType},

--- a/payjoin-ffi/src/test_utils.rs
+++ b/payjoin-ffi/src/test_utils.rs
@@ -13,8 +13,6 @@ use serde_json::Value;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
-use crate::Url;
-
 lazy_static! {
     static ref RUNTIME: Arc<std::sync::Mutex<Runtime>> =
         Arc::new(std::sync::Mutex::new(Runtime::new().expect("Failed to create Tokio runtime")));
@@ -128,9 +126,9 @@ impl TestServices {
         runtime.block_on(async { self.0.lock().await.cert() })
     }
 
-    pub fn directory_url(&self) -> Url {
+    pub fn directory_url(&self) -> String {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.directory_url().into() })
+        runtime.block_on(async { self.0.lock().await.directory_url() })
     }
 
     pub fn take_directory_handle(&self) -> JoinHandle {
@@ -139,14 +137,14 @@ impl TestServices {
             .block_on(async { JoinHandle(Arc::new(self.0.lock().await.take_directory_handle())) })
     }
 
-    pub fn ohttp_relay_url(&self) -> Url {
+    pub fn ohttp_relay_url(&self) -> String {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.ohttp_relay_url().into() })
+        runtime.block_on(async { self.0.lock().await.ohttp_relay_url() })
     }
 
-    pub fn ohttp_gateway_url(&self) -> Url {
+    pub fn ohttp_gateway_url(&self) -> String {
         let runtime = RUNTIME.lock().expect("Lock should not be poisoned");
-        runtime.block_on(async { self.0.lock().await.ohttp_gateway_url().into() })
+        runtime.block_on(async { self.0.lock().await.ohttp_gateway_url() })
     }
 
     pub fn take_ohttp_relay_handle(&self) -> JoinHandle {
@@ -191,7 +189,7 @@ pub fn init_bitcoind_sender_receiver() -> Result<Arc<BitcoindEnv>, FfiError> {
 }
 
 #[uniffi::export]
-pub fn example_url() -> Url { EXAMPLE_URL.clone().into() }
+pub fn example_url() -> String { EXAMPLE_URL.to_string() }
 
 #[uniffi::export]
 pub fn query_params() -> String { QUERY_PARAMS.to_string() }

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -24,5 +24,4 @@ reqwest = { version = "0.12.23", default-features = false, features = ["rustls-t
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-url = "2.5.4"
 tempfile = "3.20.0"

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1138,7 +1138,7 @@ pub mod test {
         address: Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")
             .expect("valid address")
             .assume_checked(),
-        directory: EXAMPLE_URL.clone(),
+        directory: Url::from_str(EXAMPLE_URL).expect("Could not parse Url"),
         ohttp_keys: OhttpKeys(
             ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
         ),
@@ -1349,15 +1349,11 @@ pub mod test {
 
         assert_eq!(mock_err.1.to_json(), expected_json);
 
-        let (_req, _ctx) =
-            extract_err_req(&mock_err.1, EXAMPLE_URL.as_str(), &receiver.session_context)?;
+        let (_req, _ctx) = extract_err_req(&mock_err.1, EXAMPLE_URL, &receiver.session_context)?;
 
         let internal_error: Error = InternalPayloadError::MissingPayment.into();
-        let (_req, _ctx) = extract_err_req(
-            &(&internal_error).into(),
-            EXAMPLE_URL.as_str(),
-            &receiver.session_context,
-        )?;
+        let (_req, _ctx) =
+            extract_err_req(&(&internal_error).into(), EXAMPLE_URL, &receiver.session_context)?;
         Ok(())
     }
 
@@ -1384,7 +1380,7 @@ pub mod test {
         let res = error.api_error().expect("check_broadcast error should propagate to api error");
         let actual_json = JsonReply::from(&res);
 
-        let expiration = extract_err_req(&actual_json, EXAMPLE_URL.as_str(), &context);
+        let expiration = extract_err_req(&actual_json, EXAMPLE_URL, &context);
 
         match expiration {
             Err(error) => assert_eq!(
@@ -1466,7 +1462,7 @@ pub mod test {
     fn test_v2_pj_uri() {
         let uri =
             Receiver { state: Initialized {}, session_context: SHARED_CONTEXT.clone() }.pj_uri();
-        assert_ne!(uri.extras.pj_param.endpoint(), EXAMPLE_URL.clone());
+        assert_ne!(uri.extras.pj_param.endpoint().as_str(), EXAMPLE_URL);
         assert_eq!(uri.extras.output_substitution, OutputSubstitution::Disabled);
     }
 

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -619,7 +619,7 @@ mod tests {
 
         let uri = SessionHistory { events }.pj_uri();
 
-        assert_ne!(uri.extras.pj_param.endpoint(), EXAMPLE_URL.clone());
+        assert_ne!(uri.extras.pj_param.endpoint().as_str(), EXAMPLE_URL);
         assert_eq!(uri.extras.output_substitution, OutputSubstitution::Disabled);
 
         Ok(())
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_skipped_session_extract_err_request() -> Result<(), BoxError> {
-        let ohttp_relay = EXAMPLE_URL.as_str();
+        let ohttp_relay = EXAMPLE_URL;
         let mock_err = mock_err();
 
         let session_history = SessionHistory { events: vec![SessionEvent::MaybeInputsOwned()] };
@@ -660,7 +660,7 @@ mod tests {
     #[test]
     fn test_session_extract_err_req_reply_key() -> Result<(), BoxError> {
         let proposal = original_from_test_vector();
-        let ohttp_relay = EXAMPLE_URL.as_str();
+        let ohttp_relay = EXAMPLE_URL;
         let mock_err = mock_err();
 
         let session_history_one = SessionHistory {

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -350,7 +350,7 @@ mod test {
         map.insert(unknown_key, value);
         psbt_ctx.original_psbt.unknown = map;
 
-        let sender = Sender { endpoint: EXAMPLE_URL.clone(), psbt_ctx };
+        let sender = Sender { endpoint: Url::from_str(EXAMPLE_URL)?, psbt_ctx };
 
         let body = sender.create_v1_post_request().0.body;
         let res_str = std::str::from_utf8(&body)?;

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -592,13 +592,13 @@ mod test {
         let expiration =
             Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
         let sender = create_sender_context(expiration)?;
-        let ohttp_relay = EXAMPLE_URL.as_str();
+        let ohttp_relay = EXAMPLE_URL;
         let result = sender.create_v2_post_request(ohttp_relay);
         let (request, context) = result.expect("Result should be ok");
         assert!(!request.body.is_empty(), "Request body should not be empty");
         assert_eq!(
             request.url.to_string(),
-            format!("{}{}", EXAMPLE_URL.clone(), sender.pj_param.endpoint().join("/")?)
+            format!("{}/{}", EXAMPLE_URL, sender.pj_param.endpoint().join("/")?)
         );
         assert_eq!(context.psbt_ctx.original_psbt, sender.psbt_ctx.original_psbt);
         Ok(())
@@ -611,7 +611,7 @@ mod test {
             .expect("time in the past should be representable");
 
         let sender = create_sender_context(expiration)?;
-        let ohttp_relay = EXAMPLE_URL.as_str();
+        let ohttp_relay = EXAMPLE_URL;
         let result = sender.create_v2_post_request(ohttp_relay);
         assert!(result.is_err(), "Extract v2 expected expiration error, but it succeeded");
 
@@ -627,7 +627,7 @@ mod test {
         let address = Address::from_str("2N47mmrWXsNBvQR6k78hWJoTji57zXwNcU7")
             .expect("valid address")
             .assume_checked();
-        let directory = EXAMPLE_URL.as_str();
+        let directory = EXAMPLE_URL;
         let ohttp_keys = OhttpKeys(
             ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
         );

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn test_ohttp_get_set() {
-        let mut url = EXAMPLE_URL.clone();
+        let mut url = Url::from_str(EXAMPLE_URL).expect("Could not parse Url");
 
         let serialized = "OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
         let ohttp_keys = OhttpKeys::from_str(serialized).unwrap();
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_errors_when_parsing_ohttp() {
-        let missing_ohttp_url = EXAMPLE_URL.clone();
+        let missing_ohttp_url = Url::from_str(EXAMPLE_URL).expect("Could not parse Url");
         assert!(matches!(
             ohttp(&missing_ohttp_url),
             Err(ParseOhttpKeysParamError::MissingOhttpKeys)
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_exp_get_set() {
-        let mut url = EXAMPLE_URL.clone();
+        let mut url = Url::parse(EXAMPLE_URL).expect("Could not parse Url");
 
         let exp_time = Time::try_from(
             std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1720547781),
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_errors_when_parsing_exp() {
-        let missing_exp_url = EXAMPLE_URL.clone();
+        let missing_exp_url = Url::from_str(EXAMPLE_URL).expect("Could not parse Url");
         assert!(matches!(expiration(&missing_exp_url), Err(ParseExpParamError::MissingExp)));
 
         let invalid_fragment_exp_url =
@@ -503,7 +503,7 @@ mod tests {
 
     #[test]
     fn test_errors_when_parsing_receiver_pubkey() {
-        let missing_receiver_pubkey_url = EXAMPLE_URL.clone();
+        let missing_receiver_pubkey_url = Url::from_str(EXAMPLE_URL).expect("Could not parse Url");
         assert!(matches!(
             receiver_pubkey(&missing_receiver_pubkey_url),
             Err(ParseReceiverPubkeyParamError::MissingPubkey)


### PR DESCRIPTION
This removes the url crate completely and replaces it with Strings where appropriate. Notably we still use `rewqest::Url` in the `wait_for_services_ready` function.

In the payjoin crate we have not yet removed the Url so we need to parse the EXAMPLE_URL in some tests.

checks some boxes in #513 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
