### PR TITLE
Return error on duplicate input contribution

### DIFF
--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -403,6 +403,8 @@ pub struct InputContributionError(InternalInputContributionError);
 pub(crate) enum InternalInputContributionError {
     /// Total input value is not enough to cover additional output value
     ValueTooLow,
+    /// Duplicate input detected. The same outpoint is already present in the transaction
+    DuplicateInput(bitcoin::OutPoint),
 }
 
 impl fmt::Display for InputContributionError {
@@ -410,6 +412,8 @@ impl fmt::Display for InputContributionError {
         match &self.0 {
             InternalInputContributionError::ValueTooLow =>
                 write!(f, "Total input value is not enough to cover additional output value"),
+            InternalInputContributionError::DuplicateInput(outpoint) =>
+                write!(f, "Duplicate input detected: {outpoint}"),
         }
     }
 }
@@ -418,6 +422,7 @@ impl error::Error for InputContributionError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &self.0 {
             InternalInputContributionError::ValueTooLow => None,
+            InternalInputContributionError::DuplicateInput(_) => None,
         }
     }
 }


### PR DESCRIPTION
This is a followup to #1254 to address https://github.com/payjoin/rust-payjoin/pull/1254#issuecomment-3712897557
 > I fear this test is a silent error. Shouldn't contributing duplicate inputs cause error rather than continue and produce the same result with differing input?

Previously, contribute_inputs() filtered out duplicate inputs when the same outpoint was provided multiple times.
This PR makes it cause an error

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
