### PR TITLE
Return closed session state during replays

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -67,6 +67,19 @@ impl ReceiverSessionEvent {
     }
 }
 
+#[derive(Clone, uniffi::Object)]
+pub struct ReceiverSessionOutcome {
+    inner: payjoin::receive::v2::SessionOutcome,
+}
+
+impl From<payjoin::receive::v2::SessionOutcome> for ReceiverSessionOutcome {
+    fn from(value: payjoin::receive::v2::SessionOutcome) -> Self { Self { inner: value } }
+}
+
+impl From<ReceiverSessionOutcome> for payjoin::receive::v2::SessionOutcome {
+    fn from(value: ReceiverSessionOutcome) -> Self { value.inner }
+}
+
 #[derive(Clone, uniffi::Enum)]
 pub enum ReceiveSession {
     Initialized { inner: Arc<Initialized> },
@@ -81,6 +94,7 @@ pub enum ReceiveSession {
     PayjoinProposal { inner: Arc<PayjoinProposal> },
     HasReplyableError { inner: Arc<HasReplyableError> },
     Monitor { inner: Arc<Monitor> },
+    Closed { inner: Arc<ReceiverSessionOutcome> },
 }
 
 impl From<payjoin::receive::v2::ReceiveSession> for ReceiveSession {
@@ -110,6 +124,8 @@ impl From<payjoin::receive::v2::ReceiveSession> for ReceiveSession {
             ReceiveSession::HasReplyableError(inner) =>
                 Self::HasReplyableError { inner: Arc::new(inner.into()) },
             ReceiveSession::Monitor(inner) => Self::Monitor { inner: Arc::new(inner.into()) },
+            ReceiveSession::Closed(session_outcome) =>
+                Self::Closed { inner: Arc::new(session_outcome.into()) },
         }
     }
 }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -57,12 +57,25 @@ impl SenderSessionEvent {
     }
 }
 
+#[derive(Clone, uniffi::Object)]
+pub struct SenderSessionOutcome {
+    inner: payjoin::send::v2::SessionOutcome,
+}
+
+impl From<payjoin::send::v2::SessionOutcome> for SenderSessionOutcome {
+    fn from(value: payjoin::send::v2::SessionOutcome) -> Self { Self { inner: value } }
+}
+
+impl From<SenderSessionOutcome> for payjoin::send::v2::SessionOutcome {
+    fn from(value: SenderSessionOutcome) -> Self { value.inner }
+}
+
 #[derive(Clone, uniffi::Enum)]
 pub enum SendSession {
     WithReplyKey { inner: Arc<WithReplyKey> },
     PollingForProposal { inner: Arc<PollingForProposal> },
     ProposalReceived { inner: Arc<Psbt> },
-    TerminalFailure,
+    Closed { inner: Arc<SenderSessionOutcome> },
 }
 
 impl From<payjoin::send::v2::SendSession> for SendSession {
@@ -75,7 +88,8 @@ impl From<payjoin::send::v2::SendSession> for SendSession {
                 Self::PollingForProposal { inner: Arc::new(inner.into()) },
             SendSession::ProposalReceived(inner) =>
                 Self::ProposalReceived { inner: Arc::new(inner.into()) },
-            SendSession::TerminalFailure => Self::TerminalFailure,
+            SendSession::Closed(session_outcome) =>
+                Self::Closed { inner: Arc::new(session_outcome.into()) },
         }
     }
 }

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -192,8 +192,7 @@ mod tests {
     use crate::receive::tests::original_from_test_vector;
     use crate::receive::v2::test::{mock_err, SHARED_CONTEXT};
     use crate::receive::v2::{
-        HasReplyableError, Initialized, MaybeInputsOwned, PayjoinProposal, ProvisionalProposal,
-        Receiver, UncheckedOriginalPayload,
+        Initialized, MaybeInputsOwned, ProvisionalProposal, Receiver, UncheckedOriginalPayload,
     };
     use crate::receive::{InternalPayloadError, PayloadError};
 
@@ -557,12 +556,7 @@ mod tests {
                 fallback_tx: Some(expected_fallback),
                 expected_status: SessionStatus::Completed,
             },
-            expected_receiver_state: ReceiveSession::PayjoinProposal(Receiver {
-                state: PayjoinProposal {
-                    psbt_context: payjoin_proposal.state.psbt_context.clone(),
-                },
-                session_context: SessionContext { reply_key, ..session_context },
-            }),
+            expected_receiver_state: ReceiveSession::Closed(SessionOutcome::Success(vec![])),
         };
         run_session_history_test(test)
     }
@@ -597,10 +591,7 @@ mod tests {
                 fallback_tx: None,
                 expected_status: SessionStatus::Failed,
             },
-            expected_receiver_state: ReceiveSession::HasReplyableError(Receiver {
-                state: HasReplyableError { error_reply: (&expected_error).into() },
-                session_context: SessionContext { reply_key, ..session_context },
-            }),
+            expected_receiver_state: ReceiveSession::Closed(SessionOutcome::Failure),
         };
         run_session_history_test(test)
     }


### PR DESCRIPTION
We want to avoid returning the current state if a closed event was
processed from the log. The application may just perform the event that
caused the error instead of treating the session as terminally closed.

An alternative approach to #1132 


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

AI disclosure: Cursor autocomplete used 