### PR TITLE
Allow container images for pull requests in fork branches

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,14 +1,18 @@
 name: "Build and publish Docker image"
 
 on:
+  pull_request:
+    paths:
+      - payjoin-service/**
   push:
     tags:
       - payjoin-service-**
   workflow_dispatch:
 
 jobs:
-  build:
+  publish:
     name: "Build and publish Docker image"
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -30,3 +34,38 @@ jobs:
 
       - name: Build and release image
         run: nix run .#packages.x86_64-linux.payjoin-service-image.copyToRegistry
+
+  build-pr:
+    name: "Build and upload image artifact"
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build and save image artifact
+        run: |
+          TAG=$(git rev-parse --short HEAD)
+
+          nix build .#packages.x86_64-linux.payjoin-service-image.copyToDockerDaemon
+          result/bin/copy-to-docker-daemon
+            
+          docker save docker.io/payjoin/payjoin-service:${TAG} -o payjoin-service-${TAG}.tar
+
+          echo "Image saved: payjoin-service-${TAG}.tar"
+          ls -lh payjoin-service-${TAG}.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: payjoin-service-image-${{ github.sha }}
+          path: payjoin-service-*.tar
+          retention-days: 7


### PR DESCRIPTION
This adds support for creating images and saving them as artifacts when opening a PR while retaining support for the payjoin dockerhub images on pushed tags for payjoin-service

~~Claude helped me find out the missing piece that is `--impure` to allow env vars in the flake~~ no longer needed with local only docker

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
