### PR TITLE
Don't wait for workflows to publish Docker image

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,13 +20,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Wait for other workflows
-        uses: lewagon/wait-on-check-action@v1.5.0
-        with:
-          ref: ${{ github.sha }}
-          running-workflow-name: "Build and publish Docker image"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -76,7 +69,7 @@ jobs:
 
           nix build .#packages.x86_64-linux.payjoin-mailroom-image.copyToDockerDaemon
           result/bin/copy-to-docker-daemon
-            
+
           docker save docker.io/payjoin/payjoin-mailroom:${TAG} -o payjoin-mailroom-${TAG}.tar
 
           echo "Image saved: payjoin-mailroom-${TAG}.tar"


### PR DESCRIPTION
It keeps the wait step on PRs, but not on tag pushes or manual workflow dispatches. This prevents CI failures on master from blocking our ability to publish a docker image, as was the case with coveralls.io errors the last few days due to circumstances out of our control.