### PR TITLE
Specify --tree-root to treefmt flake check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -210,7 +210,7 @@
             src = pkgs.lib.sources.sourceFilesBySuffices ./. [ ".nix" ];
             nativeBuildInputs = [ pkgs.nixfmt-tree ];
             checkPhase = ''
-              treefmt --ci
+              treefmt --ci --tree-root .
             '';
           };
 


### PR DESCRIPTION
Since the .git directory is filtered out of the the src files in the sandboxed build, treefmt incorrectly identifies /nix/store as the project root and attempts to format readonly files there

Specifying `--tree-root .` (will be `/build/source` in the sandbox container) ensures that only the project files are formatted as expected.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
  AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
  in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
