### PR TITLE
Pin .NET SDK to 8.0.x for C# CI

### DIFF
--- a/payjoin-ffi/csharp/global.json
+++ b/payjoin-ffi/csharp/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Ubuntu runners now ship with .NET 10.0 pre-installed. Without a global.json, the dotnet CLI picks the highest SDK even though the workflow installs 8.0.x. SDK 10.0 can't produce a net8.0 apphost, failing the build with MSB3030.

Add global.json with rollForward: latestFeature so the CLI uses any 8.0.xxx but never rolls forward to 9.0+.

co-authored-by: Claude Opus 4.6

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
