### PR TITLE
Add Payjoin txid access to Receiver<Monitor>

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1292,6 +1292,12 @@ impl Receiver<Monitor> {
 
         MaybeFatalOrSuccessTransition::no_results(self.clone())
     }
+
+    /// The Payjoin Proposal TXID.
+    pub fn txid(&self) -> Txid {
+        let psbt = &self.psbt_context.payjoin_psbt;
+        psbt.unsigned_tx.compute_txid()
+    }
 }
 
 /// Derive a mailbox endpoint on a directory given a [`ShortId`].

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -630,6 +630,7 @@ mod integration {
                 );
 
                 // monitor the payment on the receiver side
+                assert_eq!(monitoring_payment.txid(), payjoin_tx.compute_txid());
                 monitoring_payment.check_payment(
                     |txid| {
                         let tx = receiver


### PR DESCRIPTION
I created the issue for this (https://github.com/payjoin/rust-payjoin/issues/1195) a couple of minutes ago and went with it since it is so quick.

One issue I found while working on the BDK CLI integration was that there was no way to fetch the TXID which was being monitored as it is limited to the closure which is passed to the monitor function. With this function, if there is multi thread resume happening, the caller can extract the TXID of the transaction which was just confirmed on the mempool and do something with it -- in the case of BDK CLI, it would be returning the TXID in a JSON.

Closes https://github.com/payjoin/rust-payjoin/issues/1195

  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
