### PR TITLE
Update corepc-node to v0.10.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -917,8 +917,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-client"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/corepc.git?rev=0e3f028#0e3f028803dee946490e00783404d4d6397ce698"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7755b8b9219b23d166a5897b5e2d8266cbdd0de5861d351b96f6db26bcf415f3"
 dependencies = [
  "bitcoin 0.32.7",
  "corepc-types",
@@ -930,8 +931,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/corepc.git?rev=0e3f028#0e3f028803dee946490e00783404d4d6397ce698"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bd382fc775f760a8b55d658527621b890eaa3d8e8bc9779864659b172e81c6"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -948,8 +950,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/corepc.git?rev=0e3f028#0e3f028803dee946490e00783404d4d6397ce698"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e94b68cfbafce3a4f7a0d0f3553dedcf83586f71ddf16d737694915c28823b5"
 dependencies = [
  "bitcoin 0.32.7",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -917,8 +917,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-client"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/corepc.git?rev=0e3f028#0e3f028803dee946490e00783404d4d6397ce698"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7755b8b9219b23d166a5897b5e2d8266cbdd0de5861d351b96f6db26bcf415f3"
 dependencies = [
  "bitcoin 0.32.7",
  "corepc-types",
@@ -930,8 +931,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/corepc.git?rev=0e3f028#0e3f028803dee946490e00783404d4d6397ce698"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bd382fc775f760a8b55d658527621b890eaa3d8e8bc9779864659b172e81c6"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -948,8 +950,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/corepc.git?rev=0e3f028#0e3f028803dee946490e00783404d4d6397ce698"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e94b68cfbafce3a4f7a0d0f3553dedcf83586f71ddf16d737694915c28823b5"
 dependencies = [
  "bitcoin 0.32.7",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ resolver = "2"
 payjoin = { path = "payjoin" }
 payjoin-directory = { path = "payjoin-directory" }
 payjoin-test-utils = { path = "payjoin-test-utils" }
-# TODO: Remove these patches once a new version (>0.8.0) is released to crates.io
-corepc-client = { git = "https://github.com/rust-bitcoin/corepc.git", rev = "0e3f028" }
-corepc-types = { git = "https://github.com/rust-bitcoin/corepc.git", rev = "0e3f028" }

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 bitcoin = { version = "0.32.7", features = ["base64"] }
-corepc-node = { git = "https://github.com/rust-bitcoin/corepc.git", rev = "0e3f028", features = ["download", "29_0"] }
+corepc-node = { version = "0.10.0", features = ["download", "29_0"] }
 http = "1.3.1"
 log = "0.4.27"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }


### PR DESCRIPTION
This commit updates corepc-node to v0.10.0 which includes the https://github.com/rust-bitcoin/corepc/tree/0e3f028803dee946490e00783404d4d6397ce698 commit that we originally were pointing to in our workspace patch.io.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
