### PR TITLE
Add uniffi-dart to standup activity search

### DIFF
--- a/.github/scripts/create_standup_discussion.py
+++ b/.github/scripts/create_standup_discussion.py
@@ -39,6 +39,7 @@ REPOS = [
     "payjoin/multiparty-protocol-docs",
     "payjoin/btsim",
     "payjoin/tx-indexer",
+    "Uniffi-Dart/uniffi-dart",
 ]
 
 REPO_FILTER = " ".join(f"repo:{r}" for r in REPOS)


### PR DESCRIPTION
Add Uniffi-Dart/uniffi-dart to the weekly standup activity search so contributor work in that repo is captured in standup discussions.