### PR TITLE
Remove extraneous destructuring

### DIFF
--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -468,8 +468,8 @@ trait InternalSessionPersister: SessionPersister {
             }
             MaybeFatalOrSuccessTransition::NoResults(current_state) =>
                 Ok(OptionalTransitionOutcome::Stasis(current_state)),
-            MaybeFatalOrSuccessTransition::Fatal(RejectFatal(event, error)) =>
-                Err(self.handle_fatal_reject(RejectFatal(event, error)).into()),
+            MaybeFatalOrSuccessTransition::Fatal(reject_fatal) =>
+                Err(self.handle_fatal_reject(reject_fatal).into()),
             MaybeFatalOrSuccessTransition::Transient(RejectTransient(err)) =>
                 Err(InternalPersistedError::Transient(err).into()),
         }
@@ -501,8 +501,8 @@ trait InternalSessionPersister: SessionPersister {
             }
             Err(Rejection::Transient(RejectTransient(err))) =>
                 Err(InternalPersistedError::Transient(err).into()),
-            Err(Rejection::Fatal(RejectFatal(event, err))) =>
-                Err(self.handle_fatal_reject(RejectFatal(event, err)).into()),
+            Err(Rejection::Fatal(reject_fatal)) =>
+                Err(self.handle_fatal_reject(reject_fatal).into()),
             Err(Rejection::ReplyableError(reject_replyable_error)) =>
                 Err(self.handle_replyable_error_reject(reject_replyable_error).into()),
         }


### PR DESCRIPTION
`handle_fatal_reject` takes as argument a `RejectFatal` struct. So destructuring and re-assembling `RejectFatal` is unnecessary.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
