### PR TITLE
Adding flake check and weekly flake.lock maintence job in git workflow

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,31 @@
+name: Flake Check
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "flake.lock"
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - msrv
+          - stable
+          - nightly
+          - maintenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run full flake check
+        run: nix build .#checks.x86_64-linux.${{ matrix.checks }}

--- a/.github/workflows/flake-maintenance.yml
+++ b/.github/workflows/flake-maintenance.yml
@@ -1,0 +1,52 @@
+name: Flake maintenance
+
+on:
+  schedule:
+    - cron: "0 11 * * 1" # weekly at 14:00 UTC
+  workflow_dispatch:
+
+jobs:
+  validate-lock-file:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - msrv
+          - stable
+          - nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Validate recreated lockfile
+        run: nix build .#checks.x86_64-linux.${{ matrix.checks }} -L --recreate-lock-file --no-write-lock-file
+
+  update-lock-file:
+    needs: validate-lock-file
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "chore: update flake.lock"
+          commit-msg: "chore: update flake.lock"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          nix-options: --offline

--- a/flake.nix
+++ b/flake.nix
@@ -309,6 +309,16 @@
               ]
               ++ pkgs.lib.attrValues packages
             );
+
+            maintenance = checkSuite "maintenance" (
+              with self.outputs.checks.${system};
+              [
+                payjoin-workspace-machete
+                payjoin-workspace-clippy
+                payjoin-workspace-doc
+                formatting
+              ]
+            );
           };
       }
     );


### PR DESCRIPTION
This PR addresses some of the issues in https://github.com/payjoin/rust-payjoin/issues/457  specifically:

Adding a Nix flake check to the GitHub workflow

Adding a flake.lock maintenance job to automatically update flake.lock
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
