### PR TITLE
Rename crane profile to nix-ci and use for checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ payjoin = { path = "payjoin" }
 payjoin-mailroom = { path = "payjoin-mailroom" }
 payjoin-test-utils = { path = "payjoin-test-utils" }
 
-[profile.crane]
+[profile.nix-ci]
 inherits = "test"
 debug = false

--- a/flake.nix
+++ b/flake.nix
@@ -132,10 +132,6 @@
           inherit src;
           strictDeps = true;
 
-          # avoid release builds throughout for faster feedback from checks
-          # note that this also affects the built packages
-          CARGO_PROFILE = "crane";
-
           # provide fallback name & version for workspace related derivations
           # this is mainly to silence warnings from crane about providing a stub
           # value overridden in per-crate packages with info from Cargo.toml
@@ -154,12 +150,31 @@
             cargoVendorDir = vendoredDeps.${name};
           };
 
+        # use nix-ci profile for fast checks
+        ciArgsFor =
+          name:
+          commonArgsFor name
+          // {
+            CARGO_PROFILE = "nix-ci";
+          };
+
         cargoArtifacts = builtins.mapAttrs (
           name: craneLib:
           craneLib.buildDepsOnly (
             commonArgsFor name
             // {
               name = "workspace-deps-${name}";
+              cargoLock = cargoLock.${name};
+            }
+          )
+        ) craneLibVersions;
+        # use nix-ci profile for cargo artifacts
+        cargoArtifactsCi = builtins.mapAttrs (
+          name: craneLib:
+          craneLib.buildDepsOnly (
+            ciArgsFor name
+            // {
+              name = "workspace-deps-ci-${name}";
               cargoLock = cargoLock.${name};
             }
           )
@@ -345,16 +360,15 @@
         };
         formatter = treefmtEval.config.build.wrapper;
         checks =
-          packages
-          // (pkgs.lib.mapAttrs' (
+          (pkgs.lib.mapAttrs' (
             name: craneLib:
             (pkgs.lib.nameValuePair "payjoin-workspace-nextest-${name}" (
               craneLib.cargoNextest (
-                commonArgsFor name
+                ciArgsFor name
                 // {
                   name = "payjoin-workspace-nextest-${name}";
                   cargoLock = cargoLock.${name};
-                  cargoArtifacts = cargoArtifacts.${name};
+                  cargoArtifacts = cargoArtifactsCi.${name};
                   partitions = 1;
                   partitionType = "count";
                   cargoExtraArgs = "--locked --workspace --all-features --exclude payjoin-fuzz";
@@ -370,11 +384,11 @@
           )
           // {
             payjoin-workspace-machete = craneLibVersions.nightly.mkCargoDerivation (
-              commonArgsFor "nightly"
+              ciArgsFor "nightly"
               // {
                 pname = "payjoin-workspace-machete";
                 cargoLock = cargoLock.nightly;
-                cargoArtifacts = cargoArtifacts.nightly;
+                cargoArtifacts = cargoArtifactsCi.nightly;
                 nativeBuildInputs = [ pkgs.cargo-machete ];
                 buildPhaseCargoCommand = "";
                 checkPhaseCargoCommand = "cargo machete";
@@ -383,24 +397,24 @@
             );
 
             payjoin-workspace-clippy = craneLibVersions.nightly.cargoClippy (
-              commonArgsFor "nightly"
+              ciArgsFor "nightly"
               // {
                 cargoLock = cargoLock.nightly;
-                cargoArtifacts = cargoArtifacts.nightly;
+                cargoArtifacts = cargoArtifactsCi.nightly;
                 cargoClippyExtraArgs = "--all-targets --all-features --keep-going -- --deny warnings";
               }
             );
 
             payjoin-workspace-doc = craneLibVersions.nightly.cargoDoc (
-              commonArgsFor "nightly"
+              ciArgsFor "nightly"
               // {
                 cargoLock = cargoLock.nightly;
-                cargoArtifacts = cargoArtifacts.nightly;
+                cargoArtifacts = cargoArtifactsCi.nightly;
               }
             );
 
             payjoin-workspace-fmt = craneLibVersions.nightly.cargoFmt (
-              commonArgsFor "nightly"
+              ciArgsFor "nightly"
               // {
                 inherit src;
                 # cargoLock = cargoLock.nightly;
@@ -444,7 +458,17 @@
               [
                 payjoin-workspace-nextest-msrv
               ]
-              ++ pkgs.lib.attrValues packages
+              ++ pkgs.lib.attrValues (
+                builtins.mapAttrs (
+                  _name: pkg:
+                  pkg.overrideAttrs (
+                    final: prev: {
+                      CARGO_PROFILE = "nix-ci";
+                      cargoArtifacts = cargoArtifactsCi.msrv;
+                    }
+                  )
+                ) packages
+              )
             );
 
             maintenance = checkSuite "maintenance" (


### PR DESCRIPTION
This PR closes https://github.com/payjoin/rust-payjoin/issues/1290

As stated in the issue this PR renames [profile.crane] to [profile.nix-ci] in Cargo.toml for clarity. 

ciArgs,cargoArtifactsCi where added they use nix-ci profile for checks which are used in CI so they are fast

releaseArgs which use release profile is added so build packages are highly optimized and ready for production use.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
