### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1400,14 +1400,11 @@ pub mod test {
             state: unchecked_proposal_v2_from_test_vector(),
             session_context: SHARED_CONTEXT.clone(),
         };
-        let server_error = || {
-            receiver
-                .clone()
-                .check_broadcast_suitability(None, |_| Err("mock error".into()))
-                .save(&noop_persister)
-        };
-
-        let error = server_error().expect_err("Server error should be populated with mock error");
+        let error = receiver
+            .clone()
+            .check_broadcast_suitability(None, |_| Err("mock error".into()))
+            .save(&noop_persister)
+            .expect_err("Server error should be populated with mock error");
         let res = error.api_error().expect("check_broadcast error should propagate to api error");
         JsonReply::from(&res)
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -424,9 +424,10 @@ mod integration {
                 let proposal = proposal.assume_interactive_receiver().save(&persister)?;
 
                 // Generate replyable error
-                let check_inputs_not_owned =
-                    || proposal.clone().check_inputs_not_owned(&mut |_| Ok(true)).save(&persister);
-                let server_error = check_inputs_not_owned()
+                let server_error = proposal
+                    .clone()
+                    .check_inputs_not_owned(&mut |_| Ok(true))
+                    .save(&persister)
                     .expect_err("should fail")
                     .api_error()
                     .expect("expected api error");


### PR DESCRIPTION
[New clippy lint warnings](https://github.com/payjoin/rust-payjoin/actions/runs/20570885734/job/59077731325) popped up in a new nightly version.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
