### PR TITLE
Remove request pub fields

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -69,11 +69,11 @@ impl AppTrait for App {
             .with_context(|| "Failed to build payjoin request")?
             .create_v1_post_request();
         let http = http_agent(&self.config)?;
-        let body = String::from_utf8(req.body.clone()).unwrap();
-        println!("Sending fallback request to {}", &req.url);
+        let body = String::from_utf8(req.body().to_vec()).unwrap();
+        println!("Sending fallback request to {}", &req.url());
         let response = http
-            .post(req.url)
-            .header("Content-Type", req.content_type)
+            .post(req.url())
+            .header("Content-Type", req.content_type())
             .body(body.clone())
             .send()
             .await

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -165,11 +165,11 @@ impl AppTrait for App {
                 .with_context(|| "Failed to build payjoin request")?
                 .create_v1_post_request();
                 let http = http_agent(&self.config)?;
-                let body = String::from_utf8(req.body.clone()).unwrap();
-                println!("Sending fallback request to {}", &req.url);
+                let body = String::from_utf8(req.body().to_vec()).unwrap();
+                println!("Sending fallback request to {}", &req.url());
                 let response = http
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
                     .body(body.clone())
                     .send()
                     .await
@@ -734,9 +734,9 @@ impl App {
 
     async fn post_request(&self, req: payjoin::Request) -> Result<reqwest::Response> {
         let http = http_agent(&self.config)?;
-        http.post(req.url)
-            .header("Content-Type", req.content_type)
-            .body(req.body)
+        http.post(req.url())
+            .header("Content-Type", req.content_type())
+            .body(req.body().to_vec())
             .send()
             .await
             .map_err(map_reqwest_err)

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -247,9 +247,9 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
     String ohttp_relay) async {
   var agent = http.Client();
   var request = receiver.createPollRequest(ohttp_relay);
-  var response = await agent.post(Uri.parse(request.request.url.asString()),
-      headers: {"Content-Type": request.request.contentType},
-      body: request.request.body);
+  var response = await agent.post(Uri.parse(request.request.url()),
+      headers: {"Content-Type": request.request.contentType()},
+      body: request.request.body());
   var res = receiver
       .processResponse(response.bodyBytes, request.clientResponse)
       .save(recv_persister);
@@ -258,8 +258,7 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
     return null;
   } else if (res is payjoin.ProgressInitializedTransitionOutcome) {
     var proposal = res.inner;
-    return await process_unchecked_proposal(
-        proposal, recv_persister);
+    return await process_unchecked_proposal(proposal, recv_persister);
   }
 
   throw Exception("Unknown initialized transition outcome: $res");
@@ -346,9 +345,9 @@ void main() {
           .save(sender_persister);
       payjoin.RequestV2PostContext request =
           req_ctx.createV2PostRequest(ohttp_relay);
-      var response = await agent.post(Uri.parse(request.request.url.asString()),
-          headers: {"Content-Type": request.request.contentType},
-          body: request.request.body);
+      var response = await agent.post(Uri.parse(request.request.url()),
+          headers: {"Content-Type": request.request.contentType()},
+          body: request.request.body());
       payjoin.PollingForProposal send_ctx = req_ctx
           .processResponse(response.bodyBytes, request.context)
           .save(sender_persister);
@@ -371,9 +370,9 @@ void main() {
       payjoin.RequestResponse request_response =
           proposal.createPostRequest(ohttp_relay);
       var fallback_response = await agent.post(
-          Uri.parse(request_response.request.url.asString()),
-          headers: {"Content-Type": request_response.request.contentType},
-          body: request_response.request.body);
+          Uri.parse(request_response.request.url()),
+          headers: {"Content-Type": request_response.request.contentType()},
+          body: request_response.request.body());
       proposal.processResponse(
           fallback_response.bodyBytes, request_response.clientResponse);
 
@@ -384,17 +383,19 @@ void main() {
       payjoin.RequestOhttpContext ohttp_context_request =
           send_ctx.createPollRequest(ohttp_relay);
       var final_response = await agent.post(
-          Uri.parse(ohttp_context_request.request.url.asString()),
-          headers: {"Content-Type": ohttp_context_request.request.contentType},
-          body: ohttp_context_request.request.body);
+          Uri.parse(ohttp_context_request.request.url()),
+          headers: {
+            "Content-Type": ohttp_context_request.request.contentType()
+          },
+          body: ohttp_context_request.request.body());
       var checked_payjoin_proposal_psbt = send_ctx
           .processResponse(
               final_response.bodyBytes, ohttp_context_request.ohttpCtx)
           .save(sender_persister);
       expect(checked_payjoin_proposal_psbt, isNotNull);
-      var checked_payjoin_proposal_psbt_inner =
-          (checked_payjoin_proposal_psbt as payjoin.ProgressPollingForProposalTransitionOutcome)
-              .inner;
+      var checked_payjoin_proposal_psbt_inner = (checked_payjoin_proposal_psbt
+              as payjoin.ProgressPollingForProposalTransitionOutcome)
+          .inner;
       var payjoin_psbt = jsonDecode(sender.call("walletprocesspsbt",
           [checked_payjoin_proposal_psbt_inner.serializeBase64()]))["psbt"];
       var final_psbt = jsonDecode(sender

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -91,9 +91,9 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         agent = httpx.AsyncClient()
         request: RequestResponse = receiver.create_poll_request(ohttp_relay)
         response = await agent.post(
-            url=request.request.url.as_string(),
-            headers={"Content-Type": request.request.content_type},
-            content=request.request.body
+            url=request.request.url(),
+            headers={"Content-Type": request.request.content_type()},
+            content=request.request.body()
         )
         res = receiver.process_response(response.content, request.client_response).save(recv_persister)
         if res.is_STASIS():
@@ -160,9 +160,9 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             req_ctx: WithReplyKey = SenderBuilder(psbt, pj_uri).build_recommended(1000).save(sender_persister)
             request: RequestV2PostContext = req_ctx.create_v2_post_request(ohttp_relay)
             response = await agent.post(
-                url=request.request.url.as_string(),
-                headers={"Content-Type": request.request.content_type},
-                content=request.request.body
+                url=request.request.url(),
+                headers={"Content-Type": request.request.content_type()},
+                content=request.request.body()
             )
             send_ctx: PollingForProposal = req_ctx.process_response(response.content, request.context).save(sender_persister)
             # POST Original PSBT
@@ -178,9 +178,9 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             payjoin_proposal = payjoin_proposal.inner
             request: RequestResponse = payjoin_proposal.create_post_request(ohttp_relay)
             response = await agent.post(
-                url=request.request.url.as_string(),
-                headers={"Content-Type": request.request.content_type},
-                content=request.request.body
+                url=request.request.url(),
+                headers={"Content-Type": request.request.content_type()},
+                content=request.request.body()
             )
             payjoin_proposal.process_response(response.content, request.client_response)
 
@@ -190,9 +190,9 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             # Replay post fallback to get the response
             request: RequestOhttpContext = send_ctx.create_poll_request(ohttp_relay)
             response = await agent.post(
-                url=request.request.url.as_string(),
-                headers={"Content-Type": request.request.content_type},
-                content=request.request.body
+                url=request.request.url(),
+                headers={"Content-Type": request.request.content_type()},
+                content=request.request.body()
             )
             checked_payjoin_proposal_psbt = send_ctx.process_response(response.content, request.ohttp_ctx).save(sender_persister).inner
             print(f"checked_payjoin_proposal_psbt: {checked_payjoin_proposal_psbt}")

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -182,7 +182,7 @@ impl SessionHistory {
     ) -> Result<Option<RequestResponse>, SessionError> {
         match self.0.extract_err_req(ohttp_relay) {
             Ok(Some((request, ctx))) => Ok(Some(RequestResponse {
-                request: request.into(),
+                request: Arc::new(request.into()),
                 client_response: Arc::new(ctx.into()),
             })),
             Ok(None) => Ok(None),
@@ -360,7 +360,7 @@ impl
 
 #[derive(uniffi::Record)]
 pub struct RequestResponse {
-    pub request: Request,
+    pub request: Arc<Request>,
     pub client_response: Arc<ClientResponse>,
 }
 
@@ -374,7 +374,7 @@ impl Initialized {
         self.0
             .create_poll_request(ohttp_relay)
             .map(|(req, ctx)| RequestResponse {
-                request: req.into(),
+                request: Arc::new(req.into()),
                 client_response: Arc::new(ctx.into()),
             })
             .map_err(Into::into)
@@ -998,7 +998,7 @@ impl PayjoinProposal {
         ohttp_relay: String,
     ) -> Result<RequestResponse, ReceiverError> {
         self.0.clone().create_post_request(ohttp_relay).map_err(Into::into).map(|(req, ctx)| {
-            RequestResponse { request: req.into(), client_response: Arc::new(ctx.into()) }
+            RequestResponse { request: Arc::new(req.into()), client_response: Arc::new(ctx.into()) }
         })
     }
 

--- a/payjoin-ffi/src/request.rs
+++ b/payjoin-ffi/src/request.rs
@@ -1,33 +1,38 @@
-use std::sync::Arc;
-
-use crate::uri::Url;
-
 ///Represents data that needs to be transmitted to the receiver.
 ///You need to send this request over HTTP(S) to the receiver.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(Clone, Debug, uniffi::Object)]
 pub struct Request {
     /// URL to send the request to.
     ///
     /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Arc<Url>,
+    url: String,
 
     /// The `Content-Type` header to use for the request.
     ///
     /// `text/plain` for v1 requests and `message/ohttp-req` for v2 requests.
-    pub content_type: String,
+    content_type: String,
 
     /// Bytes to be sent to the receiver.
     ///
     /// This is properly encoded PSBT payload either in base64 in v1 or an OHTTP encapsulated payload in v2.
-    pub body: Vec<u8>,
+    body: Vec<u8>,
 }
 
 impl From<payjoin::Request> for Request {
     fn from(value: payjoin::Request) -> Self {
         Self {
-            url: Arc::new(value.url.into()),
-            content_type: value.content_type.to_string(),
-            body: value.body,
+            url: value.url().to_string(),
+            content_type: value.content_type().to_string(),
+            body: value.body().to_vec(),
         }
     }
+}
+
+#[uniffi::export]
+impl Request {
+    pub fn url(&self) -> String { self.url.clone() }
+
+    pub fn content_type(&self) -> String { self.content_type.clone() }
+
+    pub fn body(&self) -> Vec<u8> { self.body.clone() }
 }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -301,8 +301,10 @@ impl WithReplyKey {
         ohttp_relay: String,
     ) -> Result<RequestV2PostContext, CreateRequestError> {
         match self.0.create_v2_post_request(ohttp_relay) {
-            Ok((req, ctx)) =>
-                Ok(RequestV2PostContext { request: req.into(), context: Arc::new(ctx.into()) }),
+            Ok((req, ctx)) => Ok(RequestV2PostContext {
+                request: Arc::new(req.into()),
+                context: Arc::new(ctx.into()),
+            }),
             Err(e) => Err(e.into()),
         }
     }
@@ -325,13 +327,13 @@ impl WithReplyKey {
 
 #[derive(uniffi::Record)]
 pub struct RequestV2PostContext {
-    pub request: Request,
+    pub request: Arc<Request>,
     pub context: Arc<V2PostContext>,
 }
 
 #[derive(uniffi::Record)]
 pub struct RequestV1Context {
-    pub request: Request,
+    pub request: Arc<Request>,
     pub context: Arc<V1Context>,
 }
 
@@ -366,7 +368,7 @@ impl From<payjoin::send::v2::V2PostContext> for V2PostContext {
 
 #[derive(uniffi::Record)]
 pub struct RequestOhttpContext {
-    pub request: crate::Request,
+    pub request: Arc<Request>,
     pub ohttp_ctx: Arc<crate::ClientResponse>,
 }
 
@@ -436,7 +438,7 @@ impl PollingForProposal {
         self.0
             .create_poll_request(ohttp_relay)
             .map(|(req, ctx)| RequestOhttpContext {
-                request: req.into(),
+                request: Arc::new(req.into()),
                 ohttp_ctx: Arc::new(ctx.into()),
             })
             .map_err(|e| e.into())

--- a/payjoin/src/core/request.rs
+++ b/payjoin/src/core/request.rs
@@ -13,17 +13,17 @@ pub struct Request {
     /// URL to send the request to.
     ///
     /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Url,
+    url: Url,
 
     /// The `Content-Type` header to use for the request.
     ///
     /// `text/plain` for v1 requests and `message/ohttp-req` for v2 requests.
-    pub content_type: &'static str,
+    content_type: &'static str,
 
     /// Bytes to be sent to the receiver.
     ///
     /// This is properly encoded PSBT payload either in base64 in v1 or an OHTTP encapsulated payload in v2.
-    pub body: Vec<u8>,
+    body: Vec<u8>,
 }
 
 impl Request {
@@ -41,4 +41,10 @@ impl Request {
     ) -> Self {
         Self { url: url.clone(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
+
+    pub fn url(&self) -> &str { self.url.as_str() }
+
+    pub fn content_type(&self) -> &str { self.content_type }
+
+    pub fn body(&self) -> &[u8] { self.body.as_slice() }
 }

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -352,7 +352,7 @@ mod test {
 
         let sender = Sender { endpoint: Url::from_str(EXAMPLE_URL)?, psbt_ctx };
 
-        let body = sender.create_v1_post_request().0.body;
+        let body = sender.create_v1_post_request().0.body().to_vec();
         let res_str = std::str::from_utf8(&body)?;
         let proposal = Psbt::from_str(res_str)?;
         assert!(proposal.inputs[0].tap_internal_key.is_none());

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -595,9 +595,9 @@ mod test {
         let ohttp_relay = EXAMPLE_URL;
         let result = sender.create_v2_post_request(ohttp_relay);
         let (request, context) = result.expect("Result should be ok");
-        assert!(!request.body.is_empty(), "Request body should not be empty");
+        assert!(!request.body().is_empty(), "Request body should not be empty");
         assert_eq!(
-            request.url.to_string(),
+            request.url(),
             format!("{}/{}", EXAMPLE_URL, sender.pj_param.endpoint().join("/")?)
         );
         assert_eq!(context.psbt_ctx.original_psbt, sender.psbt_ctx.original_psbt);

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -119,7 +119,7 @@ mod integration {
             let (req, ctx) = SenderBuilder::new(psbt, uri)
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
                 .create_v1_post_request();
-            let headers = HeaderMock::new(&req.body, req.content_type);
+            let headers = HeaderMock::new(req.body(), req.content_type());
 
             // **********************
             // Inside the Receiver:
@@ -178,7 +178,7 @@ mod integration {
             let (req, _ctx) = SenderBuilder::new(psbt, uri)
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
                 .create_v1_post_request();
-            let headers = HeaderMock::new(&req.body, req.content_type);
+            let headers = HeaderMock::new(req.body(), req.content_type());
 
             // **********************
             // Inside the Receiver:
@@ -247,9 +247,9 @@ mod integration {
                 let (req, _ctx) =
                     bad_initializer.create_poll_request(services.ohttp_relay_url().as_str())?;
                 agent
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
-                    .body(req.body)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await
                     .map_err(|e| e.into())
@@ -342,9 +342,9 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
-                    .body(req.body)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await?;
                 assert!(response.status().is_success(), "error response: {}", response.status());
@@ -371,10 +371,14 @@ mod integration {
                 let req_ctx = SenderBuilder::new(psbt, pj_uri)
                     .build_recommended(FeeRate::BROADCAST_MIN)?
                     .save(&sender_persister)?;
-                let (Request { url, body, content_type, .. }, _send_ctx) =
+                let (req, _send_ctx) =
                     req_ctx.create_v2_post_request(services.ohttp_relay_url().as_str())?;
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
                 // POST Original PSBT
@@ -386,9 +390,9 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
-                    .body(req.body)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await?;
                 // POST payjoin
@@ -424,9 +428,9 @@ mod integration {
                     .extract_err_req(services.ohttp_relay_url().as_str())?
                     .expect("error request should exist");
                 let err_response = agent
-                    .post(err_req.url)
-                    .header("Content-Type", err_req.content_type)
-                    .body(err_req.body)
+                    .post(err_req.url())
+                    .header("Content-Type", err_req.content_type())
+                    .body(err_req.body().to_vec())
                     .send()
                     .await?;
 
@@ -473,9 +477,9 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
-                    .body(req.body)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await?;
                 assert!(response.status().is_success(), "error response: {}", response.status());
@@ -502,10 +506,14 @@ mod integration {
                 let req_ctx = SenderBuilder::new(psbt, pj_uri)
                     .build_recommended(FeeRate::BROADCAST_MIN)?
                     .save(&send_persister)?;
-                let (Request { url, body, content_type, .. }, send_ctx) =
+                let (req, send_ctx) =
                     req_ctx.create_v2_post_request(services.ohttp_relay_url().as_str())?;
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
                 let send_ctx = req_ctx
@@ -520,9 +528,9 @@ mod integration {
                 let (req, ctx) =
                     session.create_poll_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
-                    .body(req.body)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await?;
                 // POST payjoin
@@ -538,9 +546,9 @@ mod integration {
                 let (req, ctx) =
                     payjoin_proposal.create_post_request(services.ohttp_relay_url().as_str())?;
                 let response = agent
-                    .post(req.url)
-                    .header("Content-Type", req.content_type)
-                    .body(req.body)
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await?;
                 payjoin_proposal
@@ -551,10 +559,14 @@ mod integration {
                 // Inside the Sender:
                 // Sender checks, signs, finalizes, constructs, and broadcasts
                 // Replay post fallback to get the response
-                let (Request { url, body, content_type, .. }, ohttp_ctx) =
+                let (req, ohttp_ctx) =
                     send_ctx.create_poll_request(services.ohttp_relay_url().as_str())?;
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 let response = send_ctx
                     .process_response(&response.bytes().await?, ohttp_ctx)
@@ -621,7 +633,7 @@ mod integration {
             let req_ctx = payjoin::send::v1::SenderBuilder::new(psbt, pj_uri)
                 .build_recommended(FeeRate::BROADCAST_MIN)?;
             let (req, ctx) = req_ctx.create_v1_post_request();
-            let headers = HeaderMock::new(&req.body, req.content_type);
+            let headers = HeaderMock::new(req.body(), req.content_type());
 
             // **********************
             // Inside the Receiver:
@@ -699,13 +711,12 @@ mod integration {
                         FeeRate::ZERO,
                         false,
                     )?;
-                let (Request { url, body, content_type, .. }, send_ctx) =
-                    req_ctx.create_v1_post_request();
+                let (req, send_ctx) = req_ctx.create_v1_post_request();
                 tracing::info!("send fallback v1 to offline receiver fail");
                 let res = agent
-                    .post(url.clone())
-                    .header("Content-Type", content_type)
-                    .body(body.clone())
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
                     .send()
                     .await;
                 assert!(res?.status() == StatusCode::SERVICE_UNAVAILABLE);
@@ -721,9 +732,9 @@ mod integration {
                     let proposal = loop {
                         let (req, ctx) = session.create_poll_request(&ohttp_relay)?;
                         let response = agent_clone
-                            .post(req.url)
-                            .header("Content-Type", req.content_type)
-                            .body(req.body)
+                            .post(req.url())
+                            .header("Content-Type", req.content_type())
+                            .body(req.body().to_vec())
                             .send()
                             .await?;
 
@@ -753,9 +764,9 @@ mod integration {
                     // this response would be returned as http response to the sender
                     let (req, ctx) = payjoin_proposal.create_post_request(ohttp_relay)?;
                     let response = agent_clone
-                        .post(req.url)
-                        .header("Content-Type", req.content_type)
-                        .body(req.body)
+                        .post(req.url())
+                        .header("Content-Type", req.content_type())
+                        .body(req.body().to_vec())
                         .send()
                         .await?;
                     payjoin_proposal
@@ -768,8 +779,12 @@ mod integration {
                 // **********************
                 // send fallback v1 to online receiver
                 tracing::info!("send fallback v1 to online receiver should succeed");
-                let response =
-                    agent.post(url).header("Content-Type", content_type).body(body).send().await?;
+                let response = agent
+                    .post(req.url())
+                    .header("Content-Type", req.content_type())
+                    .body(req.body().to_vec())
+                    .send()
+                    .await?;
                 tracing::info!("Response: {:#?}", &response);
                 assert!(response.status().is_success(), "error response: {}", response.status());
 
@@ -984,7 +999,7 @@ mod integration {
             let (req, ctx) = SenderBuilder::new(psbt.clone(), uri)
                 .build_with_additional_fee(max_additional_fee, None, FeeRate::ZERO, false)?
                 .create_v1_post_request();
-            let headers = HeaderMock::new(&req.body, req.content_type);
+            let headers = HeaderMock::new(req.body(), req.content_type());
 
             // **********************
             // Inside the Receiver:
@@ -1063,7 +1078,7 @@ mod integration {
             let (req, ctx) = SenderBuilder::new(psbt.clone(), uri)
                 .build_with_additional_fee(Amount::from_sat(10000), None, FeeRate::ZERO, false)?
                 .create_v1_post_request();
-            let headers = HeaderMock::new(&req.body, req.content_type);
+            let headers = HeaderMock::new(req.body(), req.content_type());
 
             // **********************
             // Inside the Receiver:
@@ -1168,8 +1183,8 @@ mod integration {
     ) -> Result<String, BoxError> {
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
         let proposal = payjoin::receive::v1::UncheckedOriginalPayload::from_request(
-            req.body.as_slice(),
-            req.url.query().unwrap_or(""),
+            req.body(),
+            url::Url::from_str(req.url()).expect("Could not parse url").query().unwrap_or(""),
             headers,
         )?;
         let proposal =


### PR DESCRIPTION
These three commits reduce the visibility of the Request Struct's internal fields and replaces their external access with a few getter methods.

I opted for `url()` instead of `url_as_str()` as we are not exposing a url to the public API anywhere so there does not need to be a distinction as all Urls in our public API are just strings

Closes #513 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
