### PR TITLE
Cover missing C# FFI validation paths

### DIFF
--- a/payjoin-ffi/csharp/IntegrationTests.cs
+++ b/payjoin-ffi/csharp/IntegrationTests.cs
@@ -362,7 +362,7 @@ namespace Payjoin.Tests
             });
 
             var validTxid = new string('0', 64);
-            Assert.Throws<InputPairException.FfiValidation>(() =>
+            var amountOutOfRange = Assert.Throws<InputPairException.FfiValidation>(() =>
             {
                 var txin = new PlainTxIn(
                     new PlainOutPoint(validTxid, 0),
@@ -377,10 +377,11 @@ namespace Payjoin.Tests
                 );
                 new InputPair(txin, psbtIn, null);
             });
+            Assert.IsType<FfiValidationException.AmountOutOfRange>(amountOutOfRange.v1);
 
             var hugeScript = new byte[10_001];
             Array.Fill(hugeScript, (byte)0x51);
-            Assert.Throws<InputPairException.FfiValidation>(() =>
+            var scriptTooLarge = Assert.Throws<InputPairException.FfiValidation>(() =>
             {
                 var txin = new PlainTxIn(
                     new PlainOutPoint(validTxid, 0),
@@ -395,8 +396,9 @@ namespace Payjoin.Tests
                 );
                 new InputPair(txin, psbtIn, null);
             });
+            Assert.IsType<FfiValidationException.ScriptTooLarge>(scriptTooLarge.v1);
 
-            Assert.Throws<InputPairException.FfiValidation>(() =>
+            var weightOutOfRange = Assert.Throws<InputPairException.FfiValidation>(() =>
             {
                 var txin = new PlainTxIn(
                     new PlainOutPoint(validTxid, 0),
@@ -411,6 +413,7 @@ namespace Payjoin.Tests
                 );
                 new InputPair(txin, psbtIn, new PlainWeight(0));
             });
+            Assert.IsType<FfiValidationException.WeightOutOfRange>(weightOutOfRange.v1);
 
             var directory = _services!.DirectoryUrl();
             _services.WaitForServicesReady();
@@ -422,12 +425,13 @@ namespace Payjoin.Tests
             using var receiver = receiveTransition.Save(recvPersister);
             using var pjUri = receiver.PjUri();
 
-            var psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+            var psbt = PayjoinMethods.OriginalPsbt();
 
-            Assert.Throws<SenderInputException.FfiValidation>(() =>
+            var feeRateOutOfRange = Assert.Throws<SenderInputException.FfiValidation>(() =>
             {
                 new SenderBuilder(psbt, pjUri).BuildRecommended(ulong.MaxValue);
             });
+            Assert.IsType<FfiValidationException.FeeRateOutOfRange>(feeRateOutOfRange.v1);
 
             Assert.Throws<FfiValidationException.AmountOutOfRange>(() =>
             {

--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -168,7 +168,7 @@ public class PersistenceTests
         var uri = receiver.PjUri();
 
         var senderPersister = new InMemorySenderPersister();
-        var psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+        var psbt = PayjoinMethods.OriginalPsbt();
         
         var withReplyKey = new SenderBuilder(psbt, uri)
             .BuildRecommended(1000)
@@ -210,7 +210,7 @@ public class PersistenceTests
         var uri = receiver.PjUri();
 
         var senderPersister = new InMemorySenderPersisterAsync();
-        var psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+        var psbt = PayjoinMethods.OriginalPsbt();
 
         var withReplyKey = await new SenderBuilder(psbt, uri)
             .BuildRecommended(1000)
@@ -237,6 +237,16 @@ public class ValidationTests
         0x00, 0x01, 0x00, 0x03,
     };
 
+    private static PjUri CreateV2PjUri()
+    {
+        var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
+        var persister = new InMemoryReceiverPersister();
+        using var builder = new ReceiverBuilder("2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK", "https://example.com", ohttpKeys);
+        using var transition = builder.Build();
+        using var receiver = transition.Save(persister);
+        return receiver.PjUri();
+    }
+
     [Fact]
     public void ReceiverBuilderRejectsBadAddress()
     {
@@ -262,5 +272,94 @@ public class ValidationTests
             var psbtIn = new PlainPsbtInput(null, null, null);
             new InputPair(txin, psbtIn, null);
         });
+    }
+
+    [Fact]
+    public void SenderBuilderRejectsBadPsbt()
+    {
+        using var parsed = Uri.Parse("bitcoin:tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4?pj=https://example.com/pj");
+        using var uri = parsed.CheckPjSupported();
+
+        var ex = Assert.Throws<SenderInputException.Psbt>(() =>
+        {
+            new SenderBuilder("not-a-psbt", uri);
+        });
+
+        Assert.IsType<PsbtParseException.InvalidPsbt>(ex.v1);
+    }
+
+    [Fact]
+    public void ReceiverBuilderRejectsAmountOverflow()
+    {
+        var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
+        using var builder = new ReceiverBuilder(
+            "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+            "https://example.com",
+            ohttpKeys);
+
+        Assert.Throws<FfiValidationException.AmountOutOfRange>(() =>
+        {
+            builder.WithAmount(21_000_000UL * 100_000_000UL + 1);
+        });
+    }
+
+    [Fact]
+    public void ReceiverBuilderRejectsExpirationOverflow()
+    {
+        var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
+        using var builder = new ReceiverBuilder(
+            "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+            "https://example.com",
+            ohttpKeys);
+
+        Assert.Throws<FfiValidationException.ExpirationOutOfRange>(() =>
+        {
+            builder.WithExpiration((ulong)uint.MaxValue + 1);
+        });
+    }
+
+    [Fact]
+    public void SenderBuilderWithAdditionalFeeRejectsFeeContributionOverflow()
+    {
+        using var uri = CreateV2PjUri();
+        var psbt = PayjoinMethods.OriginalPsbt();
+        using var builder = new SenderBuilder(psbt, uri);
+
+        var ex = Assert.Throws<SenderInputException.FfiValidation>(() =>
+        {
+            builder.BuildWithAdditionalFee(21_000_000UL * 100_000_000UL + 1, null, 1000, false);
+        });
+
+        Assert.IsType<FfiValidationException.AmountOutOfRange>(ex.v1);
+    }
+
+    [Fact]
+    public void SenderBuilderWithAdditionalFeeRejectsFeeRateOverflow()
+    {
+        using var uri = CreateV2PjUri();
+        var psbt = PayjoinMethods.OriginalPsbt();
+        using var builder = new SenderBuilder(psbt, uri);
+
+        var ex = Assert.Throws<SenderInputException.FfiValidation>(() =>
+        {
+            builder.BuildWithAdditionalFee(1, null, ulong.MaxValue, false);
+        });
+
+        Assert.IsType<FfiValidationException.FeeRateOutOfRange>(ex.v1);
+    }
+
+    [Fact]
+    public void SenderBuilderNonIncentivizingRejectsFeeRateOverflow()
+    {
+        using var uri = CreateV2PjUri();
+        var psbt = PayjoinMethods.OriginalPsbt();
+        using var builder = new SenderBuilder(psbt, uri);
+
+        var ex = Assert.Throws<SenderInputException.FfiValidation>(() =>
+        {
+            builder.BuildNonIncentivizing(ulong.MaxValue);
+        });
+
+        Assert.IsType<FfiValidationException.FeeRateOutOfRange>(ex.v1);
     }
 }


### PR DESCRIPTION
This adds the missing C# test coverage for FFI validation behavior, which had already been exercised in other bindings, as initially introduced in #1263.