### PR TITLE
Add AGENTS.md for AI and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+For the full human guide see [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md).
+
+Nightly Rust toolchain (`rust-toolchain.toml`) — required for `cargo fmt`
+unstable options.
+
+## Commit Rules
+
+Every commit must pass CI independently.
+
+Commit messages follow the seven rules:
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
+
+## Pre-commit Checks (Tiered)
+
+**Fast (every commit):**
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --all-targets --keep-going --all-features -- -D warnings
+codespell
+```
+
+**Full (before push):**
+
+```sh
+./contrib/lint.sh
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features \
+  --document-private-items
+./contrib/test_local.sh            # does NOT include payjoin-mailroom
+npx prettier --check '**/*.md'     # CI runs prettier via treefmt
+codespell
+```
+
+Per-crate scripts: `{crate}/contrib/test.sh`, `{crate}/contrib/lint.sh`.
+
+## Two Lockfiles
+
+CI tests both `Cargo-minimal.lock` and `Cargo-recent.lock`. After any
+dependency change:
+
+```sh
+bash contrib/update-lock-files.sh
+```
+
+## AI Disclosure
+
+Required in PR body. Do **not** add `Co-Authored-By` in commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with only repo-specific information that is hard to discover from source files alone
- Symlink `CLAUDE.md` → `AGENTS.md` so Claude Code loads it automatically each session
- Defines a fast tier (fmt + clippy, seconds) and full tier (lint + doc + tests, minutes) so agents use discretion on intermediate commits
- Kept minimal per findings in [Do Context Files Help LLM Agents Solve Software Engineering Tasks?](https://arxiv.org/abs/2602.11988) — detailed overviews and discoverable info hurt more than they help

## AI Assistance Disclosure
This PR was authored with Claude Code (Claude Opus 4.6).

## Test plan
- [x] Verify `CLAUDE.md` symlink resolves correctly (`cat CLAUDE.md` shows AGENTS.md content)
- [x] Confirm CI passes (no code changes, just new markdown)
- [x] Start a new Claude Code session in the repo and verify AGENTS.md content appears in context