### PR TITLE
Make nginx available in nix flake check test runs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,10 @@
         src = nixpkgs.lib.cleanSourceWith {
           src = ./.;
           filter =
-            path: type: (builtins.match ".*.udl" path != null) || (craneLib.filterCargoSources path type);
+            path: type:
+            (builtins.match ".*.udl$" path != null)
+            || (builtins.match ".*nginx.conf.template$" path != null)
+            || (craneLib.filterCargoSources path type);
           name = "source";
         };
         commonArgs = {
@@ -169,6 +172,7 @@
               partitionType = "count";
               cargoExtraArgs = "--locked --all-features";
               BITCOIND_EXE = nixpkgs.lib.getExe' pkgs.bitcoind "bitcoind";
+              nativeBuildInputs = [ nginxWithStream ];
             }
           );
 
@@ -180,6 +184,7 @@
               partitionType = "count";
               cargoExtraArgs = "--locked --all-features";
               BITCOIND_EXE = nixpkgs.lib.getExe' pkgs.bitcoind "bitcoind";
+              nativeBuildInputs = [ nginxWithStream ];
             }
           );
 


### PR DESCRIPTION
The source tree filtering also now includes the `nginx.conf.template` file.

If `doCheck = false` is removed from the crane package builds for ohttp-relay the integration tests are not run by default, so a nativeBuildInput with nginx is not strictly required even if the derivation is overridden to reenable the checks.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
