### PR TITLE
Change GitHub token for flake maintenance workflow

### DIFF
--- a/.github/workflows/flake-maintenance.yml
+++ b/.github/workflows/flake-maintenance.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           pr-title: "chore: update flake.lock"
           commit-msg: "chore: update flake.lock"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           nix-options: --offline


### PR DESCRIPTION
Instead of using the default read-only GITHUB_TOKEN, use the newly created GH_TOKEN_FOR_UPDATES [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) which has "create PR" permissions on the repo.
