### PR TITLE
Skip check_payment in Receiver<Monitor> if the sender is using non-segwit address

### DIFF
--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -135,26 +135,6 @@ impl BitcoindWallet {
     }
 
     #[cfg(feature = "v2")]
-    pub fn is_outpoint_spent(&self, outpoint: &OutPoint) -> Result<bool> {
-        let _ = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                // Note: explicitly ignore txouts in the mempool. Those should be considered spent for our purposes
-                .block_on(async {
-                    match self.rpc.get_tx_out(&outpoint.txid, outpoint.vout, false).await {
-                        Ok(_) => Ok(true),
-                        Err(e) =>
-                            if e.is_missing_or_invalid_input() {
-                                Ok(false)
-                            } else {
-                                Err(e)
-                            },
-                    }
-                })
-        })?;
-        Ok(true)
-    }
-
-    #[cfg(feature = "v2")]
     pub fn get_raw_transaction(
         &self,
         txid: &Txid,

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1136,24 +1136,13 @@ fn try_deserialize_tx(
 
 #[uniffi::export]
 impl Monitor {
-    pub fn monitor(
-        &self,
-        transaction_exists: Arc<dyn TransactionExists>,
-        outpoint_spent: Arc<dyn OutpointSpent>,
-    ) -> MonitorTransition {
-        MonitorTransition(Arc::new(RwLock::new(Some(self.0.clone().check_payment(
-            |txid| {
-                transaction_exists
-                    .callback(txid.to_string())
-                    .and_then(|buf| buf.map(try_deserialize_tx).transpose())
-                    .map_err(|e| ImplementationError::new(e).into())
-            },
-            |outpoint| {
-                outpoint_spent
-                    .callback(outpoint.into())
-                    .map_err(|e| ImplementationError::new(e).into())
-            },
-        )))))
+    pub fn monitor(&self, transaction_exists: Arc<dyn TransactionExists>) -> MonitorTransition {
+        MonitorTransition(Arc::new(RwLock::new(Some(self.0.clone().check_payment(|txid| {
+            transaction_exists
+                .callback(txid.to_string())
+                .and_then(|buf| buf.map(try_deserialize_tx).transpose())
+                .map_err(|e| ImplementationError::new(e).into())
+        })))))
     }
 }
 

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -119,7 +119,8 @@ impl SessionHistory {
         }
         match self.events.last() {
             Some(SessionEvent::Closed(outcome)) => match outcome {
-                SessionOutcome::Success(_) => SessionStatus::Completed,
+                SessionOutcome::Success(_) | SessionOutcome::PayjoinProposalSent =>
+                    SessionStatus::Completed,
                 SessionOutcome::Failure | SessionOutcome::Cancel => SessionStatus::Failed,
                 SessionOutcome::FallbackBroadcasted => SessionStatus::FallbackBroadcasted,
             },
@@ -169,6 +170,10 @@ pub enum SessionOutcome {
     Cancel,
     /// Fallback transaction was broadcasted
     FallbackBroadcasted,
+    /// Payjoin proposal was sent, but its broadcast status cannot be tracked because
+    /// the sender is using non-SegWit inputs which will change the transaction ID
+    /// of the proposal
+    PayjoinProposalSent,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

### Overview
The previous implementation of the check_payment function assumed that if the outpoints of the Payjoin transaction have been removed from the UTXO set, it is an indication of the Payjoin being broadcasted by the sender. Moreover, it relied on the same closure to detect whether there is a double-spend attempt from the sender, if only a subset of the outpoints have been spent.

Both of the usages of the outpoint closure is incorrect. If the sender does RBF on the fallback transaction, this would change the transaction ID and cause the previous implementation to incorrectly detect double-spend. Moreover, the sender can use some of the UTXOs in the Payjoin session if they wish without necessarily "attacking" the receiver.

This change removes the outpoint closure, and instead skips the check if
the fallback transaction has any inputs which does not have witness
data. This assumes that the fallback transaction has been signed which
is a certainty at this point in the Payjoin session.

Closes https://github.com/payjoin/rust-payjoin/issues/1214.

On the side: this PR also contains another small commit for completing a TODO in the unit tests.

### List of Changes
* Remove the outpoint check closure from the `check_payment` function and add skip if the fallback transaction is non-segwit.
* Add a new receiver SessionOutcome value to indicate the skip.
* Change the consumers of the function (i.e. cli, ffi) to adhere to the new signature.
* Add unit tests.

### Testing
* Added new unit tests with P2PKH PSBTs for testing this specific scenario.

### Next Step
https://github.com/payjoin/rust-payjoin/pull/1211 contains a documentation update for the `check_payment` function. Will need to update that if and when this PR gets approved and merged, and also make sure that there are integration tests for covering p2pkh as well.