### PR TITLE
Switch to upstream uniffi-bindgen-react-native

### DIFF
--- a/payjoin-ffi/javascript/package-lock.json
+++ b/payjoin-ffi/javascript/package-lock.json
@@ -11,7 +11,7 @@
                 "prettier": "^3.6.2",
                 "tsx": "^4.20.6",
                 "typescript": "^5.9.3",
-                "uniffi-bindgen-react-native": "github:spacebear21/uniffi-bindgen-react-native#update-uniffi-0.30-wasm"
+                "uniffi-bindgen-react-native": "github:jhugman/uniffi-bindgen-react-native#93bed377c6e0b5cd7afd3fb7ee0d7211d5f294c5"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -588,7 +588,7 @@
         },
         "node_modules/uniffi-bindgen-react-native": {
             "version": "0.29.3-1",
-            "resolved": "git+ssh://git@github.com/spacebear21/uniffi-bindgen-react-native.git#e2225d22d9e3246057abba59cc8ca24a038ba01c",
+            "resolved": "git+ssh://git@github.com/jhugman/uniffi-bindgen-react-native.git#93bed377c6e0b5cd7afd3fb7ee0d7211d5f294c5",
             "dev": true,
             "license": "MPL-2.0",
             "bin": {

--- a/payjoin-ffi/javascript/package.json
+++ b/payjoin-ffi/javascript/package.json
@@ -29,7 +29,7 @@
         "prettier": "^3.6.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
-        "uniffi-bindgen-react-native": "github:spacebear21/uniffi-bindgen-react-native#update-uniffi-0.30-wasm"
+        "uniffi-bindgen-react-native": "github:jhugman/uniffi-bindgen-react-native#93bed377c6e0b5cd7afd3fb7ee0d7211d5f294c5"
     },
     "repository": {
         "type": "git",

--- a/payjoin-ffi/javascript/wasm-manifest-patch.toml
+++ b/payjoin-ffi/javascript/wasm-manifest-patch.toml
@@ -9,9 +9,17 @@
 # the library and CLI versions causes "unreachable" panics at runtime.
 wasm-bindgen = "=0.2.108"
 
+# uniffi_core 0.30 requires this feature for wasm32 builds to remove the
+# Send bound on futures, which is not applicable in single-threaded WASM.
+[dependencies.uniffi_core]
+version = "0.30"
+default-features = false
+features = ["wasm-unstable-single-threaded"]
+
 [patch.crates-io]
 payjoin = { path = "../../../../payjoin" }
 payjoin-directory = { path = "../../../../payjoin-directory" }
 payjoin-test-utils = { path = "../../../../payjoin-test-utils" }
-# This patch is required due to the hardcoded 0.29 dependency in uniffi-bindgen-react-native's Cargo.toml. Once they publish the 0.30 package we shouldn't need this anymore.
+# uniffi-runtime-javascript is not yet published with uniffi_core 0.30 support.
+# This path patch lets cargo resolve it from the installed npm package.
 uniffi-runtime-javascript = { path = "../../node_modules/uniffi-bindgen-react-native/crates/uniffi-runtime-javascript" }


### PR DESCRIPTION
The upstream repo merged uniffi 0.30 support in https://github.com/jhugman/uniffi-bindgen-react-native/pull/343 so we no longer need my custom fork.

- Point dependency at upstream main (pinned to 93bed37)
- Add uniffi_core 0.30 with wasm-unstable-single-threaded feature to wasm-manifest-patch.toml, since upstream's runtime crate hasn't enabled it yet and uniffi_core 0.30 requires it for wasm32 builds
- Remove the home@=0.5.11 hack from generate_bindings.sh since upstream now pins it directly

Disclosure: co-authored by Claude Opus 4.6

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
