### PR TITLE
Make git commit hash optional in landing page

### DIFF
--- a/payjoin-mailroom/build.rs
+++ b/payjoin-mailroom/build.rs
@@ -1,16 +1,16 @@
 use std::process::Command;
 
 fn main() {
-    // Emit the short git commit hash at build time.
-    let commit = Command::new("git")
+    // Emit the short git commit hash at build time when available.
+    if let Some(commit) = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_else(|| "unknown".into());
-
-    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+    {
+        println!("cargo:rustc-env=GIT_COMMIT={commit}");
+    }
 
     // Re-run if HEAD changes (new commit).
     println!("cargo:rerun-if-changed=../.git/HEAD");

--- a/payjoin-mailroom/src/directory.rs
+++ b/payjoin-mailroom/src/directory.rs
@@ -436,8 +436,11 @@ fn handle_peek<E: SendableError>(
 fn landing_page_html() -> String {
     const TEMPLATE: &str = include_str!("../static/index.html");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
-    const COMMIT: &str = env!("GIT_COMMIT");
-    TEMPLATE.replace("{{VERSION}}", VERSION).replace("{{COMMIT}}", COMMIT)
+    let version_string = match option_env!("GIT_COMMIT") {
+        Some(commit) => format!("payjoin-mailroom-v{VERSION} @ {commit}"),
+        None => format!("payjoin-mailroom-v{VERSION}"),
+    };
+    TEMPLATE.replace("{{VERSION_STRING}}", &version_string)
 }
 
 async fn handle_directory_home_path() -> Result<Response<Body>, HandlerError> {
@@ -799,7 +802,6 @@ mod tests {
     #[test]
     fn landing_page_contains_version() {
         let html = landing_page_html();
-        assert!(!html.contains("{{VERSION}}"));
-        assert!(!html.contains("{{COMMIT}}"));
+        assert!(!html.contains("{{VERSION_STRING}}"));
     }
 }

--- a/payjoin-mailroom/static/index.html
+++ b/payjoin-mailroom/static/index.html
@@ -242,7 +242,7 @@
     </main>
 
     <footer>
-      <span><code>payjoin-mailroom-v{{VERSION}} @ {{COMMIT}}</code></span>
+      <span><code>{{VERSION_STRING}}</code></span>
       <span
         >Copyright &copy;
         <script>


### PR DESCRIPTION
Environments without git (e.g. Docker builds from nix2container) previously displayed "unknown" as the commit hash. Now the build script only sets GIT_COMMIT when git is available, and the landing page gracefully omits the hash, showing only the cargo package version.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
