### PR TITLE
Depend on `url/serde` with no default features

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -37,7 +37,7 @@ ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 serde = { version = "1.0.219", default-features = false, optional = true }
 reqwest = { version = "0.12.23", default-features = false, optional = true }
 rustls = { version = "0.23.31", optional = true, default-features=false, features = ["ring"] }
-url = { version = "2.5.4", optional = true }
+url = { version = "2.5.4", optional = true, default-feature=false, features = ["serde"] }
 serde_json = { version = "1.0.142", optional = true }
 tracing = "0.1.41"
 


### PR DESCRIPTION
IDNA is huge ball of complexity that some of our targets, namely Block applications, don't want to depend on. This isn't a full #1124 removal but it's a one line change that gets rid of the biggest offenders.

~~I probably need to update the lock files too.~~ nope, it works.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR. (none)
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
