### PR TITLE
docs: clarify bech32 uppercase assertion TODO

### DIFF
--- a/payjoin/src/bech32.rs
+++ b/payjoin/src/bech32.rs
@@ -41,7 +41,7 @@ mod test {
             (hrp.as_str().len() + 1) as f32 + (bytes.len() as f32 * 8.0 / 5.0).ceil()
         );
 
-        // TODO assert uppercase
+        // TODO: Add assertion to ensure HRP is uppercase per BIP 173
 
         // should not error
         let corrupted = encoded + "QQPP";


### PR DESCRIPTION
Clarifies the intent of an existing TODO comment per BIP 173, clarifying that an actual assertion should be added in the future.

This is a documentation-only change.


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
