### PR TITLE
Print reverse proxy reminder in v1 CLI

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -152,6 +152,12 @@ impl App {
             "Listening at {}. Configured to accept payjoin at BIP 21 Payjoin Uri:",
             listener.local_addr()?
         );
+
+        #[cfg(not(feature = "_manual-tls"))]
+        println!(
+            "Make sure to configure a reverse proxy to handle TLS termination for the listener"
+        );
+
         println!("{pj_uri_string}");
 
         let app = self.clone();


### PR DESCRIPTION
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

Closes https://github.com/payjoin/rust-payjoin/issues/1169.

A very quick PR on adding a print statement for when there is no manual TLS. In this case, the default listener needs to have a reverse proxy running to terminate TLS in v1.