### PR TITLE
Add safe catch-all for secp256k1::Error conversion in HpkeError

### DIFF
--- a/payjoin/src/core/hpke.rs
+++ b/payjoin/src/core/hpke.rs
@@ -277,6 +277,7 @@ pub enum HpkeError {
     InvalidKeyLength,
     PayloadTooLarge { actual: usize, max: usize },
     PayloadTooShort,
+    UnexpectedSecp256k1Error,
 }
 
 impl From<hpke::HpkeError> for HpkeError {
@@ -286,10 +287,11 @@ impl From<hpke::HpkeError> for HpkeError {
 impl From<secp256k1::Error> for HpkeError {
     fn from(value: secp256k1::Error) -> Self {
         match value {
-            // As of writing, this is the only relevant variant that could arise here.
-            // This may need to be updated if relevant variants are added to secp256k1
+            // As of writing, this is the only relevant variant that could arise here. The other variant has
+            // been added due to new secp256k1::Error variants that may be added in the future. update this
+            // match statement if relevant error variants that are needed are added to secp256k1
             secp256k1::Error::InvalidPublicKey => Self::InvalidPublicKey,
-            _ => panic!("Unsupported variant of secp256k1::Error"),
+            _other => Self::UnexpectedSecp256k1Error,
         }
     }
 }
@@ -309,6 +311,7 @@ impl fmt::Display for HpkeError {
             }
             PayloadTooShort => write!(f, "Payload too small"),
             InvalidPublicKey => write!(f, "Invalid public key"),
+            UnexpectedSecp256k1Error => write!(f, "Unexpected secp256k1 error"),
         }
     }
 }
@@ -322,6 +325,7 @@ impl error::Error for HpkeError {
             PayloadTooLarge { .. } => None,
             InvalidKeyLength | PayloadTooShort => None,
             InvalidPublicKey => None,
+            UnexpectedSecp256k1Error => None,
         }
     }
 }
@@ -329,6 +333,25 @@ impl error::Error for HpkeError {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn secp256k1_error_conversion_no_panic() {
+        // Test the known variant that maps to InvalidPublicKey(update if new variants are added)
+        let err = secp256k1::Error::InvalidPublicKey;
+        let hpke_err: HpkeError = err.into();
+        assert_eq!(hpke_err, HpkeError::InvalidPublicKey);
+        // Test other variants that may arise
+        let other_variants = [
+            secp256k1::Error::InvalidSecretKey,
+            secp256k1::Error::InvalidRecoveryId,
+            secp256k1::Error::InvalidTweak,
+            secp256k1::Error::NotEnoughMemory,
+        ];
+        for err in other_variants {
+            let hpke_err: HpkeError = err.into();
+            assert_eq!(hpke_err, HpkeError::UnexpectedSecp256k1Error);
+        }
+    }
 
     #[test]
     fn message_a_round_trip() {


### PR DESCRIPTION
Closes: https://github.com/payjoin/rust-payjoin/issues/1274

Replace panic with a match to Other(String)  to handle unknown secp256k1 error variants. This prevents crashes for unknown varients and if new variants are added upstream.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
