### PR TITLE
Fix send success log error and order

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -241,7 +241,7 @@ impl AppTrait for App {
                 };
                 let mut interrupt = self.interrupt.clone();
                 tokio::select! {
-                    _ = self.process_sender_session(sender_state, &persister) => return Ok(()),
+                    res = self.process_sender_session(sender_state, &persister) => return res,
                     _ = interrupt.changed() => {
                         println!("Interrupted. Call `send` with the same arguments to resume this session or `resume` to resume all sessions.");
                         return Err(anyhow!("Interrupted"))
@@ -503,8 +503,8 @@ impl App {
             self.unwrap_relay_or_else_fetch(Some(&sender.endpoint())).await?.as_str(),
         )?;
         let response = self.post_request(req).await?;
-        println!("Posted original proposal...");
         let sender = sender.process_response(&response.bytes().await?, ctx).save(persister)?;
+        println!("Posted original proposal...");
         self.get_proposed_payjoin_psbt(sender, persister).await
     }
 


### PR DESCRIPTION
<details>
  <summary> This PR addresses the issue in #1394 where payjoin-cli "send" command silently exits when process_response fails. Two bugs were identified and fixed:

println!("Posted original proposal...") fired before process_response validated the directory response, showing a false success banner even on failure.
tokio::select! in send_payjoin discarded the Result from process_sender_session with _ = ... => return Ok(()), silently swallowing all errors.
The fix moves the print statement after validation and propagates the result with res = ... => return res, so errors reach main.rs where anyhow prints them.

Manually tested with self-loop configuration (relay = directory) confirming the error Unexpected response size 0, expected 8192 bytes is now surfaced and the process exits non-zero.</summary>

I brainstormed the implementation approach with Claude while working through this fix.

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
