### PR TITLE
Sort session events by auto-incrementing id

### DIFF
--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -68,7 +68,7 @@ impl SessionPersister for SenderPersister {
     {
         let conn = self.db.get_connection()?;
         let mut stmt = conn.prepare(
-            "SELECT event_data FROM send_session_events WHERE session_id = ?1 ORDER BY created_at ASC",
+            "SELECT event_data FROM send_session_events WHERE session_id = ?1 ORDER BY id ASC",
         )?;
 
         let event_rows = stmt.query_map(params![*self.session_id], |row| {
@@ -149,7 +149,7 @@ impl SessionPersister for ReceiverPersister {
     > {
         let conn = self.db.get_connection()?;
         let mut stmt = conn.prepare(
-            "SELECT event_data FROM receive_session_events WHERE session_id = ?1 ORDER BY created_at ASC",
+            "SELECT event_data FROM receive_session_events WHERE session_id = ?1 ORDER BY id ASC",
         )?;
 
         let event_rows = stmt.query_map(params![*self.session_id], |row| {


### PR DESCRIPTION
Events may share the same `created_at` timestamp if they were created in the same second. An out of sync system time could also lead to inconsistent sorting -- which would eventually cause a panic when replaying the session.

cherry picked from #1158  
Closes: #1201 
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
