### PR TITLE
Abstract V2 Sender over SenderContext and remove public Url

### DIFF
--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -29,7 +29,7 @@ pub(crate) struct ValidatedOhttpKeys {
 
 pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
     config: &Config,
-    directory: Option<payjoin::Url>,
+    directory: Option<url::Url>,
     relay_manager: Arc<Mutex<RelayManager>>,
 ) -> Result<ValidatedOhttpKeys> {
     if let Some(ohttp_keys) = config.v2()?.ohttp_keys.clone() {
@@ -48,7 +48,7 @@ pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
 
 async fn fetch_ohttp_keys(
     config: &Config,
-    directory: Option<payjoin::Url>,
+    directory: Option<url::Url>,
     relay_manager: Arc<Mutex<RelayManager>>,
 ) -> Result<ValidatedOhttpKeys> {
     use payjoin::bitcoin::secp256k1::rand::prelude::SliceRandom;

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -6,25 +6,25 @@ use super::Config;
 
 #[derive(Debug, Clone)]
 pub struct RelayManager {
-    selected_relay: Option<payjoin::Url>,
-    failed_relays: Vec<payjoin::Url>,
+    selected_relay: Option<url::Url>,
+    failed_relays: Vec<url::Url>,
 }
 
 impl RelayManager {
     pub fn new() -> Self { RelayManager { selected_relay: None, failed_relays: Vec::new() } }
 
-    pub fn set_selected_relay(&mut self, relay: payjoin::Url) { self.selected_relay = Some(relay); }
+    pub fn set_selected_relay(&mut self, relay: url::Url) { self.selected_relay = Some(relay); }
 
-    pub fn get_selected_relay(&self) -> Option<payjoin::Url> { self.selected_relay.clone() }
+    pub fn get_selected_relay(&self) -> Option<url::Url> { self.selected_relay.clone() }
 
-    pub fn add_failed_relay(&mut self, relay: payjoin::Url) { self.failed_relays.push(relay); }
+    pub fn add_failed_relay(&mut self, relay: url::Url) { self.failed_relays.push(relay); }
 
-    pub fn get_failed_relays(&self) -> Vec<payjoin::Url> { self.failed_relays.clone() }
+    pub fn get_failed_relays(&self) -> Vec<url::Url> { self.failed_relays.clone() }
 }
 
 pub(crate) struct ValidatedOhttpKeys {
     pub(crate) ohttp_keys: payjoin::OhttpKeys,
-    pub(crate) relay_url: payjoin::Url,
+    pub(crate) relay_url: url::Url,
 }
 
 pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -343,13 +343,13 @@ void main() {
       payjoin.WithReplyKey req_ctx = payjoin.SenderBuilder(psbt, pj_uri)
           .buildRecommended(1000)
           .save(sender_persister);
-      payjoin.RequestV2PostContext request =
+      payjoin.RequestOhttpContext request =
           req_ctx.createV2PostRequest(ohttp_relay);
       var response = await agent.post(Uri.parse(request.request.url),
           headers: {"Content-Type": request.request.contentType},
           body: request.request.body);
       payjoin.PollingForProposal send_ctx = req_ctx
-          .processResponse(response.bodyBytes, request.context)
+          .processResponse(response.bodyBytes, request.ohttpCtx)
           .save(sender_persister);
       // POST Original PSBT
 

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -158,13 +158,13 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
             pj_uri = session.pj_uri()
             psbt = build_sweep_psbt(self.sender, pj_uri)
             req_ctx: WithReplyKey = SenderBuilder(psbt, pj_uri).build_recommended(1000).save(sender_persister)
-            request: RequestV2PostContext = req_ctx.create_v2_post_request(ohttp_relay)
+            request: RequestOhttpContext = req_ctx.create_v2_post_request(ohttp_relay)
             response = await agent.post(
                 url=request.request.url,
                 headers={"Content-Type": request.request.content_type},
                 content=request.request.body
             )
-            send_ctx: PollingForProposal = req_ctx.process_response(response.content, request.context).save(sender_persister)
+            send_ctx: PollingForProposal = req_ctx.process_response(response.content, request.ohttp_ctx).save(sender_persister)
             # POST Original PSBT
 
             # **********************

--- a/payjoin-ffi/src/uri/error.rs
+++ b/payjoin-ffi/src/uri/error.rs
@@ -20,7 +20,7 @@ impl From<String> for PjNotSupported {
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]
-pub struct UrlParseError(#[from] payjoin::ParseError);
+pub struct UrlParseError(#[from] url::ParseError);
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[error(transparent)]

--- a/payjoin-ffi/src/uri/mod.rs
+++ b/payjoin-ffi/src/uri/mod.rs
@@ -74,22 +74,22 @@ impl PjUri {
     pub fn as_string(&self) -> String { self.0.clone().to_string() }
 }
 
-impl From<payjoin::Url> for Url {
-    fn from(value: payjoin::Url) -> Self { Self(value) }
+impl From<url::Url> for Url {
+    fn from(value: url::Url) -> Self { Self(value) }
 }
 
-impl From<Url> for payjoin::Url {
+impl From<Url> for url::Url {
     fn from(value: Url) -> Self { value.0 }
 }
 
 #[derive(Clone, Debug, uniffi::Object)]
-pub struct Url(payjoin::Url);
+pub struct Url(url::Url);
 
 #[uniffi::export]
 impl Url {
     #[uniffi::constructor]
     pub fn parse(input: String) -> Result<Url, UrlParseError> {
-        payjoin::Url::parse(input.as_str()).map_err(Into::into).map(Self)
+        url::Url::parse(input.as_str()).map_err(Into::into).map(Self)
     }
     pub fn query(&self) -> Option<String> { self.0.query().map(|x| x.to_string()) }
     pub fn as_string(&self) -> String { self.0.to_string() }

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -20,7 +20,6 @@ pub use into_url::{Error as IntoUrlError, IntoUrl};
 pub mod time;
 pub mod uri;
 pub use uri::{PjParam, PjParseError, PjUri, Uri, UriExt};
-pub use url::{ParseError, Url};
 pub(crate) mod error_codes;
 
 pub(crate) mod output_substitution;

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -348,7 +348,7 @@ impl Sender<WithReplyKey> {
     }
 
     /// The endpoint in the Payjoin URI
-    pub fn endpoint(&self) -> Url { self.pj_param.endpoint().clone() }
+    pub fn endpoint(&self) -> String { self.pj_param.endpoint().to_string() }
 
     pub(crate) fn apply_polling_for_proposal(self) -> SendSession {
         SendSession::PollingForProposal(Sender {
@@ -447,8 +447,8 @@ impl Sender<PollingForProposal> {
             &HpkeKeyPair::from_secret_key(&self.reply_key).public_key().to_compressed_bytes(),
         );
         let mailbox: ShortId = hash.into();
-        let url = self
-            .endpoint()
+        let url = Url::parse(&self.endpoint())
+            .expect("Could not parse url")
             .join(&mailbox.to_string())
             .map_err(|e| InternalCreateRequestError::Url(e.into()))?;
         let body = encrypt_message_a(
@@ -544,7 +544,7 @@ impl Sender<PollingForProposal> {
         )
     }
 
-    pub fn endpoint(&self) -> Url { self.pj_param.endpoint() }
+    pub fn endpoint(&self) -> String { self.pj_param.endpoint().to_string() }
 }
 
 #[cfg(test)]

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -170,7 +170,10 @@ impl SenderBuilder {
         psbt_ctx: PsbtContext,
     ) -> NextStateTransition<SessionEvent, Sender<WithReplyKey>> {
         let sender = Sender::new(pj_param, psbt_ctx);
-        NextStateTransition::success(SessionEvent::Created(Box::new(sender.clone())), sender)
+        NextStateTransition::success(
+            SessionEvent::Created(Box::new(sender.session_context.clone())),
+            sender,
+        )
     }
 }
 
@@ -190,6 +193,11 @@ pub trait State: sealed::State {}
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sender<State> {
     pub(crate) state: State,
+    pub(crate) session_context: SessionContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionContext {
     /// The endpoint in the Payjoin URI
     pub(crate) pj_param: PjParam,
     /// The Original PSBT context
@@ -210,7 +218,7 @@ impl<State> core::ops::DerefMut for Sender<State> {
 
 impl<State> Sender<State> {
     /// The endpoint in the Payjoin URI
-    pub fn endpoint(&self) -> String { self.pj_param.endpoint().to_string() }
+    pub fn endpoint(&self) -> String { self.session_context.pj_param.endpoint().to_string() }
 }
 
 /// Represents the various states of a Payjoin send session during the protocol flow.
@@ -226,7 +234,9 @@ pub enum SendSession {
 }
 
 impl SendSession {
-    fn new(sender: Sender<WithReplyKey>) -> Self { SendSession::WithReplyKey(sender) }
+    fn new(session_context: SessionContext) -> Self {
+        SendSession::WithReplyKey(Sender { state: WithReplyKey, session_context })
+    }
 
     fn process_event(
         self,
@@ -256,7 +266,14 @@ pub struct WithReplyKey;
 
 impl Sender<WithReplyKey> {
     fn new(pj_param: PjParam, psbt_ctx: PsbtContext) -> Self {
-        Sender { state: WithReplyKey, pj_param, psbt_ctx, reply_key: HpkeKeyPair::gen_keypair().0 }
+        Sender {
+            state: WithReplyKey,
+            session_context: SessionContext {
+                pj_param,
+                psbt_ctx,
+                reply_key: HpkeKeyPair::gen_keypair().0,
+            },
+        }
     }
 
     /// Construct serialized Request and Context from a Payjoin Proposal.
@@ -272,37 +289,32 @@ impl Sender<WithReplyKey> {
         &self,
         ohttp_relay: impl IntoUrl,
     ) -> Result<(Request, V2PostContext), CreateRequestError> {
-        if self.pj_param.expiration().elapsed() {
-            return Err(InternalCreateRequestError::Expired(self.pj_param.expiration()).into());
+        if self.session_context.pj_param.expiration().elapsed() {
+            return Err(InternalCreateRequestError::Expired(
+                self.session_context.pj_param.expiration(),
+            )
+            .into());
         }
 
-        let mut sanitized_psbt = self.psbt_ctx.original_psbt.clone();
+        let mut sanitized_psbt = self.session_context.psbt_ctx.original_psbt.clone();
         clear_unneeded_fields(&mut sanitized_psbt);
         let body = serialize_v2_body(
             &sanitized_psbt,
-            self.psbt_ctx.output_substitution,
-            self.psbt_ctx.fee_contribution,
-            self.psbt_ctx.min_fee_rate,
+            self.session_context.psbt_ctx.output_substitution,
+            self.session_context.psbt_ctx.fee_contribution,
+            self.session_context.psbt_ctx.min_fee_rate,
         )?;
-        let base_url = self.pj_param.endpoint().clone();
-        let ohttp_keys = self.pj_param.ohttp_keys();
+        let base_url = self.session_context.pj_param.endpoint().clone();
+        let ohttp_keys = self.session_context.pj_param.ohttp_keys();
         let (request, ohttp_ctx) = extract_request(
             ohttp_relay,
-            self.reply_key.clone(),
+            self.session_context.reply_key.clone(),
             body,
             base_url,
-            self.pj_param.receiver_pubkey().clone(),
+            self.session_context.pj_param.receiver_pubkey().clone(),
             ohttp_keys,
         )?;
-        Ok((
-            request,
-            V2PostContext {
-                pj_param: self.pj_param.clone(),
-                psbt_ctx: self.psbt_ctx.clone(),
-                reply_key: self.reply_key.clone(),
-                ohttp_ctx,
-            },
-        ))
+        Ok((request, V2PostContext { ohttp_ctx }))
     }
 
     /// Processes the response for the initial POST message from the sender
@@ -335,21 +347,14 @@ impl Sender<WithReplyKey> {
                 },
         }
 
-        let sender = Sender {
-            state: PollingForProposal,
-            pj_param: post_ctx.pj_param,
-            psbt_ctx: post_ctx.psbt_ctx,
-            reply_key: post_ctx.reply_key,
-        };
+        let sender = Sender { state: PollingForProposal, session_context: self.session_context };
         MaybeFatalTransition::success(SessionEvent::PostedOriginalPsbt(), sender)
     }
 
     pub(crate) fn apply_polling_for_proposal(self) -> SendSession {
         SendSession::PollingForProposal(Sender {
             state: PollingForProposal,
-            pj_param: self.pj_param,
-            psbt_ctx: self.psbt_ctx,
-            reply_key: self.reply_key,
+            session_context: self.session_context,
         })
     }
 }
@@ -397,15 +402,10 @@ pub(crate) fn serialize_v2_body(
     Ok(format!("{base64}\n{query_params}").into_bytes())
 }
 
-/// Data required to validate the POST response.
+/// Wrapper for ohttp context
 ///
 /// This type is used to process a BIP77 POST response.
-/// Call [`Sender<V2PostContext>::process_response`] on it to continue the BIP77 flow.
 pub struct V2PostContext {
-    /// The endpoint in the Payjoin URI
-    pub(crate) pj_param: PjParam,
-    pub(crate) psbt_ctx: PsbtContext,
-    pub(crate) reply_key: HpkeSecretKey,
     pub(crate) ohttp_ctx: ohttp::ClientResponse,
 }
 
@@ -432,20 +432,22 @@ impl Sender<PollingForProposal> {
     ) -> Result<(Request, ohttp::ClientResponse), CreateRequestError> {
         // TODO unify with receiver's fn short_id_from_pubkey
         let hash = sha256::Hash::hash(
-            &HpkeKeyPair::from_secret_key(&self.reply_key).public_key().to_compressed_bytes(),
+            &HpkeKeyPair::from_secret_key(&self.session_context.reply_key)
+                .public_key()
+                .to_compressed_bytes(),
         );
         let mailbox: ShortId = hash.into();
-        let url = Url::parse(self.pj_param.endpoint().as_str())
+        let url = Url::parse(self.session_context.pj_param.endpoint().as_str())
             .expect("Could not parse url")
             .join(&mailbox.to_string())
             .map_err(|e| InternalCreateRequestError::Url(e.into()))?;
         let body = encrypt_message_a(
             Vec::new(),
-            HpkeKeyPair::from_secret_key(&self.reply_key).public_key(),
-            self.pj_param.receiver_pubkey(),
+            HpkeKeyPair::from_secret_key(&self.session_context.reply_key).public_key(),
+            self.session_context.pj_param.receiver_pubkey(),
         )
         .map_err(InternalCreateRequestError::Hpke)?;
-        let ohttp_keys = self.pj_param.ohttp_keys();
+        let ohttp_keys = self.session_context.pj_param.ohttp_keys();
         let (body, ohttp_ctx) = ohttp_encapsulate(ohttp_keys, "GET", url.as_str(), Some(&body))
             .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
 
@@ -491,8 +493,8 @@ impl Sender<PollingForProposal> {
 
         let body = match decrypt_message_b(
             &body,
-            self.pj_param.receiver_pubkey().clone(),
-            self.reply_key.clone(),
+            self.session_context.pj_param.receiver_pubkey().clone(),
+            self.session_context.reply_key.clone(),
         ) {
             Ok(body) => body,
             Err(e) =>
@@ -517,14 +519,15 @@ impl Sender<PollingForProposal> {
                     InternalProposalError::Psbt(e).into(),
                 ),
         };
-        let processed_proposal = match self.psbt_ctx.clone().process_proposal(proposal) {
-            Ok(processed_proposal) => processed_proposal,
-            Err(e) =>
-                return MaybeSuccessTransitionWithNoResults::fatal(
-                    SessionEvent::Closed(SessionOutcome::Failure),
-                    e.into(),
-                ),
-        };
+        let processed_proposal =
+            match self.session_context.psbt_ctx.clone().process_proposal(proposal) {
+                Ok(processed_proposal) => processed_proposal,
+                Err(e) =>
+                    return MaybeSuccessTransitionWithNoResults::fatal(
+                        SessionEvent::Closed(SessionOutcome::Failure),
+                        e.into(),
+                    ),
+            };
 
         MaybeSuccessTransitionWithNoResults::success(
             processed_proposal.clone(),
@@ -565,15 +568,17 @@ mod test {
         );
         Ok(super::Sender {
             state: super::WithReplyKey,
-            pj_param,
-            psbt_ctx: PsbtContext {
-                original_psbt: PARSED_ORIGINAL_PSBT.clone(),
-                output_substitution: OutputSubstitution::Enabled,
-                fee_contribution: None,
-                min_fee_rate: FeeRate::ZERO,
-                payee: ScriptBuf::from(vec![0x00]),
+            session_context: SessionContext {
+                pj_param,
+                psbt_ctx: PsbtContext {
+                    original_psbt: PARSED_ORIGINAL_PSBT.clone(),
+                    output_substitution: OutputSubstitution::Enabled,
+                    fee_contribution: None,
+                    min_fee_rate: FeeRate::ZERO,
+                    payee: ScriptBuf::from(vec![0x00]),
+                },
+                reply_key: HpkeKeyPair::gen_keypair().0,
             },
-            reply_key: HpkeKeyPair::gen_keypair().0,
         })
     }
 
@@ -583,10 +588,10 @@ mod test {
             Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
         let sender = create_sender_context(expiration)?;
         let body = serialize_v2_body(
-            &sender.psbt_ctx.original_psbt,
-            sender.psbt_ctx.output_substitution,
-            sender.psbt_ctx.fee_contribution,
-            sender.psbt_ctx.min_fee_rate,
+            &sender.session_context.psbt_ctx.original_psbt,
+            sender.session_context.psbt_ctx.output_substitution,
+            sender.session_context.psbt_ctx.fee_contribution,
+            sender.session_context.psbt_ctx.min_fee_rate,
         );
         assert_eq!(body.as_ref().unwrap(), &<Vec<u8> as FromHex>::from_hex(SERIALIZED_BODY_V2)?,);
         Ok(())
@@ -599,13 +604,12 @@ mod test {
         let sender = create_sender_context(expiration)?;
         let ohttp_relay = EXAMPLE_URL;
         let result = sender.create_v2_post_request(ohttp_relay);
-        let (request, context) = result.expect("Result should be ok");
+        let (request, _) = result.expect("Result should be ok");
         assert!(!request.body.is_empty(), "Request body should not be empty");
         assert_eq!(
             request.url.to_string(),
-            format!("{}/{}", EXAMPLE_URL, sender.pj_param.endpoint().join("/")?)
+            format!("{}/{}", EXAMPLE_URL, sender.session_context.pj_param.endpoint().join("/")?)
         );
-        assert_eq!(context.psbt_ctx.original_psbt, sender.psbt_ctx.original_psbt);
         Ok(())
     }
 
@@ -649,26 +653,38 @@ mod test {
             .expect("sender should succeed");
         // v2 senders may always override the receiver's `pjos` parameter to enable output
         // substitution
-        assert_eq!(req_ctx.psbt_ctx.output_substitution, OutputSubstitution::Enabled);
-        assert_eq!(&req_ctx.psbt_ctx.payee, &address.script_pubkey());
-        let fee_contribution =
-            req_ctx.psbt_ctx.fee_contribution.expect("sender should contribute fees");
+        assert_eq!(
+            req_ctx.session_context.psbt_ctx.output_substitution,
+            OutputSubstitution::Enabled
+        );
+        assert_eq!(&req_ctx.session_context.psbt_ctx.payee, &address.script_pubkey());
+        let fee_contribution = req_ctx
+            .session_context
+            .psbt_ctx
+            .fee_contribution
+            .expect("sender should contribute fees");
         assert_eq!(fee_contribution.max_amount, Amount::from_sat(91));
         assert_eq!(fee_contribution.vout, 0);
-        assert_eq!(req_ctx.psbt_ctx.min_fee_rate, FeeRate::from_sat_per_kwu(250));
+        assert_eq!(req_ctx.session_context.psbt_ctx.min_fee_rate, FeeRate::from_sat_per_kwu(250));
         // ensure that the other builder methods also enable output substitution
         let req_ctx = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri.clone())
             .build_non_incentivizing(FeeRate::BROADCAST_MIN)
             .expect("build on test vector should succeed")
             .save(&NoopSessionPersister::default())
             .expect("sender should succeed");
-        assert_eq!(req_ctx.psbt_ctx.output_substitution, OutputSubstitution::Enabled);
+        assert_eq!(
+            req_ctx.session_context.psbt_ctx.output_substitution,
+            OutputSubstitution::Enabled
+        );
         let req_ctx = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri.clone())
             .build_with_additional_fee(Amount::ZERO, Some(0), FeeRate::BROADCAST_MIN, false)
             .expect("build on test vector should succeed")
             .save(&NoopSessionPersister::default())
             .expect("sender should succeed");
-        assert_eq!(req_ctx.psbt_ctx.output_substitution, OutputSubstitution::Enabled);
+        assert_eq!(
+            req_ctx.session_context.psbt_ctx.output_substitution,
+            OutputSubstitution::Enabled
+        );
         // ensure that a v2 sender may still disable output substitution if they prefer.
         let req_ctx = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri)
             .always_disable_output_substitution()
@@ -676,6 +692,9 @@ mod test {
             .expect("build on test vector should succeed")
             .save(&NoopSessionPersister::default())
             .expect("sender should succeed");
-        assert_eq!(req_ctx.psbt_ctx.output_substitution, OutputSubstitution::Disabled);
+        assert_eq!(
+            req_ctx.session_context.psbt_ctx.output_substitution,
+            OutputSubstitution::Disabled
+        );
     }
 }

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -130,6 +130,7 @@ pub enum SessionOutcome {
 mod tests {
     use bitcoin::{FeeRate, ScriptBuf};
     use payjoin_test_utils::{KEM, KEY_ID, PARSED_ORIGINAL_PSBT, SYMMETRIC};
+    use url::Url;
 
     use super::*;
     use crate::output_substitution::OutputSubstitution;
@@ -255,9 +256,8 @@ mod tests {
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap();
         let reply_key = HpkeKeyPair::gen_keypair();
-        let endpoint = sender.endpoint().clone();
+        let endpoint = Url::parse(&sender.endpoint()).expect("Could not parse url");
         let fallback_tx = sender.psbt_ctx.original_psbt.clone().extract_tx_unchecked_fee_rate();
-
         let id = crate::uri::ShortId::try_from(&b"12345670"[..]).expect("valid short id");
         let expiration =
             (std::time::SystemTime::now() - std::time::Duration::from_secs(1)).try_into().unwrap();
@@ -303,7 +303,7 @@ mod tests {
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap();
         let reply_key = HpkeKeyPair::gen_keypair();
-        let endpoint = sender.endpoint().clone();
+        let endpoint = Url::parse(&sender.endpoint()).expect("Could not parse url");
         let fallback_tx = sender.psbt_ctx.original_psbt.clone().extract_tx_unchecked_fee_rate();
         let id = crate::uri::ShortId::try_from(&b"12345670"[..]).expect("valid short id");
         let expiration =
@@ -351,7 +351,7 @@ mod tests {
         .unwrap();
 
         let reply_key = HpkeKeyPair::gen_keypair();
-        let endpoint = sender.endpoint().clone();
+        let endpoint = Url::parse(&sender.endpoint()).expect("Could not parse url");
         let id = crate::uri::ShortId::try_from(&b"12345670"[..]).expect("valid short id");
         let expiration =
             Time::from_now(std::time::Duration::from_secs(60)).expect("Valid expiration");

--- a/payjoin/src/core/uri/mod.rs
+++ b/payjoin/src/core/uri/mod.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 
 use bitcoin::address::NetworkChecked;
 pub use error::PjParseError;
-use url::Url;
 
 #[cfg(feature = "v2")]
 pub(crate) use crate::directory::ShortId;
@@ -48,7 +47,9 @@ impl PjParam {
         compile_error!("Either v1 or v2 feature must be enabled");
     }
 
-    pub fn endpoint(&self) -> Url {
+    pub fn endpoint(&self) -> String { self.endpoint_url().to_string() }
+
+    pub(crate) fn endpoint_url(&self) -> url::Url {
         match self {
             #[cfg(feature = "v1")]
             PjParam::V1(url) => url.endpoint(),
@@ -62,7 +63,7 @@ impl std::fmt::Display for PjParam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // normalizing to uppercase enables QR alphanumeric mode encoding
         // unfortunately Url normalizes these to be lowercase
-        let endpoint = self.endpoint();
+        let endpoint = &self.endpoint_url();
         let scheme = endpoint.scheme();
         let host = endpoint.host_str().expect("host must be set");
         let endpoint_str = self
@@ -101,7 +102,7 @@ pub struct PayjoinExtras {
 
 impl PayjoinExtras {
     pub fn pj_param(&self) -> &PjParam { &self.pj_param }
-    pub fn endpoint(&self) -> Url { self.pj_param.endpoint() }
+    pub fn endpoint(&self) -> String { self.pj_param.endpoint() }
     pub fn output_substitution(&self) -> OutputSubstitution { self.output_substitution }
 }
 

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -90,7 +90,7 @@ fn set_expiration(url: &mut Url, exp: &Time) {
 pub struct PjParam {
     directory: Url,
     id: ShortId,
-    expiration: Time,
+    pub(crate) expiration: Time,
     ohttp_keys: OhttpKeys,
     receiver_pubkey: HpkePublicKey,
 }

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -548,7 +548,7 @@ mod tests {
                    &pjos=0&pj=HTTPS://EXAMPLE.COM/\
                    %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
         let pjuri = Uri::try_from(uri).unwrap().assume_checked().check_pj_supported().unwrap();
-        assert!(ohttp(&pjuri.extras.endpoint()).is_ok());
+        assert!(ohttp(&Url::parse(&pjuri.extras.endpoint()).expect("Could not parse url")).is_ok());
         assert_eq!(format!("{pjuri}"), uri);
 
         let reordered = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=0.01\
@@ -557,7 +557,7 @@ mod tests {
                    &pjos=0";
         let pjuri =
             Uri::try_from(reordered).unwrap().assume_checked().check_pj_supported().unwrap();
-        assert!(ohttp(&pjuri.extras.endpoint()).is_ok());
+        assert!(ohttp(&Url::parse(&pjuri.extras.endpoint()).expect("Could not parse url")).is_ok());
         assert_eq!(format!("{pjuri}"), uri);
     }
 


### PR DESCRIPTION
These were errant publicly accessible Url crate Urls that should be Strings instead.

This was missed in #513.

Perhaps these would ideally be payjoin::Url with a custom type as described in #1124 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
