### PR TITLE
Encapsulate fatal error message in fail outcome

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -79,7 +79,10 @@ impl StatusText for ReceiveSession {
                 "Session failure, waiting to post error response",
             ReceiveSession::Monitor(_) => "Monitoring payjoin proposal",
             ReceiveSession::Closed(session_outcome) => match session_outcome {
-                ReceiverSessionOutcome::Failure => "Session failure",
+                ReceiverSessionOutcome::Failure(e) => {
+                    let error_message = format!("Session failure: {}", e);
+                    Box::leak(error_message.into_boxed_str())
+                }
                 ReceiverSessionOutcome::Success(_) => "Session success",
                 ReceiverSessionOutcome::Cancel => "Session cancelled",
                 ReceiverSessionOutcome::FallbackBroadcasted => "Fallback broadcasted",
@@ -373,7 +376,9 @@ impl AppTrait for App {
                     let row = SessionHistoryRow {
                         session_id,
                         role: Role::Receiver,
-                        status: ReceiveSession::Closed(ReceiverSessionOutcome::Failure),
+                        status: ReceiveSession::Closed(ReceiverSessionOutcome::Failure(
+                            e.to_string(),
+                        )),
                         completed_at: None,
                         error_message: Some(e.to_string()),
                     };
@@ -428,7 +433,9 @@ impl AppTrait for App {
                         let row = SessionHistoryRow {
                             session_id,
                             role: Role::Receiver,
-                            status: ReceiveSession::Closed(ReceiverSessionOutcome::Failure),
+                            status: ReceiveSession::Closed(ReceiverSessionOutcome::Failure(
+                                e.to_string(),
+                            )),
                             completed_at: Some(completed_at),
                             error_message: Some(e.to_string()),
                         };

--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -119,6 +119,8 @@ impl JsonReply {
         }
         .as_u16()
     }
+
+    pub fn message(&self) -> &str { &self.message }
 }
 
 impl From<&ProtocolError> for JsonReply {


### PR DESCRIPTION
Fatal errors should end up in the session event log for auditability.

Addressing [this comment](https://github.com/payjoin/rust-payjoin/issues/796#issuecomment-3365849390)

sender side is missing. 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
