### PR TITLE
Update issue templates to include ohttp-relay

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-general.yml
+++ b/.github/ISSUE_TEMPLATE/bug-general.yml
@@ -30,6 +30,7 @@ body:
         - payjoin-directory
         - payjoin-test-utils
         - payjoin-ffi
+        - ohttp-relay
   - type: dropdown
     attributes:
       label: How did you obtain this crate?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -12,6 +12,7 @@ body:
         - payjoin-directory
         - payjoin-test-utils
         - payjoin-ffi
+        - ohttp-relay
   - type: textarea
     id: feature
     attributes:

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -11,6 +11,7 @@ body:
         - payjoin-directory
         - payjoin-test-utils
         - payjoin-ffi
+        - ohttp-relay
   - type: textarea
     id: question
     attributes:

--- a/.github/ISSUE_TEMPLATE/good-first-issue.yml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.yml
@@ -12,6 +12,7 @@ body:
         - payjoin-directory
         - payjoin-test-utils
         - payjoin-ffi
+        - ohttp-relay
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
With the ohttp-relay repo merged in we should include this in our issue templates for organization/

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
