### PR TITLE
Clear V1 payload from memory after first read

### DIFF
--- a/payjoin-directory/src/db/mod.rs
+++ b/payjoin-directory/src/db/mod.rs
@@ -16,6 +16,7 @@ pub enum Error<OperationalError: SendableError> {
     Operational(OperationalError),
     Timeout(tokio::time::error::Elapsed),
     OverCapacity,
+    AlreadyRead,
     V1SenderUnavailable,
 }
 
@@ -33,6 +34,7 @@ impl<E: SendableError> std::fmt::Display for Error<E> {
             Operational(error) => write!(f, "Db error: {error}"),
             Timeout(timeout) => write!(f, "Timeout: {timeout}"),
             OverCapacity => "Database over capacity".fmt(f),
+            AlreadyRead => "Mailbox payload already read".fmt(f),
             V1SenderUnavailable => "Sender no longer connected".fmt(f),
         }
     }

--- a/payjoin-directory/src/lib.rs
+++ b/payjoin-directory/src/lib.rs
@@ -453,6 +453,7 @@ fn handle_peek<Error: db::SendableError>(
             db::Error::OverCapacity => Err(HandlerError::ServiceUnavailable(anyhow::Error::msg(
                 "mailbox storage at capacity",
             ))),
+            db::Error::AlreadyRead => Ok(timeout_response),
             db::Error::V1SenderUnavailable => Err(HandlerError::SenderGone(anyhow::Error::msg(
                 "Sender is unavailable try a new request",
             ))),


### PR DESCRIPTION
## Summary
- Wraps V1 `payload` in `Option<Arc<Vec<u8>>>` so it can be `.take()`n after the first read, clearing plaintext PSBT data from memory
- Adds `AlreadyRead` error variant to distinguish consumed payloads from capacity conflicts
- Adds `test_v1_data_minimization` unit test verifying second read returns `AlreadyRead`

## Test plan
- [x] `cargo test -p payjoin-directory --features v1 --lib` passes (14 tests)
- [x] CI passes

> This PR was developed with AI assistance (Claude)