### PR TITLE
Add completed_event_id FK to prevent session replay

### DIFF
--- a/payjoin-cli/src/db/error.rs
+++ b/payjoin-cli/src/db/error.rs
@@ -14,6 +14,10 @@ pub(crate) enum Error {
     Serialize(serde_json::Error),
     #[cfg(feature = "v2")]
     Deserialize(serde_json::Error),
+    #[cfg(feature = "v2")]
+    MissingCompletedEventId {
+        session_id: i64,
+    },
 }
 
 impl fmt::Display for Error {
@@ -25,6 +29,10 @@ impl fmt::Display for Error {
             Error::Serialize(e) => write!(f, "Serialization failed: {e}"),
             #[cfg(feature = "v2")]
             Error::Deserialize(e) => write!(f, "Deserialization failed: {e}"),
+            #[cfg(feature = "v2")]
+            Error::MissingCompletedEventId { session_id } => {
+                write!(f, "completed_event_id for Session {} is none", session_id)
+            }
         }
     }
 }
@@ -38,6 +46,8 @@ impl std::error::Error for Error {
             Error::Serialize(e) => Some(e),
             #[cfg(feature = "v2")]
             Error::Deserialize(e) => Some(e),
+            #[cfg(feature = "v2")]
+            Error::MissingCompletedEventId { .. } => None,
         }
     }
 }

--- a/payjoin-cli/src/db/mod.rs
+++ b/payjoin-cli/src/db/mod.rs
@@ -38,7 +38,8 @@ impl Database {
             "CREATE TABLE IF NOT EXISTS send_sessions (
                 session_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 receiver_pubkey BLOB NOT NULL,
-                completed_at INTEGER
+                completed_event_id INTEGER,
+                FOREIGN KEY(completed_event_id) REFERENCES send_session_events(id)
             )",
             [],
         )?;
@@ -46,7 +47,8 @@ impl Database {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS receive_sessions (
                 session_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                completed_at INTEGER
+                completed_event_id INTEGER,
+                FOREIGN KEY(completed_event_id) REFERENCES receive_session_events(id)
             )",
             [],
         )?;


### PR DESCRIPTION
This PR adds completed_event_id foreign key columns to both send_sessions and receive_sessions tables. This column references the exact event row that closed the session.

Closes [#1146 ]( https://github.com/payjoin/rust-payjoin/issues/1146)
<details>
  <summary>

- [x] Replaced completed_at columns with completed_event_id foreign keys
- [x] Updated close() methods to validate if completed_event_id is None
- [x] Modified inactive session queries to derive timestamps from  closed event 

</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
