### PR TITLE
Add new ignores in codespell for local runs

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,target,Cargo.toml,Cargo.lock,Cargo-minimal.lock,Cargo-recent.lock,package-lock.json
-ignore-words-list = crate,ser,ot
+skip = .git,target,Cargo.toml,Cargo.lock,Cargo-minimal.lock,Cargo-recent.lock,package-lock.json,./fuzz/corpus
+ignore-words-list = crate,ser,ot,re-useable


### PR DESCRIPTION
Running codespell brought up a bunch of catches on the fuzz corpus and on autogenerated python code. This fix is mostly as a way to reduce the confusion for the agents now running codespell locally as a dev may have an existing corpus and built python code
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
