### PR TITLE
DRAFT: commit service docker-compose

### DIFF
--- a/payjoin-service/docker-compose.yml
+++ b/payjoin-service/docker-compose.yml
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 version: '3.8'
 
 services:
@@ -61,3 +62,31 @@ networks:
 
 volumes:
   redis-data:
+||||||| Stash base
+=======
+version: "3.8"
+
+services:
+  payjoin-directory:
+    image: benalleng/payjoin-service:e060a78
+    command: ["--config", "/config/config.toml"]
+    environment:
+      RUST_LOG: "info"
+    volumes:
+      - ./config.toml:/config/config.toml:ro
+      - ./data:/data
+      - ./acme:/acme
+    ports:
+      - "443:443"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500m"
+        max-file: "10"
+    networks:
+      - payjoin-network
+
+networks:
+  payjoin-network:
+
+>>>>>>> Stashed changes


### PR DESCRIPTION
This still includes redis because this is what's running at the moment. When we commit we want to get rid of this. And probably nginx too.

ai to search and set envvars. We may not ever even need this because we won't need certbot, nginx, and redis. Perhaps we'll merge it when it's got just the container config & some sane environment variable defaults.

TBH we may just never commit this after this discussion.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
