### PR TITLE
Add navigability signposts for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ mutants.out*
 *.ikm
 *payjoin.sqlite
 data
+.claude/
+.direnv/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ unstable options.
 
 Tools are provided by nix via direnv. Do not install tools globally.
 If you need a new tool, add it to the devshell in `flake.nix` so
-others can reproduce.
+others can reproduce. rust-analyzer LSP is available for navigation
+(go-to-definition, find-references, hover) — prefer it over grepping.
 
 ## Commit Rules
 
@@ -56,6 +57,28 @@ dependency change:
 ```sh
 bash contrib/update-lock-files.sh
 ```
+
+## Spec-code mapping
+
+| Spec section            | Code location                                                    |
+| ----------------------- | ---------------------------------------------------------------- |
+| BIP 77 sender flow      | `payjoin/src/core/send/v2/mod.rs`                                |
+| BIP 77 receiver flow    | `payjoin/src/core/receive/v2/mod.rs`                             |
+| BIP 77 directory        | `payjoin-directory/src/lib.rs` `handle_decapsulated_request()`   |
+| BIP 78 sender checklist | `payjoin/src/core/send/mod.rs` `PsbtContext::process_proposal()` |
+| BIP 78 receiver checks  | `payjoin/src/core/receive/mod.rs` `OriginalPayload` methods      |
+| OHTTP (RFC 9458)        | `payjoin/src/core/ohttp.rs`                                      |
+
+## Non-obvious things
+
+- `payjoin/src/lib.rs` re-exports all of `src/core/` — the `core`
+  module is the entire implementation but is `pub(crate)`.
+- `receive::v2` types wrap `receive::common` via `.inner`; all PSBT
+  logic lives in `common/`.
+- Relay vs directory routing lives in `payjoin-mailroom`, not in
+  either sub-crate.
+- V1 proposals through V2 directories MUST disable output substitution
+  (enforced in `receive::v2::unchecked_from_payload()`).
 
 ## AI Disclosure
 

--- a/payjoin/src/core/ohttp.rs
+++ b/payjoin/src/core/ohttp.rs
@@ -1,3 +1,8 @@
+//! OHTTP encapsulation (RFC 9458) for v2 communication.
+//!
+//! The relay (ohttp-relay) sees client IPs but not content; the gateway
+//! (inside payjoin-directory) sees content but not IPs.
+
 use std::ops::{Deref, DerefMut};
 use std::{error, fmt};
 

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -1,3 +1,9 @@
+//! Session persistence for the typestate protocol.
+//!
+//! Protocol methods that advance state return a transition type from
+//! this module. Call `.save(&persister)` to persist the session event
+//! and extract the next state.
+
 use std::fmt;
 
 /// Representation of the actions that the persister should take, if any.


### PR DESCRIPTION
Really testing the waters here between what gets committed and what's just local. I'm erring on the side of sharing because I think this is gonna be new workflow we're all going to need to learn.

## Summary

- Inline AGENTS.md spec-code mapping table and
  non-obvious structural decisions
- Add module docs to `persist.rs` and `ohttp.rs`
- Note LSP availability in AGENTS.md tooling section
- Gitignore `.claude/`, `.direnv/`, `__pycache__/`

Signposts target the gaps between what LSP can tell an
agent (type info, definitions, references) and what only
a human knows (which BIP section maps where, why the
crate topology is split the way it is, security
invariants). Kept minimal per the finding in
[Evaluating AGENTS.md](https://arxiv.org/abs/2602.11988)
that verbose context reduces agent solve rates.

Disclosure: co-authored by claude-code