### PR TITLE
Unpin the nix crane dip from a specific commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,16 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1770419512,
-        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,7 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    crane = {
-      url = "github:ipetkov/crane/2510f2cbc3ccd237f700bb213756a8f35c32d8d7";
-    };
+    crane.url = "github:ipetkov/crane";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Followup from #1418 

Following a checkup from a weekly flake.lock update the crane dep issue has been fixed and no longer needs to be pinned so this commit reverts back to the standard behavior for crane.

I added the first commit following a failure which I traced back to this new [default](https://github.com/ipetkov/crane/pull/983) in crane. In addition to this change and a new requirment in nix that args and env's of the same name cannot be duplicated, instead of making a new env `NEXTTEST_SHOW_PROGRESS` I opted to just use the new minimal default.

Claude Opus 4.6 authored dd471b5bd5ca99c108f35846cac67cf2895445eb more notes about the purpose of that commit [here](https://github.com/payjoin/rust-payjoin/pull/1419#issuecomment-4068060147)

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
