### PR TITLE
Ensure random relay selection with fixed ohttp-keys config

### DIFF
--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -34,10 +34,8 @@ pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
 ) -> Result<ValidatedOhttpKeys> {
     if let Some(ohttp_keys) = config.v2()?.ohttp_keys.clone() {
         println!("Using OHTTP Keys from config");
-        return Ok(ValidatedOhttpKeys {
-            ohttp_keys,
-            relay_url: config.v2()?.ohttp_relays[0].clone(),
-        });
+        let validated = fetch_ohttp_keys(config, directory, relay_manager).await?;
+        Ok(ValidatedOhttpKeys { ohttp_keys, relay_url: validated.relay_url })
     } else {
         println!("Bootstrapping private network transport over Oblivious HTTP");
         let fetched_keys = fetch_ohttp_keys(config, directory, relay_manager).await?;


### PR DESCRIPTION
Closes #1384 

This fixes a bug whereby the relay selection was skipped if the config set a fixed value for the ohttp-keys.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
