### PR TITLE
Add locktime default to payjoin-cli

### DIFF
--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -53,6 +53,13 @@ impl BitcoindWallet {
             conf_target: None,
         };
 
+        // Set locktime to current block height for anti-fee-sniping
+        // This is to follow wallet fingerprinting best practices and set and opinionated
+        // default for external wallet integrations to follow along with
+        let locktime = Some(tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { self.rpc.get_block_count().await })
+        })? as u32);
+
         // Sync wrapper around async call - use tokio handle to avoid deadlock
         let result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
@@ -66,7 +73,7 @@ impl BitcoindWallet {
                                 amount: v.to_btc(),
                             })
                             .collect::<Vec<_>>(),
-                        None, // locktime
+                        locktime,
                         Some(options),
                         None,
                     )


### PR DESCRIPTION
This a default locktime to the payjoin-cli for the purpose of demonstrating good wallet fingerprinting practices. For demonstrating wallet fingerprinting in external wallet integrations I think it is important for the cli to be opinionated about how every aspect of tx creation is a way to give up some privacy.

Here is an example of a [tx](https://mempool.space/testnet/tx/eda3548853d3ad9f33931168742e6aab986095b61925a5f0b43e9240f8083b54?showDetails=true#flow=&vin=0) using this new locktime feature

Written mostly by claude code
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
