### PR TITLE
Expose async persistence in FFI

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2658,6 +2658,7 @@ dependencies = [
 name = "payjoin-ffi"
 version = "0.24.0"
 dependencies = [
+ "async-trait",
  "bdk",
  "bitcoin-ohttp",
  "getrandom 0.2.15",
@@ -4432,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "uniffi-dart"
 version = "0.1.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=5bdcc79#5bdcc790c3fc99845e7b4a61d7a4f6e1460896e9"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=f830323#f830323646fb6fbca89f9798dcf425f339f166ca"
 dependencies = [
  "anyhow",
  "camino",
@@ -4502,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "uniffi_dart_macro"
 version = "0.1.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=5bdcc79#5bdcc790c3fc99845e7b4a61d7a4f6e1460896e9"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=f830323#f830323646fb6fbca89f9798dcf425f339f166ca"
 dependencies = [
  "futures",
  "proc-macro2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2658,6 +2658,7 @@ dependencies = [
 name = "payjoin-ffi"
 version = "0.24.0"
 dependencies = [
+ "async-trait",
  "bdk",
  "bitcoin-ohttp",
  "getrandom 0.2.15",
@@ -4432,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "uniffi-dart"
 version = "0.1.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=5bdcc79#5bdcc790c3fc99845e7b4a61d7a4f6e1460896e9"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=f830323#f830323646fb6fbca89f9798dcf425f339f166ca"
 dependencies = [
  "anyhow",
  "camino",
@@ -4502,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "uniffi_dart_macro"
 version = "0.1.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=5bdcc79#5bdcc790c3fc99845e7b4a61d7a4f6e1460896e9"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=f830323#f830323646fb6fbca89f9798dcf425f339f166ca"
 dependencies = [
  "futures",
  "proc-macro2",

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -22,6 +22,7 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
+async-trait = "0.1"
 getrandom = "0.2"
 lazy_static = "1.5.0"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
@@ -32,7 +33,7 @@ serde_json = "1.0.142"
 thiserror = "2.0.14"
 tokio = { version = "1.47.1", features = ["full"], optional = true }
 uniffi = { version = "0.30.0", features = ["cli"] }
-uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", rev = "5bdcc79", optional = true }
+uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", rev = "f830323", optional = true }
 url = "2.5.4"
 
 # getrandom is ignored here because it's required by the wasm_js feature

--- a/payjoin-ffi/javascript/package-lock.json
+++ b/payjoin-ffi/javascript/package-lock.json
@@ -588,7 +588,7 @@
         },
         "node_modules/uniffi-bindgen-react-native": {
             "version": "0.29.3-1",
-            "resolved": "git+ssh://git@github.com/spacebear21/uniffi-bindgen-react-native.git#723c0c77c45db1eb74e832a8814e4ac36d07fc28",
+            "resolved": "git+ssh://git@github.com/spacebear21/uniffi-bindgen-react-native.git#e2225d22d9e3246057abba59cc8ca24a038ba01c",
             "dev": true,
             "license": "MPL-2.0",
             "bin": {

--- a/payjoin-ffi/javascript/test/unit.test.ts
+++ b/payjoin-ffi/javascript/test/unit.test.ts
@@ -54,6 +54,54 @@ class InMemorySenderPersister {
     }
 }
 
+class InMemoryReceiverPersisterAsync {
+    id: number;
+    events: any[];
+    closed: boolean;
+
+    constructor(id: number) {
+        this.id = id;
+        this.events = [];
+        this.closed = false;
+    }
+
+    async save(event: any): Promise<void> {
+        this.events.push(event);
+    }
+
+    async load(): Promise<any[]> {
+        return this.events;
+    }
+
+    async close(): Promise<void> {
+        this.closed = true;
+    }
+}
+
+class InMemorySenderPersisterAsync {
+    id: number;
+    events: any[];
+    closed: boolean;
+
+    constructor(id: number) {
+        this.id = id;
+        this.events = [];
+        this.closed = false;
+    }
+
+    async save(event: any): Promise<void> {
+        this.events.push(event);
+    }
+
+    async load(): Promise<any[]> {
+        return this.events;
+    }
+
+    async close(): Promise<void> {
+        this.closed = true;
+    }
+}
+
 describe("URI tests", () => {
     test("URL encoded payjoin parameter", () => {
         const uri =
@@ -167,6 +215,76 @@ describe("Persistence tests", () => {
         const withReplyKey = new payjoin.SenderBuilder(psbt, uri)
             .buildRecommended(BigInt(1000))
             .save(senderPersister);
+
+        assert.ok(withReplyKey, "Sender should be created successfully");
+    });
+});
+
+describe("Async Persistence tests", () => {
+    test("receiver async persistence", async () => {
+        const persister = new InMemoryReceiverPersisterAsync(1);
+        const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+        const ohttpKeys = payjoin.OhttpKeys.decode(
+            new Uint8Array([
+                0x01, 0x00, 0x16, 0x04, 0xba, 0x48, 0xc4, 0x9c, 0x3d, 0x4a,
+                0x92, 0xa3, 0xad, 0x00, 0xec, 0xc6, 0x3a, 0x02, 0x4d, 0xa1,
+                0x0c, 0xed, 0x02, 0x18, 0x0c, 0x73, 0xec, 0x12, 0xd8, 0xa7,
+                0xad, 0x2c, 0xc9, 0x1b, 0xb4, 0x83, 0x82, 0x4f, 0xe2, 0xbe,
+                0xe8, 0xd2, 0x8b, 0xfe, 0x2e, 0xb2, 0xfc, 0x64, 0x53, 0xbc,
+                0x4d, 0x31, 0xcd, 0x85, 0x1e, 0x8a, 0x65, 0x40, 0xe8, 0x6c,
+                0x53, 0x82, 0xaf, 0x58, 0x8d, 0x37, 0x09, 0x57, 0x00, 0x04,
+                0x00, 0x01, 0x00, 0x03,
+            ]).buffer,
+        );
+
+        const builder = new payjoin.ReceiverBuilder(
+            address,
+            "https://example.com",
+            ohttpKeys,
+        );
+        await builder.build().saveAsync(persister);
+
+        const result = await payjoin.replayReceiverEventLogAsync(persister);
+        const state = result.state();
+
+        assert.strictEqual(
+            state.tag,
+            "Initialized",
+            "State should be Initialized",
+        );
+    });
+
+    test("sender async persistence", async () => {
+        const persister = new InMemoryReceiverPersisterAsync(1);
+        const address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
+        const ohttpKeys = payjoin.OhttpKeys.decode(
+            new Uint8Array([
+                0x01, 0x00, 0x16, 0x04, 0xba, 0x48, 0xc4, 0x9c, 0x3d, 0x4a,
+                0x92, 0xa3, 0xad, 0x00, 0xec, 0xc6, 0x3a, 0x02, 0x4d, 0xa1,
+                0x0c, 0xed, 0x02, 0x18, 0x0c, 0x73, 0xec, 0x12, 0xd8, 0xa7,
+                0xad, 0x2c, 0xc9, 0x1b, 0xb4, 0x83, 0x82, 0x4f, 0xe2, 0xbe,
+                0xe8, 0xd2, 0x8b, 0xfe, 0x2e, 0xb2, 0xfc, 0x64, 0x53, 0xbc,
+                0x4d, 0x31, 0xcd, 0x85, 0x1e, 0x8a, 0x65, 0x40, 0xe8, 0x6c,
+                0x53, 0x82, 0xaf, 0x58, 0x8d, 0x37, 0x09, 0x57, 0x00, 0x04,
+                0x00, 0x01, 0x00, 0x03,
+            ]).buffer,
+        );
+
+        const receiver = await new payjoin.ReceiverBuilder(
+            address,
+            "https://example.com",
+            ohttpKeys,
+        )
+            .build()
+            .saveAsync(persister);
+        const uri = receiver.pjUri();
+
+        const senderPersister = new InMemorySenderPersisterAsync(1);
+        const psbt =
+            "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+        const withReplyKey = await new payjoin.SenderBuilder(psbt, uri)
+            .buildRecommended(BigInt(1000))
+            .saveAsync(senderPersister);
 
         assert.ok(withReplyKey, "Sender should be created successfully");
     });

--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -48,22 +48,6 @@ class InMemoryReceiverPersister(payjoin.JsonReceiverSessionPersister):
         self.closed = True
 
 
-class TestReceiverPersistence(unittest.TestCase):
-    def test_receiver_persistence(self):
-        persister = InMemoryReceiverPersister(1)
-        payjoin.ReceiverBuilder(
-            "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
-            "https://example.com",
-            payjoin.OhttpKeys.decode(
-                bytes.fromhex(
-                    "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003"
-                )
-            ),
-        ).build().save(persister)
-        result = payjoin.replay_receiver_event_log(persister)
-        self.assertTrue(result.state().is_INITIALIZED())
-
-
 class InMemorySenderPersister(payjoin.JsonSenderSessionPersister):
     def __init__(self, id):
         self.id = id
@@ -78,6 +62,54 @@ class InMemorySenderPersister(payjoin.JsonSenderSessionPersister):
 
     def close(self):
         self.closed = True
+
+
+class InMemoryReceiverPersisterAsync(payjoin.JsonReceiverSessionPersisterAsync):
+    def __init__(self, id):
+        self.id = id
+        self.events = []
+        self.closed = False
+
+    async def save(self, event: str):
+        self.events.append(event)
+
+    async def load(self):
+        return self.events
+
+    async def close(self):
+        self.closed = True
+
+
+class InMemorySenderPersisterAsync(payjoin.JsonSenderSessionPersisterAsync):
+    def __init__(self, id):
+        self.id = id
+        self.events = []
+        self.closed = False
+
+    async def save(self, event: str):
+        self.events.append(event)
+
+    async def load(self):
+        return self.events
+
+    async def close(self):
+        self.closed = True
+
+
+class TestReceiverPersistence(unittest.TestCase):
+    def test_receiver_persistence(self):
+        persister = InMemoryReceiverPersister(1)
+        payjoin.ReceiverBuilder(
+            "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+            "https://example.com",
+            payjoin.OhttpKeys.decode(
+                bytes.fromhex(
+                    "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003"
+                )
+            ),
+        ).build().save(persister)
+        result = payjoin.replay_receiver_event_log(persister)
+        self.assertTrue(result.state().is_INITIALIZED())
 
 
 class TestSenderPersistence(unittest.TestCase):
@@ -104,6 +136,64 @@ class TestSenderPersistence(unittest.TestCase):
         with_reply_key = (
             payjoin.SenderBuilder(psbt, uri).build_recommended(1000).save(persister)
         )
+
+
+class TestReceiverAsyncPersistence(unittest.TestCase):
+    def test_receiver_async_persistence(self):
+        import asyncio
+
+        async def run_test():
+            persister = InMemoryReceiverPersisterAsync(1)
+            await (
+                payjoin.ReceiverBuilder(
+                    "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+                    "https://example.com",
+                    payjoin.OhttpKeys.decode(
+                        bytes.fromhex(
+                            "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003"
+                        )
+                    ),
+                )
+                .build()
+                .save_async(persister)
+            )
+            result = await payjoin.replay_receiver_event_log_async(persister)
+            self.assertTrue(result.state().is_INITIALIZED())
+
+        asyncio.run(run_test())
+
+
+class TestSenderAsyncPersistence(unittest.TestCase):
+    def test_sender_async_persistence(self):
+        import asyncio
+
+        async def run_test():
+            # Create a receiver to just get the pj uri
+            persister = InMemoryReceiverPersisterAsync(1)
+            receiver = await (
+                payjoin.ReceiverBuilder(
+                    "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
+                    "https://example.com",
+                    payjoin.OhttpKeys.decode(
+                        bytes.fromhex(
+                            "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003"
+                        )
+                    ),
+                )
+                .build()
+                .save_async(persister)
+            )
+            uri = receiver.pj_uri()
+
+            persister = InMemorySenderPersisterAsync(1)
+            psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA="
+            with_reply_key = await (
+                payjoin.SenderBuilder(psbt, uri)
+                .build_recommended(1000)
+                .save_async(persister)
+            )
+
+        asyncio.run(run_test())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This exposes the async persistence methods in payjoin-ffi and accompanying unit tests in downstream languages.

I wanted to address https://github.com/payjoin/rust-payjoin/issues/1199 so that we wouldn't duplicate all the hardcoded test values so much, but it turned out to be more involved than I anticipated (see my comment on that issue).

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
