### PR TITLE
Fix HTTP error handling in payjoin-cli

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -860,13 +860,7 @@ impl App {
             .body(req.body)
             .send()
             .await
-            .map_err(map_reqwest_err)
-    }
-}
-
-fn map_reqwest_err(e: reqwest::Error) -> anyhow::Error {
-    match e.status() {
-        Some(status_code) => anyhow!("HTTP request failed: {} {}", status_code, e),
-        None => anyhow!("No HTTP response: {}", e),
+            .and_then(|r| r.error_for_status())
+            .context("HTTP request failed")
     }
 }


### PR DESCRIPTION
While testing @Arowolokehinde 's PR #1498 I noticed that cli was attempting to process the OHTTP response even though it was returning a 403. This fix ensures we actually bubble up HTTP error responses from the ohttp relay:

Before:

```
❯ cargo run -- send $BIP21 --fee-rate 1
   Compiling payjoin-cli v0.2.0 (/Users/spacebear/Projects/rust-payjoin/payjoin-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.63s
     Running `/Users/spacebear/Projects/rust-payjoin/target/debug/payjoin-cli send 'bitcoin:bcrt1qpvnwwzs00tjys006szgx26krf8kewmk8qah2ah?amount=0.00001&pjos=0&pj=HTTPS://PAYJO.IN/8EZPMVL7YVTHZ%23EX1C4PW56G-OH1QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ-RK1QDN0WY7AAH7YLXKJYHEN7SSDT04WG2JKMDY3UGGGWDU8S6X9GXSZG' --fee-rate 1`
Bootstrapping private network transport over Oblivious HTTP
Error: Transient error: Directory response error: Unexpected response size 0, expected 8192 bytes
```

After:

```
❯ cargo run -- send $BIP21 --fee-rate 1
   Compiling payjoin-cli v0.2.0 (/Users/spacebear/Projects/rust-payjoin/payjoin-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.89s
     Running `/Users/spacebear/Projects/rust-payjoin/target/debug/payjoin-cli send 'bitcoin:bcrt1qpvnwwzs00tjys006szgx26krf8kewmk8qah2ah?amount=0.00001&pjos=0&pj=HTTPS://PAYJO.IN/8EZPMVL7YVTHZ%23EX1C4PW56G-OH1QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ-RK1QDN0WY7AAH7YLXKJYHEN7SSDT04WG2JKMDY3UGGGWDU8S6X9GXSZG' --fee-rate 1`
Bootstrapping private network transport over Oblivious HTTP
Error: HTTP request failed

Caused by:
    HTTP status client error (403 Forbidden) for url (https://payjo.in/https://payjo.in/)
```

Closes #1394 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
