### PR TITLE
fix(cli): add proper error handling in send command

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -503,8 +503,15 @@ impl App {
             self.unwrap_relay_or_else_fetch(Some(&sender.endpoint())).await?.as_str(),
         )?;
         let response = self.post_request(req).await?;
-        println!("Posted original proposal...");
-        let sender = sender.process_response(&response.bytes().await?, ctx).save(persister)?;
+        let response_bytes = response
+            .bytes()
+            .await
+            .map_err(|e| anyhow!("Failed to read response body: {e}"))?;
+        let sender = sender
+            .process_response(&response_bytes, ctx)
+            .save(persister)
+            .map_err(|e| anyhow!("Failed to process proposal response: {e}"))?;
+        println!("Posted original proposal. Awaiting payjoin proposal...");
         self.get_proposed_payjoin_psbt(sender, persister).await
     }
 


### PR DESCRIPTION
Fixes #1394

## Summary

The payjoin-cli `send` command printed a success message ("Posted original proposal...") before verifying the HTTP response from `process_response`. If `process_response` failed (e.g., receiver rejected the proposal), users saw a misleading success message followed by an unclear error.

## Changes

- **Moved success log** to after `process_response` completes successfully in `post_original_proposal()`
- **Added explicit error context** for `response.bytes().await` failures ("Failed to read response body")
- **Added explicit error context** for `process_response(...).save(persister)` failures ("Failed to process proposal response")
- **Updated log message** to "Posted original proposal. Awaiting payjoin proposal..." to accurately reflect the state

## File modified

`payjoin-cli/src/app/v2/mod.rs` — `post_original_proposal()` method

---

**Disclosure:** This PR was prepared with the assistance of an AI coding tool (Claude). The fix was reviewed for correctness and all existing tests pass.