### PR TITLE
Use `HasReplyableErrorTransition` in reply error typestate

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1012,7 +1012,7 @@ pub struct HasReplyableErrorTransition(
                 payjoin::persist::MaybeSuccessTransition<
                     payjoin::receive::v2::SessionEvent,
                     (),
-                    payjoin::receive::Error,
+                    payjoin::receive::ProtocolError,
                 >,
             >,
         >,
@@ -1050,8 +1050,8 @@ impl HasReplyableError {
         &self,
         body: &[u8],
         ohttp_context: &ClientResponse,
-    ) -> PayjoinProposalTransition {
-        PayjoinProposalTransition(Arc::new(RwLock::new(Some(
+    ) -> HasReplyableErrorTransition {
+        HasReplyableErrorTransition(Arc::new(RwLock::new(Some(
             self.0.clone().process_error_response(body, ohttp_context.into()),
         ))))
     }


### PR DESCRIPTION
The ffi `HasReplyableError` typestate is incorrectly using using the `PayjoinProposalTransition` state transition.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
