### PR TITLE
Pin wasm-bindgen-cli to 0.2.108

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -37,8 +37,9 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install llvm
 
+      # 0.2.109+ requires rustc 1.88 (via time crate).
       - name: Install wasm-bindgen
-        run: cargo install --locked wasm-bindgen-cli
+        run: cargo install --locked wasm-bindgen-cli --version 0.2.108
 
       - name: "Install dependencies"
         run: npm ci

--- a/payjoin-ffi/javascript/wasm-manifest-patch.toml
+++ b/payjoin-ffi/javascript/wasm-manifest-patch.toml
@@ -3,6 +3,12 @@
 # Because that generated crate doesn't belong to the `payjoin` workspace, we need to patch the generated Cargo.toml accordingly for local development.
 # The patch is applied via the ubrn.config.yaml `manifestPatchFile` option.
 # The paths below are relative to payjoin-ffi/javascript/rust_modules/wasm/Cargo.toml
+[dependencies]
+# Pin wasm-bindgen to match the CLI version in .github/workflows/javascript.yml.
+# The generated template uses "*", which resolves to latest. A mismatch between
+# the library and CLI versions causes "unreachable" panics at runtime.
+wasm-bindgen = "=0.2.108"
+
 [patch.crates-io]
 payjoin = { path = "../../../../payjoin" }
 payjoin-directory = { path = "../../../../payjoin-directory" }


### PR DESCRIPTION
Fixes JS CI which [broke](https://github.com/payjoin/rust-payjoin/actions/runs/22244027450/job/64354004677) with the latest wasm-bindgen release earlier today.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
