### PR TITLE
Add nix2container workflows for creating payjoin-service docker images

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,32 @@
+name: "Build and publish Docker image"
+
+on:
+  push:
+    tags:
+      - payjoin-service-**
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "Build and publish Docker image"
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PAYJOIN_DOCKER_RW }}
+
+      - name: Build and release image
+        run: nix run .#packages.x86_64-linux.payjoin-service-image.copyToRegistry

--- a/flake.nix
+++ b/flake.nix
@@ -175,7 +175,8 @@
             releasePkg = pkg.overrideAttrs (final: prev: { CARGO_PROFILE = "release"; });
           in
           nix2containerPkgs.nix2container.buildImage {
-            inherit name tag;
+            inherit tag;
+            name = "docker.io/payjoin/${name}";
             copyToRoot = pkgs.buildEnv {
               name = "root";
               paths = [ releasePkg ];


### PR DESCRIPTION
This is a draft to explore the use of nix2container as our workflow docker deployment mechanism. At the moment I am hand deploying docker images to my personal docker hub when requested but ideally I don't want to do that.

If we can get this working I expect it will be our onestop shop for all things we would want to be a docker image. This should be able to close #1244 unless we feel like we also want to have a separate image for ohttp-relay and payjoin-directory before payjoin-service is completely fleshed out.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
