### PR TITLE
Remove Docker instructions from CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -113,7 +113,7 @@ also provided.
 
 ### Testing
 
-We test a few different features combinations in CI. To run all of the combinations locally, have Docker running and run `contrib/test.sh`.
+We test a few different features combinations in CI. To run all of the combinations locally run `contrib/test.sh`.
 
 If you are adding a new feature please add tests for it.
 


### PR DESCRIPTION
Docker is no longer a dependency for tests.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
