### PR TITLE
payjoin-cli: surface bitcoin RPC error instead of generic message

### DIFF
--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -184,7 +184,7 @@ impl BitcoindWallet {
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async { self.rpc.network().await })
         })
-        .map_err(|_| anyhow!("Failed to get blockchain info"))
+        .map_err(|e| anyhow!("Bitcoin RPC error: {}", e))
     }
 }
 


### PR DESCRIPTION
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>



Fixes #1258

This PR improves error handling in payjoin-cli by propagating the
underlying Bitcoin RPC error message instead of replacing it with
a generic error. This allows users to see actionable RPC errors
such as unloaded wallets.

AI Assistance Disclosure:
I used ChatGPT to understand the codebase and reason about the fix.
The implementation was written and reviewed manually.
