### PR TITLE
docs(payjoin): highlight {v1,v2}::{send,receive} as primary API entry

### DIFF
--- a/payjoin/src/lib.rs
+++ b/payjoin/src/lib.rs
@@ -8,10 +8,18 @@
 //!
 //! Only the latest BIP 77 Payjoin V2 is enabled by default. To use BIP 78 Payjoin V1, enable the `v1` feature.
 //!
+//! The library API is organized by protocol version and operation type:
+//! - Sending Payjoins: [`send::v1`] and [`send::v2`] modules
+//! - Receiving Payjoins: [`receive::v1`] and [`receive::v2`] modules
+//!
 //! The library is perfectly IO-agnostic — in fact, it does no IO by default without the `io` feature.
 //!
 //! Types relevant to a Payjoin Directory as defined in BIP 77 are available in the [`directory`] module enabled by
 //!  the `directory` feature.
+//!
+//! ## Example Usage
+//!
+//! See [payjoin-cli](https://github.com/payjoin/rust-payjoin/tree/master/payjoin-cli) for a complete example of sending and receiving payjoins using both protocol versions.
 //!
 //! ## Disclaimer ⚠️ WIP
 //!


### PR DESCRIPTION
This PR address some issues in https://github.com/payjoin/rust-payjoin/issues/865 mainly this issue :
>the top level payjoin module doc should:
>refer to the {v1,v2}::{send,receive} modules for the actual API, without prior knowledge it's hard to tell that these are the main entry points into the API they're just in the middle of the modules list
explain refer to payjoin-cli crate as an example

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
