### PR TITLE
fix(test): remove payjoin-ffi from root CRATES and update ffi test script

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -24,7 +24,7 @@ if [ -f "$LOCKFILE" ]; then
 fi
 
 DEPS="recent minimal"
-CRATES="payjoin payjoin-cli payjoin-ffi payjoin-mailroom"
+CRATES="payjoin payjoin-cli payjoin-mailroom"
 
 for dep in $DEPS; do
     cargo --version

--- a/contrib/test_local.sh
+++ b/contrib/test_local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CRATES="payjoin payjoin-cli payjoin-ffi payjoin-mailroom"
+CRATES="payjoin payjoin-cli payjoin-mailroom"
 
 cargo --version
 rustc --version

--- a/payjoin-ffi/contrib/test.sh
+++ b/payjoin-ffi/contrib/test.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-RUST_VERSION=$(rustc --version | awk '{print $2}')
+cd "$(dirname "$0")/.."
 
-if [[ ! $RUST_VERSION =~ ^1\.85\. ]]; then
-    cargo test --package payjoin-ffi --verbose --features=_manual-tls,_test-utils
-else
-    echo "Skipping payjoin-ffi tests for Rust version $RUST_VERSION (MSRV)"
-fi
+cargo test --package payjoin-ffi --verbose --features=_manual-tls,_test-utils
+
+BINDINGS="dart javascript python csharp"
+
+for binding in $BINDINGS; do
+    (
+        cd "$binding"
+        ./contrib/test.sh
+    )
+done

--- a/payjoin-ffi/contrib/test.sh
+++ b/payjoin-ffi/contrib/test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-RUST_VERSION=$(rustc --version | awk '{print $2}')
+cargo test --package payjoin-ffi --verbose --features=_manual-tls,_test-utils
 
-if [[ ! $RUST_VERSION =~ ^1\.85\. ]]; then
-    cargo test --package payjoin-ffi --verbose --features=_manual-tls,_test-utils
-else
-    echo "Skipping payjoin-ffi tests for Rust version $RUST_VERSION (MSRV)"
-fi
+for binding in dart javascript python; do
+    (
+        cd "$binding"
+        bash ./contrib/test.sh
+    )
+done

--- a/payjoin-ffi/csharp/contrib/test.sh
+++ b/payjoin-ffi/csharp/contrib/test.sh
@@ -6,5 +6,5 @@ cd "$(dirname "$0")/.."
 echo "==> Generating FFI bindings..."
 bash ./scripts/generate_bindings.sh
 
-echo "==> Running dart tests..."
-dart test
+echo "==> Running C# tests..."
+dotnet test --logger "console;verbosity=minimal"


### PR DESCRIPTION
Closes #1454

payjoin-ffi tests were either being skipped due to an unnecessary MSRV version check or entangling language binding tests with core rust CI.

- Remove payjoin-ffi from CRATES in root contrib/test.sh and contrib/test_local.sh
- Remove MSRV version check from payjoin-ffi/contrib/test.sh
- Add cargo test for payjoin-ffi rust code
- Loop over language bindings (dart, javascript, python) and run their contrib/test.sh

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
