### PR TITLE
Async persistence

### DIFF
--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -51,6 +51,8 @@ pub struct MaybeSuccessTransitionWithNoResults<Event, SuccessValue, CurrentState
 
 impl<Event, SuccessValue, CurrentState, Err>
     MaybeSuccessTransitionWithNoResults<Event, SuccessValue, CurrentState, Err>
+where
+    Err: std::error::Error,
 {
     pub(crate) fn fatal(event: Event, error: Err) -> Self {
         MaybeSuccessTransitionWithNoResults(Err(Rejection::fatal(event, error)))
@@ -103,7 +105,6 @@ impl<Event, SuccessValue, CurrentState, Err>
     >
     where
         P: SessionPersister<SessionEvent = Event>,
-        Err: std::error::Error,
     {
         let (actions, outcome) = self.deconstruct();
         actions.execute(persister).map_err(InternalPersistedError::Storage)?;
@@ -119,7 +120,7 @@ impl<Event, SuccessValue, CurrentState, Err>
     >
     where
         P: AsyncSessionPersister<SessionEvent = Event>,
-        Err: std::error::Error + Send,
+        Err: Send,
         SuccessValue: Send,
         CurrentState: Send,
         Event: Send,
@@ -137,6 +138,8 @@ pub struct MaybeFatalTransitionWithNoResults<Event, NextState, CurrentState, Err
 
 impl<Event, NextState, CurrentState, Err>
     MaybeFatalTransitionWithNoResults<Event, NextState, CurrentState, Err>
+where
+    Err: std::error::Error,
 {
     pub(crate) fn fatal(event: Event, error: Err) -> Self {
         MaybeFatalTransitionWithNoResults(Err(Rejection::fatal(event, error)))
@@ -186,7 +189,6 @@ impl<Event, NextState, CurrentState, Err>
     >
     where
         P: SessionPersister<SessionEvent = Event>,
-        Err: std::error::Error,
     {
         let (actions, outcome) = self.deconstruct();
         actions.execute(persister).map_err(InternalPersistedError::Storage)?;
@@ -202,7 +204,7 @@ impl<Event, NextState, CurrentState, Err>
     >
     where
         P: AsyncSessionPersister<SessionEvent = Event>,
-        Err: std::error::Error + Send,
+        Err: Send,
         NextState: Send,
         CurrentState: Send,
         Event: Send,
@@ -220,6 +222,7 @@ pub struct MaybeFatalTransition<Event, NextState, Err, ErrorState = ()>(
 
 impl<Event, NextState, Err, ErrorState> MaybeFatalTransition<Event, NextState, Err, ErrorState>
 where
+    Err: std::error::Error,
     ErrorState: fmt::Debug,
 {
     pub(crate) fn fatal(event: Event, error: Err) -> Self {
@@ -258,7 +261,6 @@ where
     ) -> Result<NextState, PersistedError<Err, P::InternalStorageError, ErrorState>>
     where
         P: SessionPersister<SessionEvent = Event>,
-        Err: std::error::Error,
     {
         let (actions, outcome) = self.deconstruct();
         actions.execute(persister).map_err(InternalPersistedError::Storage)?;
@@ -271,7 +273,7 @@ where
     ) -> Result<NextState, PersistedError<Err, P::InternalStorageError, ErrorState>>
     where
         P: AsyncSessionPersister<SessionEvent = Event>,
-        Err: std::error::Error + Send,
+        Err: Send,
         ErrorState: Send,
         NextState: Send,
         Event: Send,
@@ -288,7 +290,10 @@ pub struct MaybeTransientTransition<Event, NextState, Err>(
     Result<AcceptNextState<Event, NextState>, RejectTransient<Err>>,
 );
 
-impl<Event, NextState, Err> MaybeTransientTransition<Event, NextState, Err> {
+impl<Event, NextState, Err> MaybeTransientTransition<Event, NextState, Err>
+where
+    Err: std::error::Error,
+{
     pub(crate) fn success(event: Event, next_state: NextState) -> Self {
         MaybeTransientTransition(Ok(AcceptNextState(event, next_state)))
     }
@@ -310,7 +315,6 @@ impl<Event, NextState, Err> MaybeTransientTransition<Event, NextState, Err> {
     ) -> Result<NextState, PersistedError<Err, P::InternalStorageError>>
     where
         P: SessionPersister<SessionEvent = Event>,
-        Err: std::error::Error,
     {
         let (actions, outcome) = self.deconstruct();
         actions.execute(persister).map_err(InternalPersistedError::Storage)?;
@@ -323,7 +327,7 @@ impl<Event, NextState, Err> MaybeTransientTransition<Event, NextState, Err> {
     ) -> Result<NextState, PersistedError<Err, P::InternalStorageError>>
     where
         P: AsyncSessionPersister<SessionEvent = Event>,
-        Err: std::error::Error + Send,
+        Err: Send,
         NextState: Send,
         Event: Send,
     {
@@ -486,7 +490,6 @@ where
     >
     where
         P: SessionPersister<SessionEvent = Event>,
-        Err: std::error::Error,
     {
         let (actions, outcome) = self.deconstruct();
         actions.execute(persister).map_err(InternalPersistedError::Storage)?;
@@ -502,7 +505,7 @@ where
     >
     where
         P: AsyncSessionPersister<SessionEvent = Event>,
-        Err: std::error::Error + Send,
+        Err: Send,
         CurrentState: Send,
         Event: Send,
     {


### PR DESCRIPTION
It is becoming clear that we need to ship an async persister trait alongside the blocking one to accommodate real developer needs. We've been discussing this in #816 and most recently this need came up again regarding the [LDK-node integration](https://github.com/orgs/payjoin/discussions/1234#discussioncomment-15277857).

This PR introduces the `AsyncSessionPersister` trait as an async counterpart to the synchronous `SessionPersister`, along with the `save_async` method for persisting state transition results.

Leaving as draft because the current approach makes no attempt to refactor any internal logic and is rather WET, but it gives us a foundation for the new API surface and async unit tests to validate it. Claude code wrote most of this copypasta (sloppypasta?).

It seems to me the DRYest approach will involve macros (see [lightning-macros](https://github.com/lightningdevkit/rust-lightning/blob/62c58495c3cbd47387962f31998899f6bbac8766/lightning-macros/src/lib.rs#L31) for some async macro examples). I'm not super thrilled about the prospect because `persist.rs` is already the most abstract part of the codebase, and while macros are cool they're not exactly easy to reason about. I'd like to get other opinions before going down a refactoring route cc @arminsabouri @nothingmuch @DanGould 

EDIT: we will also need to do this for the payjoin-ffi `JsonReceiver/SenderPersister`s which are not covered in this draft.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
