### PR TITLE
Support ipv6 in the ohttp nginx config template

### DIFF
--- a/ohttp-relay/nginx.conf.template
+++ b/ohttp-relay/nginx.conf.template
@@ -8,12 +8,14 @@ events {
 stream {
     server {
         listen {{http_port}};
+        listen [::]:{{http_port}};
 
         proxy_pass {{proxy_pass}};
     }
 
     server {
         listen {{https_port}} ssl;
+        listen [::]:{{https_port}} ssl;
 
         ssl_certificate {{cert_path}};
         ssl_certificate_key {{key_path}};
@@ -21,3 +23,4 @@ stream {
         proxy_pass {{proxy_pass}};
     }
 }
+


### PR DESCRIPTION
This PR addresses #1241. the previous nginx config template isn't ipv6 compatible. This pr introduces ipv6 support in the config file.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
