### PR TITLE
Remove redundant `try_for_each` in history method

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -317,7 +317,7 @@ impl AppTrait for App {
         print_header();
         let mut send_rows = vec![];
         let mut recv_rows = vec![];
-        self.db.get_send_session_ids()?.into_iter().try_for_each(|session_id| {
+        self.db.get_send_session_ids()?.into_iter().for_each(|session_id| {
             let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
             if let Ok((sender_state, _)) = replay_sender_event_log(&persister) {
                 let row = SessionHistoryRow {
@@ -329,10 +329,9 @@ impl AppTrait for App {
                 };
                 send_rows.push(row);
             }
-            Ok::<_, anyhow::Error>(())
-        })?;
+        });
 
-        self.db.get_recv_session_ids()?.into_iter().try_for_each(|session_id| {
+        self.db.get_recv_session_ids()?.into_iter().for_each(|session_id| {
             let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
             if let Ok((receiver_state, _)) = replay_receiver_event_log(&persister) {
                 let row = SessionHistoryRow {
@@ -344,10 +343,9 @@ impl AppTrait for App {
                 };
                 recv_rows.push(row);
             }
-            Ok::<_, anyhow::Error>(())
-        })?;
+        });
 
-        self.db.get_inactive_send_session_ids()?.into_iter().try_for_each(
+        self.db.get_inactive_send_session_ids()?.into_iter().for_each(
             |(session_id, completed_at)| {
                 let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
                 if let Ok((sender_state, session_history)) = replay_sender_event_log(&persister) {
@@ -360,11 +358,10 @@ impl AppTrait for App {
                     };
                     send_rows.push(row);
                 }
-                Ok::<_, anyhow::Error>(())
             },
-        )?;
+        );
 
-        self.db.get_inactive_recv_session_ids()?.into_iter().try_for_each(
+        self.db.get_inactive_recv_session_ids()?.into_iter().for_each(
             |(session_id, completed_at)| {
                 let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
                 if let Ok((receiver_state, session_history)) = replay_receiver_event_log(&persister)
@@ -380,9 +377,8 @@ impl AppTrait for App {
                     };
                     recv_rows.push(row);
                 }
-                Ok::<_, anyhow::Error>(())
             },
-        )?;
+        );
 
         // Print receiver and sender rows separately
         for row in send_rows {


### PR DESCRIPTION
We always return Ok.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
