### PR TITLE
Allow publishing the mailroom image with a master tag pointing to a rev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,7 +215,13 @@
         containerImages =
           let
             envTag = builtins.getEnv "IMAGE_TAG";
-            tag = if envTag != "" then envTag else (self.shortRev or "dirty");
+            tag =
+              if envTag == "master" then
+                self.shortRev
+              else if envTag != "" then
+                envTag
+              else
+                self.shortRev or "dirty";
           in
           {
             "payjoin-mailroom-image" = mkContainerImage "payjoin-mailroom" packages.payjoin-mailroom tag;


### PR DESCRIPTION
This commit adds logic to allow publishing on push to a master tag to trigger the workflow in release-image.yml to publish the image according to the current commit hash.

This came about as a request to be able to publish to non-named tags, but since the workflow is looking for a named tag we would have to name a tag a commit, clogging our github tags and making unclear which one is the "latest"; another naming convention which I think is best avoided in favor of commit hashes.

As a note @DanGould if you have the time I think we should delete this published [docker image]( https://hub.docker.com/layers/payjoin/payjoin-mailroom/master/images/sha256-716fa7dca5801dadcfd7a1abb96ff4d9a6452ec40f4efa734bd178462372b0d6) from https://github.com/payjoin/rust-payjoin/actions/runs/22923881483/job/66529164347 as it just muddies the list since this "master" tag is stale immediately.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
