### PR TITLE
Remove nightly toolchain flag from recommended precommit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,9 +51,9 @@ Every commit should be [hygenic](https://github.com/bitcoin/bitcoin/blob/master/
 #!/usr/bin/env bash
 set -euo pipefail
 
-# -------- 1. Rustfmt (nightly toolchain) --------
-echo "▶  cargo +nightly fmt --check"
-cargo +nightly fmt --all -- --check
+# -------- 1. Rustfmt --------
+echo "▶  cargo fmt --check"
+cargo fmt --all -- --check
 
 # -------- 2.1 Project-specific linter --------
 echo "▶  ./contrib/lint.sh"


### PR DESCRIPTION
I asked Claude to give me bash code to select between nix and non-nix environments. So this PR in its entirety was written with AI... UNTIL there was an edit based on spacebear's recommendation below, and the change turned from adding a branching logic to account for the nix shell, to just removing the toolchain flag.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

Originally, this PR was for adding an if-statement to the recommended pre-commit hook so that it does not attempt to find +nightly for rust formatter. However, as spacebear mentions below, we do not need it anymore as it is enforced. So this change simply removes that flag now.