### PR TITLE
feat:use of tokio-listener in payjoin-directory

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1144,7 +1144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1165,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2046,6 +2055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2182,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2194,7 +2220,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2403,7 +2429,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "nix",
+ "nix 0.30.1",
  "payjoin",
  "payjoin-test-utils",
  "r2d2",
@@ -2440,6 +2466,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "tokio-listener",
  "tokio-rustls",
  "tokio-rustls-acme",
  "tokio-stream",
@@ -2552,6 +2579,26 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3721,6 +3768,24 @@ dependencies = [
  "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-listener"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a49c7295dbf705691c238002e4be940d5e0605f204683b1c8e55490032c79d"
+dependencies = [
+ "clap",
+ "document-features",
+ "futures-core",
+ "futures-util",
+ "nix 0.26.4",
+ "pin-project",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1144,7 +1144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1165,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2046,6 +2055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2182,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2194,7 +2220,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2403,7 +2429,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "nix",
+ "nix 0.30.1",
  "payjoin",
  "payjoin-test-utils",
  "r2d2",
@@ -2440,6 +2466,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "tokio-listener",
  "tokio-rustls",
  "tokio-rustls-acme",
  "tokio-stream",
@@ -2552,6 +2579,26 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3721,6 +3768,24 @@ dependencies = [
  "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-listener"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a49c7295dbf705691c238002e4be940d5e0605f204683b1c8e55490032c79d"
+dependencies = [
+ "clap",
+ "document-features",
+ "futures-core",
+ "futures-util",
+ "nix 0.26.4",
+ "pin-project",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/payjoin-directory/Cargo.toml
+++ b/payjoin-directory/Cargo.toml
@@ -36,6 +36,7 @@ prometheus = "0.13.4"
 rand = "0.8"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.47.1", features = ["full"] }
+tokio-listener = { version = "0.5", features = ["clap"] }
 tokio-rustls = { version = "0.26.2", features = [
   "ring",
 ], default-features = false, optional = true }

--- a/payjoin-directory/docker-compose.yml
+++ b/payjoin-directory/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       RUST_LOG: "trace"
       PJ_DB_HOST: "redis:6379"
-      PJ_DIR_PORT: "8080"
+      PJ_LISTEN_ADDR: "[::]:8080"
     depends_on:
       - redis
     networks:

--- a/payjoin-directory/src/cli.rs
+++ b/payjoin-directory/src/cli.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use clap::Parser;
+use tokio_listener::ListenerAddressLFlag;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -10,11 +11,11 @@ use clap::Parser;
     long_about = None,
 )]
 pub struct Cli {
-    #[arg(long, short = 'p', env = "PJ_DIR_PORT", help = "The port to bind [default: 8080]")]
-    pub port: Option<u16>, // TODO tokio_listener::ListenerAddressLFlag
+    #[clap(flatten)]
+    pub listen: ListenerAddressLFlag,
 
-    #[arg(long, env = "PJ_METRIC_PORT", help = "The port to bind for prometheus metrics export")]
-    pub metrics_port: Option<u16>, // TODO tokio_listener::ListenerAddressLFlag
+    #[arg(long = "metrics-listen-addr")]
+    pub metrics_listen_addr: Option<String>,
 
     #[cfg(feature = "acme")]
     #[clap(flatten)]


### PR DESCRIPTION
Have used tokio-listener, --listen-addr instead of --port in payjoin-directory as part of #941 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
