### PR TITLE
Disable reqwest dep when _manual-tls is enabled in the payjoin crate

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -36,7 +36,7 @@ v1 = ["_core"]
 v2 = ["_core", "hpke", "bhttp", "ohttp", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
-_manual-tls = ["reqwest/rustls-tls", "rustls"]
+_manual-tls = ["rustls"]
 _test-utils = []
 
 [dependencies]


### PR DESCRIPTION
The reqwest dep is enabled in the _manual-tls feature pulling in url as a sub dependency but this is only used in conjunction with the io feature which already has reqwest as a dep.

Closes #1483 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
