### PR TITLE
Remove `ReceivedProposalPsbt` infavor of session outcome

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -52,10 +52,9 @@ impl StatusText for SendSession {
         match self {
             SendSession::WithReplyKey(_) | SendSession::PollingForProposal(_) =>
                 "Waiting for proposal",
-            SendSession::ProposalReceived(_) => "Proposal received",
             SendSession::Closed(session_outcome) => match session_outcome {
                 SenderSessionOutcome::Failure => "Session failure",
-                SenderSessionOutcome::Success => "Session success",
+                SenderSessionOutcome::Success(_) => "Session success",
                 SenderSessionOutcome::Cancel => "Session cancelled",
             },
         }
@@ -461,7 +460,7 @@ impl App {
                 self.post_original_proposal(context, persister).await?,
             SendSession::PollingForProposal(context) =>
                 self.get_proposed_payjoin_psbt(context, persister).await?,
-            SendSession::ProposalReceived(proposal) => {
+            SendSession::Closed(SenderSessionOutcome::Success(proposal)) => {
                 self.process_pj_response(proposal)?;
                 return Ok(());
             }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -72,7 +72,6 @@ impl From<SenderSessionOutcome> for payjoin::send::v2::SessionOutcome {
 pub enum SendSession {
     WithReplyKey { inner: Arc<WithReplyKey> },
     PollingForProposal { inner: Arc<PollingForProposal> },
-    ProposalReceived { inner: Arc<Psbt> },
     Closed { inner: Arc<SenderSessionOutcome> },
 }
 
@@ -84,8 +83,6 @@ impl From<payjoin::send::v2::SendSession> for SendSession {
                 Self::WithReplyKey { inner: Arc::new(inner.into()) },
             SendSession::PollingForProposal(inner) =>
                 Self::PollingForProposal { inner: Arc::new(inner.into()) },
-            SendSession::ProposalReceived(inner) =>
-                Self::ProposalReceived { inner: Arc::new(inner.into()) },
             SendSession::Closed(session_outcome) =>
                 Self::Closed { inner: Arc::new(session_outcome.into()) },
         }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -247,7 +247,6 @@ impl<State> Sender<State> {
 pub enum SendSession {
     WithReplyKey(Sender<WithReplyKey>),
     PollingForProposal(Sender<PollingForProposal>),
-    ProposalReceived(Psbt),
     Closed(SessionOutcome),
 }
 
@@ -265,8 +264,8 @@ impl SendSession {
                 Ok(state.apply_polling_for_proposal()),
             (
                 SendSession::PollingForProposal(_state),
-                SessionEvent::ReceivedProposalPsbt(proposal),
-            ) => Ok(SendSession::ProposalReceived(proposal)),
+                SessionEvent::Closed(SessionOutcome::Success(proposal)),
+            ) => Ok(SendSession::Closed(SessionOutcome::Success(proposal))),
             (_, SessionEvent::Closed(session_outcome)) => Ok(SendSession::Closed(session_outcome)),
             (current_state, event) => Err(InternalReplayError::InvalidEvent(
                 Box::new(event),
@@ -530,7 +529,7 @@ impl Sender<PollingForProposal> {
 
         MaybeSuccessTransitionWithNoResults::success(
             processed_proposal.clone(),
-            SessionEvent::ReceivedProposalPsbt(processed_proposal),
+            SessionEvent::Closed(SessionOutcome::Success(processed_proposal)),
         )
     }
 }


### PR DESCRIPTION
The sender session is marked as successfully closed once the payjoin proposal is received. Currently, this state is recorded in a separate event (`ReceivedProposalPsbt`) from the `Closed` event which is inconsistent with the reciever implementation.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
