### PR TITLE
Upgrade wheel to 0.46.3

### DIFF
--- a/payjoin-ffi/python/pyproject.toml
+++ b/payjoin-ffi/python/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "semantic-version==2.9.0",
   "setuptools==78.1.1",
   "typing-extensions==4.0.1",
-  "wheel==0.38.4",
+  "wheel==0.46.3",
   "httpx==0.28.1",
 ]
 


### PR DESCRIPTION
This fixes a vulnerability reported by Dependabot.