### PR TITLE
Fix clippy::question_mark warnings in FFI load() impls

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1386,20 +1386,15 @@ impl payjoin::persist::SessionPersister for CallbackPersisterAdapter {
         &self,
     ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
         let res = self.callback_persister.load()?;
-        Ok(Box::new(
-            match res
-                .into_iter()
-                .map(|event| {
-                    ReceiverSessionEvent::from_json(event)
-                        .map_err(|e| ForeignError::InternalError(e.to_string()))
-                        .map(|e| e.into())
-                })
-                .collect::<Result<Vec<_>, _>>()
-            {
-                Ok(events) => Box::new(events.into_iter()),
-                Err(e) => return Err(e),
-            },
-        ))
+        let events = res
+            .into_iter()
+            .map(|event| {
+                ReceiverSessionEvent::from_json(event)
+                    .map_err(|e| ForeignError::InternalError(e.to_string()))
+                    .map(|e| e.into())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Box::new(events.into_iter()))
     }
 
     fn close(&self) -> Result<(), Self::InternalStorageError> { self.callback_persister.close() }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -608,20 +608,15 @@ impl payjoin::persist::SessionPersister for CallbackPersisterAdapter {
         &self,
     ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
         let res = self.callback_persister.load()?;
-        Ok(Box::new(
-            match res
-                .into_iter()
-                .map(|event| {
-                    SenderSessionEvent::from_json(event)
-                        .map_err(|e| ForeignError::InternalError(e.to_string()))
-                        .map(|e| e.into())
-                })
-                .collect::<Result<Vec<_>, _>>()
-            {
-                Ok(events) => Box::new(events.into_iter()),
-                Err(e) => return Err(e),
-            },
-        ))
+        let events = res
+            .into_iter()
+            .map(|event| {
+                SenderSessionEvent::from_json(event)
+                    .map_err(|e| ForeignError::InternalError(e.to_string()))
+                    .map(|e| e.into())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Box::new(events.into_iter()))
     }
 
     fn close(&self) -> Result<(), Self::InternalStorageError> { self.callback_persister.close() }


### PR DESCRIPTION

Fixes pre-existing clippy::question_mark warnings in the FFI
SessionPersister::load() implementations for both sender and receiver.

These were causing Lint-FFI CI failures on PRs unrelated to payjoin-ffi,
including #1490.

Pull Request Checklist
- [x] I have disclosed my use of AI in the body of this PR.
- [x] I have read CONTRIBUTING.md and rebased my branch to produce hygienic commits.

Disclosure: I consulted Claude to understand the codebase structure,
but the solution was authored by myself.