### PR TITLE
Add library package to have missing packages available at runtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,6 +207,7 @@
                 rust-analyzer
                 dart
                 cargo-fuzz
+                bzip2 # needed for some machines to have access to libzip at runtime
               ]
               ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
                 cargo-llvm-cov


### PR DESCRIPTION
There has been a regression where corepc-node needs libbz2.so.1.0 but it is not compiled at runtime. This commit explicitly adds bzip2 to the package list to allow corepc-node to compile.

This regression is not easily reproduce-able as it is not happening in all environments.

~~Chatgpt read through the cranelib docs to show me where to put this instead of alongside packages as a LD_LIBRARY_PATH which accomplishes the same thing but I think the syntax of just adding it to the package list instead of a library path env variable is simple enough still.~~ I ended up not using this approach

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
