### PR TITLE
Force ffi workflow to use certain python version

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,11 @@ jobs:
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
       - name: Install a specific version of uv
         uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
This relates to #1177 but I think it should remain open until we can determine why uv is doing this and revert our runner to not having any special OS clauses

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
