### PR TITLE
Sender closed variant

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -31,4 +31,7 @@ exclude_re = [
     "replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is
     # payjoin/src/core/send/mod.rs
     "replace match guard proposed_txout.script_pubkey == original_output.script_pubkey with true in PsbtContext::check_outputs", # This non-deterministic mutation has a possible test to catch it
+    # These will be removed following #1123
+    # payjoin/src/core/send/v2/session.rs
+    "SessionHistory::terminal_error",
 ]


### PR DESCRIPTION
By adding a Closed state for sender `SessionEvent`s we can consolidate
the failed, succeded, and canceled states into one enum to keep
eveyrting more concise and clear.

The Session outcomes are as follows, `ReceivedProposalPsbt(bitcoin::psbt)` which
represents the success state, `FailedSession(String)` wich represntes
the failure state and accepts an error string, and `Cancel` which
represents a manual cancel.

Addresses some of #1119 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
