### PR TITLE
Disable fail-on-error for coveralls workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,6 +103,8 @@ jobs:
         run: bash contrib/coverage.sh
       - name: "Upload report to coveralls"
         uses: coverallsapp/github-action@v2
+        with:
+          fail-on-error: false
 
   CodeSpell:
     name: Code spell check


### PR DESCRIPTION
The coveralls workflow is essentially an upload only workflow. Any failure is generally as a result of loss of connection to the coveralls API or the internet as a whole. As of this commit the entire coveralls infra is down including their website.

Adds the flag following this readme https://github.com/marketplace/actions/coveralls-github-action
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
