### PR TITLE
Expose standard Rust traits on FFI error types

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "uniffi-dart"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?tag=v0.1.0%2Bv0.30.0#e3ed67f780257a5a7fae23231e13d84f931208e0"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
 dependencies = [
  "anyhow",
  "camino",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "uniffi_dart_macro"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?tag=v0.1.0%2Bv0.30.0#e3ed67f780257a5a7fae23231e13d84f931208e0"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
 dependencies = [
  "futures",
  "proc-macro2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "uniffi-dart"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?tag=v0.1.0%2Bv0.30.0#e3ed67f780257a5a7fae23231e13d84f931208e0"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
 dependencies = [
  "anyhow",
  "camino",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "uniffi_dart_macro"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?tag=v0.1.0%2Bv0.30.0#e3ed67f780257a5a7fae23231e13d84f931208e0"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
 dependencies = [
  "futures",
  "proc-macro2",

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "2.0.14"
 tokio = { version = "1.47.1", features = ["full"], optional = true }
 uniffi = { version = "0.30.0", features = ["cli"] }
 uniffi-bindgen-cs = { git = "https://github.com/chavic/uniffi-bindgen-cs.git", rev = "878a3d269eacce64beadcd336ade0b7c8da09824", optional = true }
-uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", tag = "v0.1.0+v0.30.0", optional = true }
+uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", rev = "b0157aa", optional = true }
 url = "2.5.4"
 
 # getrandom is ignored here because it's required by the wasm_js feature

--- a/payjoin-ffi/src/error.rs
+++ b/payjoin-ffi/src/error.rs
@@ -4,6 +4,7 @@ use std::error;
 ///
 /// e.g. database errors, network failures, wallet errors
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct ImplementationError(#[from] payjoin::ImplementationError);
 
@@ -18,6 +19,7 @@ impl From<ImplementationError> for payjoin::ImplementationError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error("Error de/serializing JSON object: {0}")]
 pub struct SerdeJsonError(#[from] serde_json::Error);
 

--- a/payjoin-ffi/src/ohttp.rs
+++ b/payjoin-ffi/src/ohttp.rs
@@ -2,6 +2,7 @@ pub use error::OhttpError;
 
 pub mod error {
     #[derive(Debug, thiserror::Error, uniffi::Object)]
+    #[uniffi::export(Debug, Display)]
     #[error(transparent)]
     pub struct OhttpError(#[from] ohttp::Error);
 }

--- a/payjoin-ffi/src/receive/error.rs
+++ b/payjoin-ffi/src/receive/error.rs
@@ -115,6 +115,7 @@ impl From<payjoin::bitcoin::address::ParseError> for ReceiverBuilderError {
 
 /// Error parsing a Bitcoin address.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error("Invalid Bitcoin address: {msg}")]
 pub struct AddressParseError {
     msg: String,
@@ -136,6 +137,7 @@ impl From<payjoin::bitcoin::address::ParseError> for AddressParseError {
 /// 4. Provide errors according to BIP-78 JSON error specifications for return
 ///    after conversion into [`JsonReply`]
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct ProtocolError(#[from] receive::ProtocolError);
 
@@ -149,6 +151,7 @@ pub struct ProtocolError(#[from] receive::ProtocolError);
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Debug, Eq)]
 pub struct JsonReply(receive::JsonReply);
 
 impl From<JsonReply> for receive::JsonReply {
@@ -165,11 +168,13 @@ impl From<ProtocolError> for JsonReply {
 
 /// Error that may occur during a v2 session typestate change
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct SessionError(#[from] receive::v2::SessionError);
 
 /// Protocol error raised during output substitution.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct OutputSubstitutionProtocolError(#[from] receive::OutputSubstitutionError);
 
@@ -194,16 +199,19 @@ impl From<FfiValidationError> for OutputSubstitutionError {
 
 /// Error that may occur when coin selection fails.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct SelectionError(#[from] receive::SelectionError);
 
 /// Error that may occur when input contribution fails.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct InputContributionError(#[from] receive::InputContributionError);
 
 /// Error validating a PSBT Input
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct PsbtInputError(#[from] receive::PsbtInputError);
 
@@ -233,6 +241,7 @@ impl From<FfiValidationError> for InputPairError {
 
 /// Error that may occur when a receiver event log is replayed
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct ReceiverReplayError(
     #[from] payjoin::error::ReplayError<receive::v2::ReceiveSession, receive::v2::SessionEvent>,

--- a/payjoin-ffi/src/send/error.rs
+++ b/payjoin-ffi/src/send/error.rs
@@ -9,6 +9,7 @@ use crate::error::{FfiValidationError, ImplementationError};
 ///
 /// This error is unrecoverable.
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display, Eq)]
 #[error("Error initializing the sender: {msg}")]
 pub struct BuildSenderError {
     msg: String,
@@ -55,16 +56,19 @@ impl From<FfiValidationError> for SenderInputError {
 /// `unwrap()`ing it is thus considered OK in Rust but you may achieve nicer message by displaying
 /// it.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct CreateRequestError(#[from] send::v2::CreateRequestError);
 
 /// Error returned for v2-specific payload encapsulation errors.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct EncapsulationError(#[from] send::v2::EncapsulationError);
 
 /// Error that may occur when the response from receiver is malformed.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct ValidationError(#[from] send::ValidationError);
 
@@ -106,11 +110,13 @@ impl From<send::ResponseError> for ResponseError {
 
 /// A well-known error that can be safely displayed to end users.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct WellKnownError(#[from] send::WellKnownError);
 
 /// Error that may occur when the sender session event log is replayed
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct SenderReplayError(
     #[from] payjoin::error::ReplayError<send::v2::SendSession, send::v2::SessionEvent>,

--- a/payjoin-ffi/src/test_utils.rs
+++ b/payjoin-ffi/src/test_utils.rs
@@ -78,6 +78,7 @@ impl FfiError {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct BoxSendSyncError(#[from] payjoin_test_utils::BoxSendSyncError);
 

--- a/payjoin-ffi/src/uri/error.rs
+++ b/payjoin-ffi/src/uri/error.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display, Eq)]
 #[error("Error parsing the payjoin URI: {msg}")]
 pub struct PjParseError {
     msg: String,
@@ -9,6 +10,7 @@ impl PjParseError {
 }
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display, Eq)]
 #[error("URI doesn't support payjoin: {msg}")]
 pub struct PjNotSupported {
     msg: String,
@@ -21,14 +23,17 @@ impl PjNotSupported {
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct UrlParseError(#[from] url::ParseError);
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error(transparent)]
 pub struct IntoUrlError(#[from] payjoin::IntoUrlError);
 
 #[derive(Debug, thiserror::Error, uniffi::Object)]
+#[uniffi::export(Debug, Display)]
 #[error("{msg}")]
 pub struct FeeRateError {
     msg: String,


### PR DESCRIPTION
This fixes the string representation of the FFI errors to use the Rust Display string instead of an opaque `Instance of *Error` message. See https://github.com/payjoin/rust-payjoin/issues/1264#issuecomment-4255578441 for more context. 

Discovered and authored with Claude.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
