### PR TITLE
Add Python devshell 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772822230,
-        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
         "type": "github"
       },
       "original": {
@@ -83,14 +83,63 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773190977,
+        "narHash": "sha256-fkJvOxz80cJViPz6GVaayC8BVCs5fclJ8qHDaNUpoEA=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "10ebca8a137bf26b7fbd3e94b339bf68cee18693",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs_2",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
         "rust-overlay": "rust-overlay",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "uv2nix": "uv2nix"
       }
     },
     "rust-overlay": {
@@ -100,11 +149,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773025773,
-        "narHash": "sha256-Wik8+xApNfldpUFjPmJkPdg0RrvUPSWGIZis+A/0N1w=",
+        "lastModified": 1773115373,
+        "narHash": "sha256-bfK9FJFcQth6f3ydYggS5m0z2NRGF/PY6Y2XgZDJ6pg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c06fdbbd36ff60386a1e590ee0cd52dcd1892bf",
+        "rev": "1924b4672a2b8e4aee6e6652ec2e59a8d3c5648e",
         "type": "github"
       },
       "original": {
@@ -145,6 +194,29 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,21 @@
     nix2container = {
       url = "github:nlewo/nix2container";
     };
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -29,6 +44,9 @@
       crane,
       treefmt-nix,
       nix2container,
+      pyproject-nix,
+      uv2nix,
+      pyproject-build-systems,
     }:
     {
       nixosModules.payjoin-mailroom = import ./nix/modules/payjoin-mailroom.nix self;
@@ -224,6 +242,56 @@
           }
         ) craneLibVersions;
 
+        # uv2nix: load the Python workspace from payjoin-ffi/python/uv.lock
+        pythonWorkspace = uv2nix.lib.workspace.loadWorkspace {
+          workspaceRoot = ./payjoin-ffi/python;
+        };
+
+        pythonOverlay = pythonWorkspace.mkPyprojectOverlay {
+          sourcePreference = "wheel";
+        };
+
+        pythonSet =
+          (pkgs.callPackage pyproject-nix.build.packages {
+            python = pkgs.python3;
+          }).overrideScope
+            (
+              nixpkgs.lib.composeManyExtensions [
+                pyproject-build-systems.overlays.wheel
+                pythonOverlay
+              ]
+            );
+
+        # Build a virtualenv with dependency groups from uv.lock, excluding the payjoin package, which is built separately
+        pythonVenv = pythonSet.mkVirtualEnv "payjoin-python-dev-env" (
+          builtins.removeAttrs pythonWorkspace.deps.all [ "payjoin" ]
+        );
+
+        pythonDevShell = pkgs.mkShell {
+          name = "python-dev";
+          packages = [
+            pythonVenv
+            pkgs.uv
+            rustVersions.msrv
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.pkg-config
+            pkgs.openssl
+            pkgs.clang
+          ];
+
+          env = {
+            # Prevent uv from downloading Python or managing the venv itself, nix provides both;
+            UV_NO_SYNC = "1";
+            UV_PYTHON_DOWNLOADS = "never";
+          };
+
+          shellHook = ''
+            # to avoid host/global Python path leaking into the Nix env
+            unset PYTHONPATH
+          '';
+        };
+
         simpleCheck =
           args:
           pkgs.stdenvNoCC.mkDerivation (
@@ -253,6 +321,7 @@
           };
         devShells = devShells // {
           default = devShells.nightly;
+          python = pythonDevShell;
         };
         formatter = treefmtEval.config.build.wrapper;
         checks =

--- a/payjoin-ffi/python/README.md
+++ b/payjoin-ffi/python/README.md
@@ -13,27 +13,29 @@ pip install payjoin
 uv add payjoin
 ```
 
-## Running Tests
+## Development
 
-Follow these steps to clone the repository and run the tests.
+### Using Nix (recommended)
 
-```shell
-# Ensure you have uv installed:
-# https://docs.astral.sh/uv/getting-started/installation/
+If you have [nix](https://nixos.org/download/) installed, enter the Python dev
+environment and run the test script:
 
-# Setup virtual environment/install all packages (including developer packages)
-uv sync --all-extras
+```sh
+nix develop .#python
+cd payjoin-ffi/python
+./contrib/test.sh
+```
 
-bash ./scripts/generate_bindings.sh
+This provides `uv`, Python, Rust, and all other dependencies needed to generate
+bindings, build the wheel, and run the tests.
 
-# Build the wheel
-uv build --wheel
+### Without Nix
 
-# Force reinstall payjoin with <version>
-uv pip install ./dist/payjoin-*.whl --force-reinstall
+Ensure you have [uv](https://docs.astral.sh/uv/getting-started/installation/)
+and Rust 1.85+ installed, then from `payjoin-ffi/python`:
 
-# Run all tests
-uv run python -m unittest --verbose
+```sh
+./contrib/test.sh
 ```
 
 ## Building the Package

--- a/payjoin-ffi/python/contrib/test.sh
+++ b/payjoin-ffi/python/contrib/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Syncing Python dependencies with uv..."
+uv sync --all-extras
+
+echo "==> Generating FFI bindings..."
+bash ./scripts/generate_bindings.sh
+
+echo "==> Building wheel..."
+uv build --wheel
+
+echo "==> Installing wheel..."
+uv pip install ./dist/*.whl --force-reinstall
+
+echo "==> Running tests..."
+uv run python -m unittest --verbose


### PR DESCRIPTION
Adds `nix develop .#python` for payjoin-ffi/python work. Provides uv, Python, and Rust MSRV in one shell.

supersede https://github.com/payjoin/rust-payjoin/pull/864
went through comments and followed the nix2python approach as suggested by Yuval in  PR 

Address https://github.com/payjoin/rust-payjoin/issues/457#issuecomment-3009499255

Note to reviewers:
should we make the script in contrib/test.sh also what runs in CI python.yaml to keep changes consistent or keep current worklow  

co authored using claude sonnet 4.6

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
