### PR TITLE
Remove mailbox from receiver session context

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -69,7 +69,6 @@ pub struct SessionContext {
     #[serde(deserialize_with = "deserialize_address_assume_checked")]
     address: Address,
     directory: url::Url,
-    mailbox: Option<url::Url>,
     ohttp_keys: OhttpKeys,
     expiration: Time,
     amount: Option<Amount>,
@@ -307,7 +306,6 @@ impl ReceiverBuilder {
             expiration: Time::from_now(TWENTY_FOUR_HOURS_DEFAULT_EXPIRATION)
                 .expect("Default expiration time should be representable as u32 unix time"),
             amount: None,
-            mailbox: None,
             reply_key: None,
             max_fee_rate: FeeRate::BROADCAST_MIN,
         };
@@ -324,10 +322,6 @@ impl ReceiverBuilder {
 
     pub fn with_amount(self, amount: Amount) -> Self {
         Self(SessionContext { amount: Some(amount), ..self.0 })
-    }
-
-    pub fn with_mailbox(self, mailbox: impl IntoUrl) -> Result<Self, IntoUrlError> {
-        Ok(Self(SessionContext { mailbox: Some(mailbox.into_url()?), ..self.0 }))
     }
 
     /// Set the maximum effective fee rate the receiver is willing to pay for their own input/output contributions
@@ -1145,7 +1139,6 @@ pub mod test {
             .expect("valid address")
             .assume_checked(),
         directory: EXAMPLE_URL.clone(),
-        mailbox: None,
         ohttp_keys: OhttpKeys(
             ohttp::KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).expect("valid key config"),
         ),


### PR DESCRIPTION
Mailbox is always unused regardless if its set to `Some(...)`.

Closes: https://github.com/payjoin/rust-payjoin/issues/1104

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
