### PR TITLE
Remove Docker mention in dart README

### DIFF
--- a/payjoin-ffi/dart/README.md
+++ b/payjoin-ffi/dart/README.md
@@ -17,5 +17,3 @@ bash ./scripts/generate_<platform>.sh
 # Run all tests
 dart test
 ```
-
-Note that you'll need Docker to run the integration tests. If you get a "Failed to start container" error, ensure the Docker engine is running on your machine.


### PR DESCRIPTION
Docker is no longer needed