### PR TITLE
Fix `avoid_uih` method comment

### DIFF
--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -218,7 +218,7 @@ impl WantsInputs {
     /// Heuristics and PayJoin Transactions by Ghesmati et al. (2022)](https://eprint.iacr.org/2022/589).
     ///
     /// Based on the paper, we are looking for the candidate input which, when added to the
-    /// transaction with 2 existing outputs, results in the minimum input amount to be lower than the minimum
+    /// transaction with 2 existing outputs, results in the minimum input amount to be greater than the minimum
     /// output amount. Note that when calculating the minimum output amount, we consider the
     /// post-contribution amounts, and expect the output which pays to the receiver to have its
     /// value increased by the amount of the candidate input.


### PR DESCRIPTION
The code accepts a candidate only when:
```rust
if candidate_min_in > candidate_min_out
```

So the implemented condition is the opposite: it wants the minimum input to be greater than the minimum output, not lower.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
