### PR TITLE
Use String type instead of Url on Request Struct

### DIFF
--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -247,7 +247,7 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
     String ohttp_relay) async {
   var agent = http.Client();
   var request = receiver.createPollRequest(ohttp_relay);
-  var response = await agent.post(Uri.parse(request.request.url.asString()),
+  var response = await agent.post(Uri.parse(request.request.url),
       headers: {"Content-Type": request.request.contentType},
       body: request.request.body);
   var res = receiver
@@ -258,8 +258,7 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
     return null;
   } else if (res is payjoin.ProgressInitializedTransitionOutcome) {
     var proposal = res.inner;
-    return await process_unchecked_proposal(
-        proposal, recv_persister);
+    return await process_unchecked_proposal(proposal, recv_persister);
   }
 
   throw Exception("Unknown initialized transition outcome: $res");
@@ -346,7 +345,7 @@ void main() {
           .save(sender_persister);
       payjoin.RequestV2PostContext request =
           req_ctx.createV2PostRequest(ohttp_relay);
-      var response = await agent.post(Uri.parse(request.request.url.asString()),
+      var response = await agent.post(Uri.parse(request.request.url),
           headers: {"Content-Type": request.request.contentType},
           body: request.request.body);
       payjoin.PollingForProposal send_ctx = req_ctx
@@ -371,7 +370,7 @@ void main() {
       payjoin.RequestResponse request_response =
           proposal.createPostRequest(ohttp_relay);
       var fallback_response = await agent.post(
-          Uri.parse(request_response.request.url.asString()),
+          Uri.parse(request_response.request.url),
           headers: {"Content-Type": request_response.request.contentType},
           body: request_response.request.body);
       proposal.processResponse(
@@ -384,7 +383,7 @@ void main() {
       payjoin.RequestOhttpContext ohttp_context_request =
           send_ctx.createPollRequest(ohttp_relay);
       var final_response = await agent.post(
-          Uri.parse(ohttp_context_request.request.url.asString()),
+          Uri.parse(ohttp_context_request.request.url),
           headers: {"Content-Type": ohttp_context_request.request.contentType},
           body: ohttp_context_request.request.body);
       var checked_payjoin_proposal_psbt = send_ctx
@@ -392,9 +391,9 @@ void main() {
               final_response.bodyBytes, ohttp_context_request.ohttpCtx)
           .save(sender_persister);
       expect(checked_payjoin_proposal_psbt, isNotNull);
-      var checked_payjoin_proposal_psbt_inner =
-          (checked_payjoin_proposal_psbt as payjoin.ProgressPollingForProposalTransitionOutcome)
-              .inner;
+      var checked_payjoin_proposal_psbt_inner = (checked_payjoin_proposal_psbt
+              as payjoin.ProgressPollingForProposalTransitionOutcome)
+          .inner;
       var payjoin_psbt = jsonDecode(sender.call("walletprocesspsbt",
           [checked_payjoin_proposal_psbt_inner.serializeBase64()]))["psbt"];
       var final_psbt = jsonDecode(sender

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -91,7 +91,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         agent = httpx.AsyncClient()
         request: RequestResponse = receiver.create_poll_request(ohttp_relay)
         response = await agent.post(
-            url=request.request.url.as_string(),
+            url=request.request.url,
             headers={"Content-Type": request.request.content_type},
             content=request.request.body
         )
@@ -160,7 +160,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             req_ctx: WithReplyKey = SenderBuilder(psbt, pj_uri).build_recommended(1000).save(sender_persister)
             request: RequestV2PostContext = req_ctx.create_v2_post_request(ohttp_relay)
             response = await agent.post(
-                url=request.request.url.as_string(),
+                url=request.request.url,
                 headers={"Content-Type": request.request.content_type},
                 content=request.request.body
             )
@@ -178,7 +178,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             payjoin_proposal = payjoin_proposal.inner
             request: RequestResponse = payjoin_proposal.create_post_request(ohttp_relay)
             response = await agent.post(
-                url=request.request.url.as_string(),
+                url=request.request.url,
                 headers={"Content-Type": request.request.content_type},
                 content=request.request.body
             )
@@ -190,7 +190,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             # Replay post fallback to get the response
             request: RequestOhttpContext = send_ctx.create_poll_request(ohttp_relay)
             response = await agent.post(
-                url=request.request.url.as_string(),
+                url=request.request.url,
                 headers={"Content-Type": request.request.content_type},
                 content=request.request.body
             )

--- a/payjoin-ffi/src/request.rs
+++ b/payjoin-ffi/src/request.rs
@@ -1,7 +1,3 @@
-use std::sync::Arc;
-
-use crate::uri::Url;
-
 ///Represents data that needs to be transmitted to the receiver.
 ///You need to send this request over HTTP(S) to the receiver.
 #[derive(Clone, Debug, uniffi::Record)]
@@ -9,7 +5,7 @@ pub struct Request {
     /// URL to send the request to.
     ///
     /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Arc<Url>,
+    pub url: String,
 
     /// The `Content-Type` header to use for the request.
     ///
@@ -24,10 +20,6 @@ pub struct Request {
 
 impl From<payjoin::Request> for Request {
     fn from(value: payjoin::Request) -> Self {
-        Self {
-            url: Arc::new(value.url.into()),
-            content_type: value.content_type.to_string(),
-            body: value.body,
-        }
+        Self { url: value.url, content_type: value.content_type.to_string(), body: value.body }
     }
 }

--- a/payjoin/src/core/request.rs
+++ b/payjoin/src/core/request.rs
@@ -13,7 +13,7 @@ pub struct Request {
     /// URL to send the request to.
     ///
     /// This is full URL with scheme etc - you can pass it right to `reqwest` or a similar library.
-    pub url: Url,
+    pub url: String,
 
     /// The `Content-Type` header to use for the request.
     ///
@@ -30,7 +30,7 @@ impl Request {
     /// Construct a new v1 request.
     #[cfg(feature = "v1")]
     pub(crate) fn new_v1(url: &Url, body: &[u8]) -> Self {
-        Self { url: url.clone(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
+        Self { url: url.to_string(), content_type: V1_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 
     /// Construct a new v2 request.
@@ -39,6 +39,6 @@ impl Request {
         url: &Url,
         body: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES],
     ) -> Self {
-        Self { url: url.clone(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
+        Self { url: url.to_string(), content_type: V2_REQ_CONTENT_TYPE, body: body.to_vec() }
     }
 }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -1169,7 +1169,7 @@ mod integration {
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
         let proposal = payjoin::receive::v1::UncheckedOriginalPayload::from_request(
             req.body.as_slice(),
-            req.url.query().unwrap_or(""),
+            url::Url::from_str(&req.url).expect("Could not parse url").query().unwrap_or(""),
             headers,
         )?;
         let proposal =


### PR DESCRIPTION
This approach removes url::Url from the public API by chaging the url field type to a String allowing us to not need to change the visibility of the internal fields on the Request Struct.

This is an alternate approach to close #513 and if we like it sill supercede #1121

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
