### PR TITLE
Receive cancel()

### DIFF
--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -223,6 +223,59 @@ public class PersistenceTests
     }
 }
 
+public class CancelTests
+{
+    private static readonly byte[] OhttpKeysData = new byte[]
+    {
+        0x01, 0x00, 0x16, 0x04, 0xba, 0x48, 0xc4, 0x9c, 0x3d, 0x4a,
+        0x92, 0xa3, 0xad, 0x00, 0xec, 0xc6, 0x3a, 0x02, 0x4d, 0xa1,
+        0x0c, 0xed, 0x02, 0x18, 0x0c, 0x73, 0xec, 0x12, 0xd8, 0xa7,
+        0xad, 0x2c, 0xc9, 0x1b, 0xb4, 0x83, 0x82, 0x4f, 0xe2, 0xbe,
+        0xe8, 0xd2, 0x8b, 0xfe, 0x2e, 0xb2, 0xfc, 0x64, 0x53, 0xbc,
+        0x4d, 0x31, 0xcd, 0x85, 0x1e, 0x8a, 0x65, 0x40, 0xe8, 0x6c,
+        0x53, 0x82, 0xaf, 0x58, 0x8d, 0x37, 0x09, 0x57, 0x00, 0x04,
+        0x00, 0x01, 0x00, 0x03,
+    };
+
+    [Fact]
+    public void ReceiverCancelFromInitialized()
+    {
+        var persister = new InMemoryReceiverPersister();
+        var address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+        var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
+
+        var initialized = new ReceiverBuilder(address, "https://example.com", ohttpKeys)
+            .Build()
+            .Save(persister);
+        var cancelTransition = initialized.Cancel();
+        var fallbackTx = cancelTransition.Save(persister);
+        Assert.Null(fallbackTx);
+
+        var result = PayjoinMethods.ReplayReceiverEventLog(persister);
+        var state = result.State();
+        Assert.IsType<ReceiveSession.Closed>(state);
+    }
+
+    [Fact]
+    public async Task ReceiverCancelFromInitializedAsync()
+    {
+        var persister = new InMemoryReceiverPersisterAsync();
+        var address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+        var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
+
+        var initialized = await new ReceiverBuilder(address, "https://example.com", ohttpKeys)
+            .Build()
+            .SaveAsync(persister);
+        var cancelTransition = initialized.Cancel();
+        var fallbackTx = await cancelTransition.SaveAsync(persister);
+        Assert.Null(fallbackTx);
+
+        var result = await PayjoinMethods.ReplayReceiverEventLogAsync(persister);
+        var state = result.State();
+        Assert.IsType<ReceiveSession.Closed>(state);
+    }
+}
+
 public class ValidationTests
 {
     private static readonly byte[] OhttpKeysData = new byte[]

--- a/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
@@ -204,6 +204,58 @@ void main() {
     });
   });
 
+  group("Test Receiver Cancel", () {
+    test("Test receiver cancel from initialized", () {
+      var persister = InMemoryReceiverPersister("1");
+      var initialized = payjoin.ReceiverBuilder(
+        address: "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+        directory: "https://example.com",
+        ohttpKeys: payjoin.OhttpKeys.decode(
+          bytes: Uint8List.fromList(
+            hex.decode(
+              "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003",
+            ),
+          ),
+        ),
+      ).build().save(persister: persister);
+      var cancelTransition = initialized.cancel();
+      var fallbackTx = cancelTransition.save(persister: persister);
+      expect(fallbackTx, isNull);
+      final result = payjoin.replayReceiverEventLog(persister: persister);
+      expect(
+        result.state(),
+        isA<payjoin.ClosedReceiveSession>(),
+        reason: "receiver should be in Closed state after cancel",
+      );
+    });
+
+    test("Test receiver cancel async from initialized", () async {
+      var persister = InMemoryReceiverPersisterAsync("1");
+      var initialized = await payjoin.ReceiverBuilder(
+        address: "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+        directory: "https://example.com",
+        ohttpKeys: payjoin.OhttpKeys.decode(
+          bytes: Uint8List.fromList(
+            hex.decode(
+              "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003",
+            ),
+          ),
+        ),
+      ).build().saveAsync(persister: persister);
+      var cancelTransition = initialized.cancel();
+      var fallbackTx = await cancelTransition.saveAsync(persister: persister);
+      expect(fallbackTx, isNull);
+      final result = await payjoin.replayReceiverEventLogAsync(
+        persister: persister,
+      );
+      expect(
+        result.state(),
+        isA<payjoin.ClosedReceiveSession>(),
+        reason: "receiver should be in Closed state after cancel",
+      );
+    });
+  });
+
   group("Test Async Persistence", () {
     test("Test receiver async persistence", () async {
       var persister = InMemoryReceiverPersisterAsync("1");

--- a/payjoin-ffi/javascript/test/unit.test.ts
+++ b/payjoin-ffi/javascript/test/unit.test.ts
@@ -220,6 +220,80 @@ describe("Persistence tests", () => {
     });
 });
 
+describe("Receiver cancel tests", () => {
+    test("receiver cancel from initialized", () => {
+        const persister = new InMemoryReceiverPersister(1);
+        const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+        const ohttpKeys = payjoin.OhttpKeys.decode(
+            new Uint8Array([
+                0x01, 0x00, 0x16, 0x04, 0xba, 0x48, 0xc4, 0x9c, 0x3d, 0x4a,
+                0x92, 0xa3, 0xad, 0x00, 0xec, 0xc6, 0x3a, 0x02, 0x4d, 0xa1,
+                0x0c, 0xed, 0x02, 0x18, 0x0c, 0x73, 0xec, 0x12, 0xd8, 0xa7,
+                0xad, 0x2c, 0xc9, 0x1b, 0xb4, 0x83, 0x82, 0x4f, 0xe2, 0xbe,
+                0xe8, 0xd2, 0x8b, 0xfe, 0x2e, 0xb2, 0xfc, 0x64, 0x53, 0xbc,
+                0x4d, 0x31, 0xcd, 0x85, 0x1e, 0x8a, 0x65, 0x40, 0xe8, 0x6c,
+                0x53, 0x82, 0xaf, 0x58, 0x8d, 0x37, 0x09, 0x57, 0x00, 0x04,
+                0x00, 0x01, 0x00, 0x03,
+            ]).buffer,
+        );
+
+        const initialized = new payjoin.ReceiverBuilder(
+            address,
+            "https://example.com",
+            ohttpKeys,
+        )
+            .build()
+            .save(persister);
+        const cancelTransition = initialized.cancel();
+        const fallbackTx = cancelTransition.save(persister);
+        assert.strictEqual(fallbackTx, undefined);
+
+        const result = payjoin.replayReceiverEventLog(persister);
+        const state = result.state();
+        assert.strictEqual(
+            state.tag,
+            "Closed",
+            "State should be Closed after cancel",
+        );
+    });
+
+    test("receiver cancel async from initialized", async () => {
+        const persister = new InMemoryReceiverPersisterAsync(1);
+        const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+        const ohttpKeys = payjoin.OhttpKeys.decode(
+            new Uint8Array([
+                0x01, 0x00, 0x16, 0x04, 0xba, 0x48, 0xc4, 0x9c, 0x3d, 0x4a,
+                0x92, 0xa3, 0xad, 0x00, 0xec, 0xc6, 0x3a, 0x02, 0x4d, 0xa1,
+                0x0c, 0xed, 0x02, 0x18, 0x0c, 0x73, 0xec, 0x12, 0xd8, 0xa7,
+                0xad, 0x2c, 0xc9, 0x1b, 0xb4, 0x83, 0x82, 0x4f, 0xe2, 0xbe,
+                0xe8, 0xd2, 0x8b, 0xfe, 0x2e, 0xb2, 0xfc, 0x64, 0x53, 0xbc,
+                0x4d, 0x31, 0xcd, 0x85, 0x1e, 0x8a, 0x65, 0x40, 0xe8, 0x6c,
+                0x53, 0x82, 0xaf, 0x58, 0x8d, 0x37, 0x09, 0x57, 0x00, 0x04,
+                0x00, 0x01, 0x00, 0x03,
+            ]).buffer,
+        );
+
+        const initialized = await new payjoin.ReceiverBuilder(
+            address,
+            "https://example.com",
+            ohttpKeys,
+        )
+            .build()
+            .saveAsync(persister);
+        const cancelTransition = initialized.cancel();
+        const fallbackTx = await cancelTransition.saveAsync(persister);
+        assert.strictEqual(fallbackTx, undefined);
+
+        const result = await payjoin.replayReceiverEventLogAsync(persister);
+        const state = result.state();
+        assert.strictEqual(
+            state.tag,
+            "Closed",
+            "State should be Closed after cancel",
+        );
+    });
+});
+
 describe("Async Persistence tests", () => {
     test("receiver async persistence", async () => {
         const persister = new InMemoryReceiverPersisterAsync(1);

--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -196,6 +196,57 @@ class TestSenderAsyncPersistence(unittest.TestCase):
         asyncio.run(run_test())
 
 
+class TestReceiverCancel(unittest.TestCase):
+    def test_receiver_cancel(self):
+        persister = InMemoryReceiverPersister(1)
+        initialized = (
+            payjoin.ReceiverBuilder(
+                "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+                "https://example.com",
+                payjoin.OhttpKeys.decode(
+                    bytes.fromhex(
+                        "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003"
+                    )
+                ),
+            )
+            .build()
+            .save(persister)
+        )
+        cancel_transition = initialized.cancel()
+        fallback_tx = cancel_transition.save(persister)
+        self.assertIsNone(fallback_tx)
+        result = payjoin.replay_receiver_event_log(persister)
+        self.assertTrue(result.state().is_CLOSED())
+
+
+class TestReceiverCancelAsync(unittest.TestCase):
+    def test_receiver_cancel_async(self):
+        import asyncio
+
+        async def run_test():
+            persister = InMemoryReceiverPersisterAsync(1)
+            initialized = await (
+                payjoin.ReceiverBuilder(
+                    "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+                    "https://example.com",
+                    payjoin.OhttpKeys.decode(
+                        bytes.fromhex(
+                            "01001604ba48c49c3d4a92a3ad00ecc63a024da10ced02180c73ec12d8a7ad2cc91bb483824fe2bee8d28bfe2eb2fc6453bc4d31cd851e8a6540e86c5382af588d370957000400010003"
+                        )
+                    ),
+                )
+                .build()
+                .save_async(persister)
+            )
+            cancel_transition = initialized.cancel()
+            fallback_tx = await cancel_transition.save_async(persister)
+            self.assertIsNone(fallback_tx)
+            result = await payjoin.replay_receiver_event_log_async(persister)
+            self.assertTrue(result.state().is_CLOSED())
+
+        asyncio.run(run_test())
+
+
 class TestValidation(unittest.TestCase):
     def test_receiver_builder_rejects_bad_address(self):
         with self.assertRaises(payjoin.ReceiverBuilderError):

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -65,6 +65,88 @@ macro_rules! impl_save_for_transition {
     };
 }
 
+/// A terminal transition produced by cancelling a receiver session.
+#[derive(uniffi::Object)]
+pub struct CancelTransition {
+    transition: RwLock<
+        Option<
+            payjoin::persist::TerminalTransition<
+                payjoin::receive::v2::SessionEvent,
+                Option<payjoin::bitcoin::Transaction>,
+            >,
+        >,
+    >,
+}
+
+#[uniffi::export]
+impl CancelTransition {
+    /// Persist the cancellation and return the fallback transaction if available.
+    ///
+    /// The fallback transaction is the consensus-encoded raw transaction bytes,
+    /// or `None` if the session was cancelled before the sender's original
+    /// proposal was received.
+    pub fn save(
+        &self,
+        persister: Arc<dyn JsonReceiverSessionPersister>,
+    ) -> Result<Option<Vec<u8>>, ReceiverPersistedError> {
+        let adapter = CallbackPersisterAdapter::new(persister);
+        let mut inner = self.transition.write().expect("Lock should not be poisoned");
+        let value = inner.take().expect("Already saved or moved");
+        let fallback = value
+            .save(&adapter)
+            .map_err(|e| ReceiverPersistedError::from(ImplementationError::new(e)))?;
+        Ok(fallback.map(|tx| payjoin::bitcoin::consensus::serialize(&tx)))
+    }
+
+    pub async fn save_async(
+        &self,
+        persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
+    ) -> Result<Option<Vec<u8>>, ReceiverPersistedError> {
+        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let value = {
+            let mut inner = self.transition.write().expect("Lock should not be poisoned");
+            inner.take().expect("Already saved or moved")
+        };
+        let fallback = value
+            .save_async(&adapter)
+            .await
+            .map_err(|e| ReceiverPersistedError::from(ImplementationError::new(e)))?;
+        Ok(fallback.map(|tx| payjoin::bitcoin::consensus::serialize(&tx)))
+    }
+}
+
+macro_rules! impl_cancel_for_receiver {
+    ($ty:ident) => {
+        #[uniffi::export]
+        impl $ty {
+            /// Cancel the Payjoin session immediately.
+            ///
+            /// Returns a [`CancelTransition`] that, once persisted, yields the fallback
+            /// transaction when applicable. The fallback transaction is the sender's original
+            /// transaction that should be broadcast to complete the payment without Payjoin.
+            ///
+            /// This is a terminal transition — the session cannot be used after cancellation.
+            pub fn cancel(&self) -> CancelTransition {
+                let transition = self.0.clone().cancel();
+                CancelTransition { transition: RwLock::new(Some(transition)) }
+            }
+        }
+    };
+}
+
+impl_cancel_for_receiver!(Initialized);
+impl_cancel_for_receiver!(UncheckedOriginalPayload);
+impl_cancel_for_receiver!(MaybeInputsOwned);
+impl_cancel_for_receiver!(MaybeInputsSeen);
+impl_cancel_for_receiver!(OutputsUnknown);
+impl_cancel_for_receiver!(WantsOutputs);
+impl_cancel_for_receiver!(WantsInputs);
+impl_cancel_for_receiver!(WantsFeeRange);
+impl_cancel_for_receiver!(ProvisionalProposal);
+impl_cancel_for_receiver!(PayjoinProposal);
+impl_cancel_for_receiver!(HasReplyableError);
+impl_cancel_for_receiver!(Monitor);
+
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct ReceiverSessionEvent(payjoin::receive::v2::SessionEvent);
 

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -460,6 +460,40 @@ impl<Event, NextState> NextStateTransition<Event, NextState> {
     }
 }
 
+/// A transition that unconditionally terminates the session.
+///
+/// Unlike other transition types, this always succeeds at the protocol level
+/// (the only possible error is from the persister's storage layer).
+/// After saving, the session is closed and no further events can be appended.
+///
+/// The `T` parameter carries a value that is returned after saving without
+/// being persisted. This lets callers receive derived data (e.g. a fallback
+/// transaction) through the same `.save()` call pattern used by every other
+/// transition type.
+pub struct TerminalTransition<Event, T>(Event, T);
+
+impl<Event, T> TerminalTransition<Event, T> {
+    pub(crate) fn new(event: Event, value: T) -> Self { Self(event, value) }
+
+    pub fn save<P>(self, persister: &P) -> Result<T, P::InternalStorageError>
+    where
+        P: SessionPersister<SessionEvent = Event>,
+    {
+        PersistActions::SaveAndClose(self.0).execute(persister)?;
+        Ok(self.1)
+    }
+
+    pub async fn save_async<P>(self, persister: &P) -> Result<T, P::InternalStorageError>
+    where
+        P: AsyncSessionPersister<SessionEvent = Event>,
+        Event: Send,
+        T: Send,
+    {
+        PersistActions::SaveAndClose(self.0).execute_async(persister).await?;
+        Ok(self.1)
+    }
+}
+
 /// A transition that can result in a succession completion, fatal error, or transient error.
 /// The transition can also result in no state change.
 pub enum MaybeFatalOrSuccessTransition<Event, CurrentState, Err> {

--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -31,7 +31,7 @@ use crate::receive::{InternalPayloadError, OriginalPayload, PsbtContext};
 /// Call [`Self::commit_outputs`] to proceed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WantsOutputs {
-    original_psbt: Psbt,
+    pub(super) original_psbt: Psbt,
     pub(super) payjoin_psbt: Psbt,
     pub(super) params: Params,
     change_vout: usize,

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -55,7 +55,7 @@ use crate::ohttp::{
 use crate::output_substitution::OutputSubstitution;
 use crate::persist::{
     MaybeFatalOrSuccessTransition, MaybeFatalTransition, MaybeFatalTransitionWithNoResults,
-    MaybeSuccessTransition, MaybeTransientTransition, NextStateTransition,
+    MaybeSuccessTransition, MaybeTransientTransition, NextStateTransition, TerminalTransition,
 };
 use crate::receive::{parse_payload, InputPair, OriginalPayload, PsbtContext};
 use crate::time::Time;
@@ -232,20 +232,73 @@ impl ReceiveSession {
 }
 
 mod sealed {
-    pub trait State {}
+    pub trait State {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> { None }
+    }
 
     impl State for super::Initialized {}
-    impl State for super::UncheckedOriginalPayload {}
-    impl State for super::MaybeInputsOwned {}
-    impl State for super::MaybeInputsSeen {}
-    impl State for super::OutputsUnknown {}
-    impl State for super::WantsOutputs {}
-    impl State for super::WantsInputs {}
-    impl State for super::WantsFeeRange {}
-    impl State for super::ProvisionalProposal {}
-    impl State for super::PayjoinProposal {}
+
+    impl State for super::UncheckedOriginalPayload {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.original.psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::MaybeInputsOwned {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.original.psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::MaybeInputsSeen {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.original.psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::OutputsUnknown {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.original.psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::WantsOutputs {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.inner.original_psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::WantsInputs {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.inner.original_psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::WantsFeeRange {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.inner.original_psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::ProvisionalProposal {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.psbt_context.original_psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
+    impl State for super::PayjoinProposal {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.psbt_context.original_psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
+
     impl State for super::HasReplyableError {}
-    impl State for super::Monitor {}
+
+    impl State for super::Monitor {
+        fn fallback_tx(&self) -> Option<bitcoin::Transaction> {
+            Some(self.psbt_context.original_psbt.clone().extract_tx_unchecked_fee_rate())
+        }
+    }
 }
 
 /// Sealed trait for V2 receive session states.
@@ -254,6 +307,8 @@ mod sealed {
 /// This trait is sealed to prevent external implementations. Only types within this crate
 /// can implement this trait, ensuring type safety and protocol integrity.
 pub trait State: sealed::State {}
+
+impl<S: sealed::State> State for S {}
 
 /// A higher-level receiver construct which will be taken through different states through the
 /// protocol workflow.
@@ -283,6 +338,20 @@ impl<State> core::ops::Deref for Receiver<State> {
 
 impl<State> core::ops::DerefMut for Receiver<State> {
     fn deref_mut(&mut self) -> &mut Self::Target { &mut self.state }
+}
+
+impl<S: State> Receiver<S> {
+    /// Cancel the Payjoin session immediately.
+    ///
+    /// Returns a [`TerminalTransition`] that, once persisted, yields the fallback
+    /// transaction when applicable. The fallback transaction is the sender's original
+    /// transaction that should be broadcast to complete the payment without Payjoin.
+    ///
+    /// This is a terminal transition — the session cannot be used after cancellation.
+    pub fn cancel(self) -> TerminalTransition<SessionEvent, Option<bitcoin::Transaction>> {
+        let fallback = self.state.fallback_tx();
+        TerminalTransition::new(SessionEvent::Closed(SessionOutcome::Cancel), fallback)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1829,5 +1898,55 @@ pub mod test {
             Receiver { state: provisional_proposal, session_context: SHARED_CONTEXT.clone() };
         let psbt = receiver.psbt_to_sign();
         assert_eq!(psbt, PARSED_PAYJOIN_PROPOSAL.clone());
+    }
+
+    #[test]
+    fn cancel_returns_expected_fallback() {
+        macro_rules! do_cancel_test {
+            ($state:expr, $expected:expr) => {{
+                let persister = InMemoryTestPersister::<SessionEvent>::default();
+                let fallback = Receiver { state: $state, session_context: SHARED_CONTEXT.clone() }
+                    .cancel()
+                    .save(&persister)
+                    .expect("save should succeed");
+                assert_eq!(fallback, $expected, "cancel from {}", stringify!($state));
+            }};
+        }
+
+        let original =
+            OriginalPayload { psbt: PARSED_ORIGINAL_PSBT.clone(), params: Params::default() };
+        let expected_tx = PARSED_ORIGINAL_PSBT.clone().extract_tx_unchecked_fee_rate();
+        let psbt_ctx = PsbtContext {
+            original_psbt: PARSED_ORIGINAL_PSBT.clone(),
+            payjoin_psbt: PARSED_PAYJOIN_PROPOSAL.clone(),
+        };
+        let wants_outputs = common::WantsOutputs::new(original.clone(), vec![0]);
+        let wants_inputs = wants_outputs.clone().commit_outputs();
+        let wants_fee_range = wants_inputs.clone().commit_inputs();
+
+        // States without a fallback transaction
+        do_cancel_test!(Initialized {}, None);
+        do_cancel_test!(HasReplyableError { error_reply: mock_err() }, None);
+
+        // States with a fallback transaction
+        do_cancel_test!(
+            UncheckedOriginalPayload { original: original.clone() },
+            Some(expected_tx.clone())
+        );
+        do_cancel_test!(MaybeInputsOwned { original: original.clone() }, Some(expected_tx.clone()));
+        do_cancel_test!(MaybeInputsSeen { original: original.clone() }, Some(expected_tx.clone()));
+        do_cancel_test!(OutputsUnknown { original }, Some(expected_tx.clone()));
+        do_cancel_test!(WantsOutputs { inner: wants_outputs }, Some(expected_tx.clone()));
+        do_cancel_test!(WantsInputs { inner: wants_inputs }, Some(expected_tx.clone()));
+        do_cancel_test!(WantsFeeRange { inner: wants_fee_range }, Some(expected_tx.clone()));
+        do_cancel_test!(
+            ProvisionalProposal { psbt_context: psbt_ctx.clone() },
+            Some(expected_tx.clone())
+        );
+        do_cancel_test!(
+            PayjoinProposal { psbt_context: psbt_ctx.clone() },
+            Some(expected_tx.clone())
+        );
+        do_cancel_test!(Monitor { psbt_context: psbt_ctx }, Some(expected_tx));
     }
 }


### PR DESCRIPTION
This implements a generic cancel() method on the Receiver, following up on discussion from #1134.

As discussed on the PR review club a few weeks ago, this implementation of cancel() returns the fallback transaction as a convenience and a "hint" to broadcast it if it hasn't already been. Doing this adds quite a bit of complexity due to having to implement a `fallback_tx` getter for every concrete typestate, some of which return `None`. IMO the ergonomics are probably worth the cost of this internal ugliness, but I'm curious what other people think.

The existing flow is for implementers to call `extract_tx_to_schedule_broadcast` after the broadcast suitability check passes and store that somewhere for broadcasting later, or to replay events and use `SessionHistory::fallback_tx` to access it for broadcasting. This PR introduces a third accessor for the same data. Is there still a need for the other two getters if we aim to encourage `cancel()`ing?

Supersedes #1134.

Authored with Claude - who incidentally has learned to generate all downstream language bindings and run their tests in parallel in the background while doing other things.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
