### PR TITLE
fix Params lint error

### DIFF
--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -425,7 +425,7 @@ impl OriginalPayload {
     pub fn identify_receiver_outputs(
         &self,
         is_receiver_output: &mut impl FnMut(&Script) -> Result<bool, ImplementationError>,
-    ) -> Result<Vec<usize>, Error> {
+    ) -> Result<(Vec<usize>, Self), Error> {
         let owned_vouts: Vec<usize> = self
             .psbt
             .unsigned_tx
@@ -452,8 +452,9 @@ impl OriginalPayload {
                 params.additional_fee_contribution = None;
             }
         }
+        let original_payload = Self { psbt: self.psbt.clone(), params };
 
-        Ok(owned_vouts)
+        Ok((owned_vouts, original_payload))
     }
 }
 

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -208,11 +208,12 @@ impl OutputsUnknown {
         self,
         is_receiver_output: &mut impl FnMut(&Script) -> Result<bool, ImplementationError>,
     ) -> Result<WantsOutputs, Error> {
-        let owned_vouts = self.original.identify_receiver_outputs(is_receiver_output)?;
+        let (owned_vouts, original_payload) =
+            self.original.identify_receiver_outputs(is_receiver_output)?;
         // In case of there being multiple outputs paying to the receiver, we select the first one
         // as the `change_vout`, which we will default to when making single output changes in
         // future mutating typestates.
-        Ok(WantsOutputs::new(self.original, owned_vouts))
+        Ok(WantsOutputs::new(original_payload, owned_vouts))
     }
 }
 


### PR DESCRIPTION
This PR Closes [#1162 ]( https://github.com/payjoin/rust-payjoin/issues/1162)

<details>


<summary>

## Problem
The function identify_receiver_outputs was modifying a local copy of `params` but never using the modified version, causing a linter error. The issue was that the function signature only returned `Vec<usize>` (the owned_vouts), so the modified params were lost.

This also stops the lint and lint ffi test workflow to fail

Looking at the logic, it looks like the intention was to modify the params to remove the additional_fee_contribution if it points to a receiver output. However, since the function couldn't return the modified params, the modification was useless.

## Solution

- [x] Changed the return type of `identify_receiver_outputs` from `Result<Vec<usize>, Error>` to `Result<(Vec<usize>, Self), Error>` to return both the owned vouts and the filtered payload.

 - [x] Created variable original_payload by constructing a new `Self` instance with the modified params
- [x] Updated the return statement** to return both values

- [x] Updated all callers in the codebase to handle the new return type In v1/mod.rs,In v2/mod.rs

the lint test also passes in  my branch test workflow : https://github.com/Mshehu5/rust-payjoin/actions/runs/18546726647
</summary>



Please confirm the following before requesting review:

- [x] I have [disclosed my use of AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>