### PR TITLE
Use full_relay_url in sender GET request

### DIFF
--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -47,7 +47,7 @@ use crate::persist::{
 };
 use crate::uri::v2::PjParam;
 use crate::uri::ShortId;
-use crate::{HpkeKeyPair, HpkePublicKey, IntoUrl, OhttpKeys, PjUri, Request};
+use crate::{HpkeKeyPair, IntoUrl, PjUri, Request};
 
 mod error;
 mod session;
@@ -322,16 +322,7 @@ impl Sender<WithReplyKey> {
             self.session_context.psbt_ctx.fee_contribution,
             self.session_context.psbt_ctx.min_fee_rate,
         )?;
-        let base_url = self.session_context.pj_param.endpoint().clone();
-        let ohttp_keys = self.session_context.pj_param.ohttp_keys();
-        let (request, ohttp_ctx) = extract_request(
-            ohttp_relay,
-            self.session_context.reply_key.clone(),
-            body,
-            base_url,
-            self.session_context.pj_param.receiver_pubkey().clone(),
-            ohttp_keys,
-        )?;
+        let (request, ohttp_ctx) = extract_request(&self.session_context, ohttp_relay, body)?;
         Ok((request, ohttp_ctx))
     }
 
@@ -378,29 +369,27 @@ impl Sender<WithReplyKey> {
 }
 
 pub(crate) fn extract_request(
+    session_context: &SessionContext,
     ohttp_relay: impl IntoUrl,
-    reply_key: HpkeSecretKey,
     body: Vec<u8>,
-    url: Url,
-    receiver_pubkey: HpkePublicKey,
-    ohttp_keys: &OhttpKeys,
 ) -> Result<(Request, ClientResponse), CreateRequestError> {
-    let ohttp_relay = ohttp_relay.into_url()?;
     let body = encrypt_message_a(
         body,
-        &HpkeKeyPair::from_secret_key(&reply_key).public_key().clone(),
-        &receiver_pubkey,
+        &HpkeKeyPair::from_secret_key(&session_context.reply_key).public_key().clone(),
+        session_context.pj_param.receiver_pubkey(),
     )
     .map_err(InternalCreateRequestError::Hpke)?;
 
-    let (body, ohttp_ctx) = ohttp_encapsulate(ohttp_keys, "POST", url.as_str(), Some(&body))
-        .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
-    tracing::debug!("ohttp_relay_url: {ohttp_relay:?}");
-    let directory_base = url.join("/").map_err(|e| InternalCreateRequestError::Url(e.into()))?;
-    let full_ohttp_relay = ohttp_relay
-        .join(&format!("/{directory_base}"))
-        .map_err(|e| InternalCreateRequestError::Url(e.into()))?;
-    let request = Request::new_v2(&full_ohttp_relay, &body);
+    let (body, ohttp_ctx) = ohttp_encapsulate(
+        session_context.pj_param.ohttp_keys(),
+        "POST",
+        session_context.pj_param.endpoint().as_str(),
+        Some(&body),
+    )
+    .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
+    let full_relay_url = session_context.full_relay_url(ohttp_relay)?;
+    tracing::debug!("ohttp_relay_url: {full_relay_url:?}");
+    let request = Request::new_v2(&full_relay_url, &body);
     Ok((request, ohttp_ctx))
 }
 


### PR DESCRIPTION
This fixes an issue with directories other than the [GATEWAY_ORIGIN](https://github.com/payjoin/ohttp-relay/blob/880d7c4e911df509112b7802b7d7b1cff016ed2f/src/main.rs#L17) specified by the OHTTP relay. Previously, attempting to use a different directory using the gateway opt-in mechanism resulted in an error due to the ohttp relay routing the sender request to the wrong directory:

```
[payjoin-cli/src/app/v2/mod.rs:499:13] &response = Response {                                                                                                                                                             url: "https://ohttp.cakewallet.com/",                                                                                                                                                                                 status: 400,
    headers: {                                                                                                                                                                                                                "server": "nginx/1.27.4",                                                                                                                                                                                             "date": "Tue, 21 Oct 2025 00:27:30 GMT",                                                                                                                                                                              "content-type": "application/problem+json",                                                                                                                                                                           "content-length": "103",
        "connection": "keep-alive",
        "access-control-allow-origin": "*",
    },
}
Transient error: The receiver sent an invalid response: v2 encapsulation error: Directory response error: Unexpected response size 103, expected 8192 bytes
```

The directory URL must be included in the path but was previously only included in POST requests (introduced in 8906c76). This includes it in GET requests as well.

I used Sonnet 4.5 for troubleshooting.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
