### PR TITLE
Remove unneeded http feature via the bhttp dep in payjoin-mailroom

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -476,7 +476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16fc24bc615b9fd63148f59b218ea58a444b55762f8845da910e23aca686398b"
 dependencies = [
  "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -476,7 +476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16fc24bc615b9fd63148f59b218ea58a444b55762f8845da910e23aca686398b"
 dependencies = [
  "thiserror 1.0.63",
- "url",
 ]
 
 [[package]]

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -29,7 +29,7 @@ axum = "0.8"
 axum-server = { version = "0.8", features = [
   "tls-rustls-no-provider",
 ], optional = true }
-bhttp = { version = "0.6.1", features = ["http"] }
+bhttp = { version = "0.6.1" }
 bitcoin = { version = "0.32.7", features = ["base64", "rand-std"] }
 byteorder = "1.5.0"
 bytes = "1.10.1"


### PR DESCRIPTION
Pulled out from #1377 as this is not really related to that directly.

I think this was not caught by machete as http is a needed dep elsewhere?

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
