### PR TITLE
Fix failing cargo machete check

### DIFF
--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,3 +32,7 @@ time = "=0.3.45"
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+
+# time is a transient dependency, but needs to be specified explicitly to pin the version for MSRV
+[package.metadata.cargo-machete]
+ignored = ["time"]


### PR DESCRIPTION
#1302 auto-merged despite failing checks, which is apparently how Github rolls, so this PR fixes the failing check.