### PR TITLE
Use nix fmt instead of treefmt in devshell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ codespell
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features \
   --document-private-items
 ./contrib/test_local.sh
-treefmt --ci                       # prettier, taplo, nixfmt, shellcheck, shfmt
+nix fmt -- --ci
 codespell
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -211,7 +211,6 @@
                 cargo-fuzz
                 bzip2 # needed for some machines to have access to libzip at runtime
                 codespell
-                treefmtEval.config.build.wrapper
               ]
               ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
                 cargo-llvm-cov


### PR DESCRIPTION
The agents should be able to access the treeformatter without directly needing it in the deps through the use of `nix fmt -- --ci`

Thanks to @nothingmuch for keeping us honest with this one. I definitely haven't flexed the AI code review side of my brain enough...

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
