### PR TITLE
Fix concurrent safety to prevent accidental double payments

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -225,10 +225,18 @@ impl AppTrait for App {
                     });
 
                 let (sender_state, persister) = match sender_state {
-                    Some((sender_state, persister)) => (sender_state, persister),
+                    Some((sender_state, persister)) => {
+                        // Resuming existing session - no duplicate checks needed
+                        (sender_state, persister)
+                    }
                     None => {
-                        let persister =
-                            SenderPersister::new(self.db.clone(), receiver_pubkey.clone())?;
+                        // Creating new session - perform duplicate checks
+                        let persister = SenderPersister::new(
+                            self.db.clone(),
+                            receiver_pubkey.clone(),
+                            bip21,
+                            &address.to_string(),
+                        )?;
                         let psbt = self.create_original_psbt(&address, amount, fee_rate)?;
                         let sender =
                             SenderBuilder::from_parts(psbt, pj_param, &address, Some(amount))

--- a/payjoin-cli/src/db/error.rs
+++ b/payjoin-cli/src/db/error.rs
@@ -14,6 +14,12 @@ pub(crate) enum Error {
     Serialize(serde_json::Error),
     #[cfg(feature = "v2")]
     Deserialize(serde_json::Error),
+    #[cfg(feature = "v2")]
+    DuplicateUri(String),
+    #[cfg(feature = "v2")]
+    DuplicateReceiverKey,
+    #[cfg(feature = "v2")]
+    DuplicateBitcoinAddress(String),
 }
 
 impl fmt::Display for Error {
@@ -25,6 +31,12 @@ impl fmt::Display for Error {
             Error::Serialize(e) => write!(f, "Serialization failed: {e}"),
             #[cfg(feature = "v2")]
             Error::Deserialize(e) => write!(f, "Deserialization failed: {e}"),
+            #[cfg(feature = "v2")]
+            Error::DuplicateUri(uri) => write!(f, "A session for URI '{}' has already been started. Use the 'resume' command to continue existing sessions.", uri),
+            #[cfg(feature = "v2")]
+            Error::DuplicateReceiverKey => write!(f, "A session with the same receiver key is already active. This indicates the URI may have been modified or the receiver is misbehaving."),
+            #[cfg(feature = "v2")]
+            Error::DuplicateBitcoinAddress(address) => write!(f, "A session sending to bitcoin address '{}' is already active. This is problematic for privacy, especially if both transactions are broadcast.", address),
         }
     }
 }
@@ -38,6 +50,10 @@ impl std::error::Error for Error {
             Error::Serialize(e) => Some(e),
             #[cfg(feature = "v2")]
             Error::Deserialize(e) => Some(e),
+            #[cfg(feature = "v2")]
+            Error::DuplicateUri(_)
+            | Error::DuplicateReceiverKey
+            | Error::DuplicateBitcoinAddress(_) => None,
         }
     }
 }

--- a/payjoin-cli/src/db/mod.rs
+++ b/payjoin-cli/src/db/mod.rs
@@ -34,6 +34,10 @@ impl Database {
         // Enable foreign keys
         conn.execute("PRAGMA foreign_keys = ON", [])?;
 
+        // Set locking mode to EXCLUSIVE for concurrent safety
+        conn.execute("PRAGMA locking_mode = EXCLUSIVE", [])?;
+
+        // Create send_sessions table with original schema first
         conn.execute(
             "CREATE TABLE IF NOT EXISTS send_sessions (
                 session_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -42,6 +46,12 @@ impl Database {
             )",
             [],
         )?;
+
+        // Add new columns if they don't exist (for migration)
+        let _ =
+            conn.execute("ALTER TABLE send_sessions ADD COLUMN original_uri TEXT DEFAULT ''", []);
+        let _ = conn
+            .execute("ALTER TABLE send_sessions ADD COLUMN bitcoin_address TEXT DEFAULT ''", []);
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS receive_sessions (


### PR DESCRIPTION
# Summary
This PR addresses #1032  where concurrent send commands could initiate sessions for the same URI with different coin selections, potentially causing double payments.


## Solution

  Implements three duplicate detection checks before creating sessions:
- Duplicate URI: Prevents identical URI sessions
- Duplicate Receiver Key: Catches modified URIs or misbehaving receivers
- Duplicate Bitcoin Address: Prevents privacy issues from multiple payments to same address


Closes #1032
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
