### PR TITLE
Document OHTTP relay random selection guidance

### DIFF
--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -1,3 +1,12 @@
+//! OHTTP relay selection and key bootstrapping for the payjoin-cli.
+//!
+//! [`RelayManager`] tracks the currently selected relay and any relays that
+//! have failed, excluding them from future selections for the lifetime of
+//! the [`RelayManager`].
+//!
+//! `fetch_ohttp_keys` selects a relay at random from the configured list,
+//! excluding relays that [`RelayManager`] has marked as failed,
+//! to avoid a fixed contact pattern at the network layer.
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Result};


### PR DESCRIPTION
Fixed relay order creates a fingerprintable pattern at the network layer, even though OHTTP protects the user's IP. Document that callers should select relays randomly and track failed ones for resilience, following the existing `RelayManager` implementation in `payjoin-cli`.

Claude sonnet 4.6 helped me doing the research of the issue.

Re: #1328

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
