### PR TITLE
Bump payjoin-mailroom version to 0.1.1

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -1130,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69bd382fc775f760a8b55d658527621b890eaa3d8e8bc9779864659b172e81c6"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "corepc-client",
  "flate2",
  "log",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin-mailroom"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3700,7 +3700,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.0",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1130,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69bd382fc775f760a8b55d658527621b890eaa3d8e8bc9779864659b172e81c6"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "corepc-client",
  "flate2",
  "log",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin-mailroom"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3700,7 +3700,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.0",
  "serde",

--- a/payjoin-mailroom/CHANGELOG.md
+++ b/payjoin-mailroom/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Payjoin Mailroom Changelog
 
+## 0.1.1
+
+- Implement Directory and its db as a tower-service (#1361)
+- Add ACME section for mailroom example config (#1382)
+- Add an example `systemd` service (#1393)
+- Add mailroom landing page (#1401)
+- Update mailroom README description (#1402)
+- Make git commit hash optional in landing page (#1408)
+- Fold ohttp relay into mailroom (#1409)
+
 ## 0.1.0
 
 Initial release of payjoin-mailroom (combining payjoin-directory and ohttp-relay).

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin-mailroom"
-version = "0.1.0"
+version = "0.1.1"
 description = "Combined Payjoin Directory and OHTTP Relay"
 repository = "https://github.com/payjoin/rust-payjoin/tree/master/payjoin-mailroom"
 keywords = ["bip77", "bitcoin", "ohttp", "payjoin", "privacy"]


### PR DESCRIPTION
This patch release resolves internal path dependencies in Cargo.toml such that we can now publish payjoin-mailroom to crates.io

#1414 