### PR TITLE
Update Dart fetchOhttpKeys to support https

### DIFF
--- a/payjoin-ffi/dart/lib/http.dart
+++ b/payjoin-ffi/dart/lib/http.dart
@@ -1,3 +1,19 @@
+// This file hand-rolls an HTTP/1.1 client over RawSocket because dart:io's
+// HttpClient cannot tunnel through an HTTPS proxy. The proxy URL parser
+// rejects the HTTPS scheme outright
+// (https://github.com/dart-lang/sdk/issues/43475).
+//
+// Even where it is accepted, HttpClient does not perform the TLS-in-TLS
+// handshake required to talk through an HTTPS proxy to an HTTPS destination
+// (https://github.com/dart-lang/sdk/issues/43876).
+//
+// This also appears to be unsolved by any dart third-party http library.
+//
+// Thankfully LLMs are undeterred by the insane task of writing an entire
+// HTTP stack from scratch, so here we are. Since this code is pretty much
+// unreviewable by a human, every change to it should be backed by a
+// regression test in test/fetch_ohttp_keys_security_test.dart.
+
 library http;
 
 import 'dart:async';

--- a/payjoin-ffi/dart/lib/http.dart
+++ b/payjoin-ffi/dart/lib/http.dart
@@ -17,12 +17,15 @@ import 'payjoin.dart' show OhttpKeys;
 /// present, intended for local test setups that use a self-signed directory
 /// certificate; leave unset in production so normal system trust-root
 /// validation applies. [relayCertificate] serves the same purpose for the
-/// relay connection.
+/// relay connection. [timeout] is applied per network phase (TCP connect,
+/// TLS handshake(s), CONNECT exchange, GET); the worst-case wall-clock is
+/// roughly 4× this value.
 Future<OhttpKeys> fetchOhttpKeys({
   required String ohttpRelayUrl,
   required String directoryUrl,
   Uint8List? certificate,
   Uint8List? relayCertificate,
+  Duration timeout = const Duration(seconds: 10),
 }) async {
   final relayUri = Uri.parse(ohttpRelayUrl);
   final keysUrl = Uri.parse(directoryUrl).resolve('/.well-known/ohttp-gateway');
@@ -30,24 +33,34 @@ Future<OhttpKeys> fetchOhttpKeys({
   final destIsHttps = keysUrl.scheme == 'https';
   final destAuthority = '${keysUrl.host}:${keysUrl.port}';
 
-  RawSocket socket = relayIsHttps
-      ? await RawSecureSocket.connect(
-          relayUri.host,
-          relayUri.port,
-          onBadCertificate: _certChecker(relayCertificate),
-        )
-      : await RawSocket.connect(relayUri.host, relayUri.port);
+  RawSocket socket =
+      await (relayIsHttps
+              ? RawSecureSocket.connect(
+                  relayUri.host,
+                  relayUri.port,
+                  onBadCertificate: _certChecker(relayCertificate),
+                )
+              : RawSocket.connect(relayUri.host, relayUri.port))
+          .timeout(
+            timeout,
+            onTimeout: () => throw HttpException('relay connect timeout'),
+          );
 
   try {
-    final tunnelSub = await _openConnectTunnel(socket, destAuthority);
+    final tunnelSub = await _openConnectTunnel(socket, destAuthority, timeout);
 
     if (destIsHttps) {
-      socket = await RawSecureSocket.secure(
-        socket,
-        subscription: tunnelSub,
-        host: keysUrl.host,
-        onBadCertificate: _certChecker(certificate),
-      );
+      socket =
+          await RawSecureSocket.secure(
+            socket,
+            subscription: tunnelSub,
+            host: keysUrl.host,
+            onBadCertificate: _certChecker(certificate),
+          ).timeout(
+            timeout,
+            onTimeout: () =>
+                throw HttpException('directory TLS handshake timeout'),
+          );
     }
 
     final response = await _sendGet(
@@ -55,6 +68,7 @@ Future<OhttpKeys> fetchOhttpKeys({
       keysUrl.path,
       keysUrl.host,
       destIsHttps ? null : tunnelSub,
+      timeout,
     );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -77,6 +91,7 @@ bool Function(X509Certificate)? _certChecker(Uint8List? der) {
 Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
   RawSocket socket,
   String authority,
+  Duration timeout,
 ) async {
   final req = Uint8List.fromList(
     utf8.encode('CONNECT $authority HTTP/1.1\r\nHost: $authority\r\n\r\n'),
@@ -102,7 +117,11 @@ Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
           final i = _indexOfCrlfCrlf(buf);
           if (i != -1) {
             socket.readEventsEnabled = false;
-            done.complete(utf8.decode(buf.sublist(0, i)));
+            try {
+              done.complete(latin1.decode(buf.sublist(0, i)));
+            } catch (e) {
+              done.completeError(e);
+            }
           }
         case RawSocketEvent.readClosed:
         case RawSocketEvent.closed:
@@ -117,7 +136,10 @@ Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
   socket.writeEventsEnabled = true;
   socket.readEventsEnabled = true;
 
-  final headers = await done.future;
+  final headers = await done.future.timeout(
+    timeout,
+    onTimeout: () => throw HttpException('CONNECT timeout'),
+  );
   final status = headers.split('\r\n').first;
   if (_parseStatusCode(status) != 200) {
     await sub.cancel();
@@ -145,6 +167,7 @@ Future<_Response> _sendGet(
   String path,
   String host,
   StreamSubscription<RawSocketEvent>? existingSub,
+  Duration timeout,
 ) async {
   final req = Uint8List.fromList(
     utf8.encode(
@@ -196,21 +219,113 @@ Future<_Response> _sendGet(
   socket.writeEventsEnabled = true;
   socket.readEventsEnabled = true;
 
-  final responseBytes = await done.future;
+  final responseBytes = await done.future.timeout(
+    timeout,
+    onTimeout: () => throw HttpException('GET timeout'),
+  );
   await sub.cancel();
 
+  return _parseResponse(responseBytes);
+}
+
+const _maxBodyBytes = 1024;
+
+_Response _parseResponse(Uint8List responseBytes) {
   final headerEnd = _indexOfCrlfCrlf(responseBytes);
   if (headerEnd == -1) {
     throw HttpException('Malformed HTTP response');
   }
-  final statusLine = utf8
-      .decode(responseBytes.sublist(0, headerEnd))
-      .split('\r\n')
-      .first;
-  return _Response(
-    _parseStatusCode(statusLine),
-    Uint8List.sublistView(responseBytes, headerEnd + 4),
-  );
+
+  final headerBlock = latin1.decode(responseBytes.sublist(0, headerEnd));
+  final lines = headerBlock.split('\r\n');
+  final statusCode = _parseStatusCode(lines.first);
+
+  final headers = <String, String>{};
+  for (var i = 1; i < lines.length; i++) {
+    final c = lines[i].indexOf(':');
+    if (c <= 0) continue;
+    headers[lines[i].substring(0, c).toLowerCase()] = lines[i]
+        .substring(c + 1)
+        .trim();
+  }
+
+  final hasCL = headers.containsKey('content-length');
+  final hasTE = headers.containsKey('transfer-encoding');
+  if (hasCL && hasTE) {
+    throw HttpException('Content-Length and Transfer-Encoding both set');
+  }
+
+  final bodyStart = headerEnd + 4;
+  final raw = (bodyStart >= responseBytes.length)
+      ? Uint8List(0)
+      : Uint8List.sublistView(responseBytes, bodyStart);
+
+  if (hasCL) {
+    final cl = int.tryParse(headers['content-length']!);
+    if (cl == null || cl < 0) {
+      throw HttpException('Invalid Content-Length');
+    }
+    if (cl > _maxBodyBytes) {
+      throw HttpException('Content-Length exceeds 1 KiB cap');
+    }
+    if (raw.length < cl) {
+      throw HttpException('Short body: expected $cl, got ${raw.length}');
+    }
+    return _Response(statusCode, Uint8List.sublistView(raw, 0, cl));
+  } else if (hasTE) {
+    if (headers['transfer-encoding']!.toLowerCase() != 'chunked') {
+      throw HttpException('Unsupported Transfer-Encoding');
+    }
+    return _Response(statusCode, _decodeSingleChunk(raw));
+  } else {
+    throw HttpException(
+      'No framing header (Content-Length or Transfer-Encoding required)',
+    );
+  }
+}
+
+Uint8List _decodeSingleChunk(Uint8List raw) {
+  // Accepts exactly: <hex-size>\r\n<body>\r\n0\r\n\r\n
+  // Rejects: chunk-extensions, trailers, multi-chunk, body > 1 KiB.
+  final crlf1 = _indexOfCrlf(raw, 0);
+  if (crlf1 == -1) {
+    throw HttpException('Malformed chunk size line');
+  }
+  final sizeLine = latin1.decode(raw.sublist(0, crlf1));
+  if (sizeLine.contains(';')) {
+    throw HttpException('Chunk extensions not supported');
+  }
+  final n = int.tryParse(sizeLine.trim(), radix: 16);
+  if (n == null || n < 0) {
+    throw HttpException('Invalid chunk size');
+  }
+  if (n > _maxBodyBytes) {
+    throw HttpException('Chunk size exceeds 1 KiB cap');
+  }
+  final bodyStart = crlf1 + 2;
+  // Body, then \r\n, then "0\r\n\r\n" — total 5 bytes after the body.
+  if (raw.length < bodyStart + n + 2 + 5) {
+    throw HttpException('Short chunked response');
+  }
+  if (raw[bodyStart + n] != 0x0d || raw[bodyStart + n + 1] != 0x0a) {
+    throw HttpException('Missing chunk terminator');
+  }
+  final term = bodyStart + n + 2;
+  if (raw[term] != 0x30 ||
+      raw[term + 1] != 0x0d ||
+      raw[term + 2] != 0x0a ||
+      raw[term + 3] != 0x0d ||
+      raw[term + 4] != 0x0a) {
+    throw HttpException('Multi-chunk responses or trailers not supported');
+  }
+  return Uint8List.sublistView(raw, bodyStart, bodyStart + n);
+}
+
+int _indexOfCrlf(List<int> bytes, int from) {
+  for (var i = from; i + 1 < bytes.length; i++) {
+    if (bytes[i] == 0x0d && bytes[i + 1] == 0x0a) return i;
+  }
+  return -1;
 }
 
 int _indexOfCrlfCrlf(List<int> bytes) {

--- a/payjoin-ffi/dart/lib/http.dart
+++ b/payjoin-ffi/dart/lib/http.dart
@@ -28,7 +28,10 @@ Future<OhttpKeys> fetchOhttpKeys({
   Duration timeout = const Duration(seconds: 10),
 }) async {
   final relayUri = Uri.parse(ohttpRelayUrl);
+  _validateAuthority(relayUri, 'ohttpRelayUrl', ohttpRelayUrl);
   final keysUrl = Uri.parse(directoryUrl).resolve('/.well-known/ohttp-gateway');
+  _validateAuthority(keysUrl, 'directoryUrl', directoryUrl);
+
   final relayIsHttps = relayUri.scheme == 'https';
   final destIsHttps = keysUrl.scheme == 'https';
   final destAuthority = '${keysUrl.host}:${keysUrl.port}';
@@ -94,6 +97,28 @@ Future<OhttpKeys> fetchOhttpKeys({
 bool Function(X509Certificate)? _certChecker(Uint8List? der) {
   if (der == null || der.isEmpty) return null;
   return (cert) => _bytesEqual(cert.der, der);
+}
+
+// Allowlist for Uri.host: ASCII letters/digits, dot, hyphen, underscore, and
+// colon (for IPv6 literals, which Dart returns without surrounding brackets).
+// Defends in depth against header-injection or smuggling via a crafted host
+// that survives Uri.parse.
+final _hostPattern = RegExp(r'^[A-Za-z0-9._\-:]+$');
+
+void _validateAuthority(Uri uri, String paramName, String original) {
+  if (uri.scheme != 'http' && uri.scheme != 'https') {
+    throw ArgumentError.value(
+      original,
+      paramName,
+      'scheme must be http or https',
+    );
+  }
+  if (uri.host.isEmpty || !_hostPattern.hasMatch(uri.host)) {
+    throw ArgumentError.value(original, paramName, 'invalid host');
+  }
+  if (uri.port < 1 || uri.port > 65535) {
+    throw ArgumentError.value(original, paramName, 'invalid port');
+  }
 }
 
 class _TunnelResult {
@@ -181,7 +206,9 @@ Future<_TunnelResult> _openConnectTunnel(
 }
 
 int _parseStatusCode(String statusLine) {
-  final m = RegExp(r'^HTTP/1\.[01] (\d{3})').firstMatch(statusLine);
+  // Anchor on a space or end of line after the status code so a status like
+  // "HTTP/1.1 2009 ..." doesn't get parsed as 200.
+  final m = RegExp(r'^HTTP/1\.[01] (\d{3})(?: |$)').firstMatch(statusLine);
   if (m == null) {
     throw HttpException('Invalid HTTP status line: $statusLine');
   }

--- a/payjoin-ffi/dart/lib/http.dart
+++ b/payjoin-ffi/dart/lib/http.dart
@@ -47,13 +47,20 @@ Future<OhttpKeys> fetchOhttpKeys({
           );
 
   try {
-    final tunnelSub = await _openConnectTunnel(socket, destAuthority, timeout);
+    final tunnel = await _openConnectTunnel(socket, destAuthority, timeout);
 
     if (destIsHttps) {
+      if (tunnel.leftover.isNotEmpty) {
+        await tunnel.subscription.cancel();
+        throw HttpException(
+          'Relay sent ${tunnel.leftover.length} unexpected bytes after '
+          'CONNECT response, before TLS handshake',
+        );
+      }
       socket =
           await RawSecureSocket.secure(
             socket,
-            subscription: tunnelSub,
+            subscription: tunnel.subscription,
             host: keysUrl.host,
             onBadCertificate: _certChecker(certificate),
           ).timeout(
@@ -67,7 +74,8 @@ Future<OhttpKeys> fetchOhttpKeys({
       socket,
       keysUrl.path,
       keysUrl.host,
-      destIsHttps ? null : tunnelSub,
+      destIsHttps ? null : tunnel.subscription,
+      destIsHttps ? Uint8List(0) : tunnel.leftover,
       timeout,
     );
 
@@ -88,7 +96,13 @@ bool Function(X509Certificate)? _certChecker(Uint8List? der) {
   return (cert) => _bytesEqual(cert.der, der);
 }
 
-Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
+class _TunnelResult {
+  final StreamSubscription<RawSocketEvent> subscription;
+  final Uint8List leftover;
+  _TunnelResult(this.subscription, this.leftover);
+}
+
+Future<_TunnelResult> _openConnectTunnel(
   RawSocket socket,
   String authority,
   Duration timeout,
@@ -99,7 +113,8 @@ Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
 
   int writePos = 0;
   final buf = <int>[];
-  final done = Completer<String>();
+  // Completes with the index of the CRLFCRLF that ends the response headers.
+  final done = Completer<int>();
   late final StreamSubscription<RawSocketEvent> sub;
 
   sub = socket.listen(
@@ -114,14 +129,19 @@ Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
         case RawSocketEvent.read:
           final chunk = socket.read();
           if (chunk != null) buf.addAll(chunk);
+          if (buf.length > _maxResponseBytes) {
+            socket.readEventsEnabled = false;
+            done.completeError(
+              HttpException(
+                'CONNECT response exceeded $_maxResponseBytes bytes',
+              ),
+            );
+            return;
+          }
           final i = _indexOfCrlfCrlf(buf);
           if (i != -1) {
             socket.readEventsEnabled = false;
-            try {
-              done.complete(latin1.decode(buf.sublist(0, i)));
-            } catch (e) {
-              done.completeError(e);
-            }
+            done.complete(i);
           }
         case RawSocketEvent.readClosed:
         case RawSocketEvent.closed:
@@ -136,16 +156,28 @@ Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
   socket.writeEventsEnabled = true;
   socket.readEventsEnabled = true;
 
-  final headers = await done.future.timeout(
-    timeout,
-    onTimeout: () => throw HttpException('CONNECT timeout'),
-  );
-  final status = headers.split('\r\n').first;
+  final int headerEnd;
+  try {
+    headerEnd = await done.future.timeout(
+      timeout,
+      onTimeout: () => throw HttpException('CONNECT timeout'),
+    );
+  } catch (_) {
+    await sub.cancel();
+    rethrow;
+  }
+
+  final status = latin1.decode(buf.sublist(0, headerEnd)).split('\r\n').first;
   if (_parseStatusCode(status) != 200) {
     await sub.cancel();
     throw HttpException('CONNECT failed: $status');
   }
-  return sub;
+
+  final leftoverStart = headerEnd + 4;
+  final leftover = leftoverStart < buf.length
+      ? Uint8List.fromList(buf.sublist(leftoverStart))
+      : Uint8List(0);
+  return _TunnelResult(sub, leftover);
 }
 
 int _parseStatusCode(String statusLine) {
@@ -167,6 +199,7 @@ Future<_Response> _sendGet(
   String path,
   String host,
   StreamSubscription<RawSocketEvent>? existingSub,
+  Uint8List initialBuffer,
   Duration timeout,
 ) async {
   final req = Uint8List.fromList(
@@ -180,7 +213,7 @@ Future<_Response> _sendGet(
   );
 
   int writePos = 0;
-  final buf = <int>[];
+  final buf = <int>[...initialBuffer];
   final done = Completer<Uint8List>();
 
   void handler(RawSocketEvent event) {
@@ -194,6 +227,13 @@ Future<_Response> _sendGet(
       case RawSocketEvent.read:
         final chunk = socket.read();
         if (chunk != null) buf.addAll(chunk);
+        if (buf.length > _maxResponseBytes) {
+          socket.readEventsEnabled = false;
+          done.completeError(
+            HttpException('GET response exceeded $_maxResponseBytes bytes'),
+          );
+          return;
+        }
       case RawSocketEvent.readClosed:
       case RawSocketEvent.closed:
         done.complete(Uint8List.fromList(buf));
@@ -229,6 +269,12 @@ Future<_Response> _sendGet(
 }
 
 const _maxBodyBytes = 1024;
+
+// Hard cap on accumulated bytes during the CONNECT and GET reads. Prevents an
+// untrusted relay or directory from forcing unbounded buffer growth before the
+// later body-cap check can fire. Sized well above any plausible legitimate
+// response (headers + a sub-1 KiB OhttpKeys body).
+const _maxResponseBytes = 16 * 1024;
 
 _Response _parseResponse(Uint8List responseBytes) {
   final headerEnd = _indexOfCrlfCrlf(responseBytes);

--- a/payjoin-ffi/dart/lib/http.dart
+++ b/payjoin-ffi/dart/lib/http.dart
@@ -1,6 +1,7 @@
 library http;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -9,42 +10,219 @@ import 'payjoin.dart' show OhttpKeys;
 /// Fetches the OHTTP keys from a payjoin directory through an OHTTP relay
 /// proxy so the directory never observes the client IP address.
 ///
-/// [ohttpRelayUrl] is the HTTP CONNECT proxy that tunnels the request.
-/// [directoryUrl] is the payjoin directory whose `/.well-known/ohttp-gateway`
-/// endpoint is queried. [certificate] is the DER-encoded
-/// certificate the directory is expected to present, intended for
-/// local test setups that use a self-signed directory certificate; leave
-/// unset in production so normal system trust-root validation applies.
+/// [ohttpRelayUrl] is the HTTP(S) CONNECT proxy that tunnels the request.
+/// HTTPS relays are supported via TLS-in-TLS. [directoryUrl] is the payjoin
+/// directory whose `/.well-known/ohttp-gateway` endpoint is queried.
+/// [certificate] is the DER-encoded certificate the directory is expected to
+/// present, intended for local test setups that use a self-signed directory
+/// certificate; leave unset in production so normal system trust-root
+/// validation applies. [relayCertificate] serves the same purpose for the
+/// relay connection.
 Future<OhttpKeys> fetchOhttpKeys({
   required String ohttpRelayUrl,
   required String directoryUrl,
   Uint8List? certificate,
+  Uint8List? relayCertificate,
 }) async {
   final relayUri = Uri.parse(ohttpRelayUrl);
   final keysUrl = Uri.parse(directoryUrl).resolve('/.well-known/ohttp-gateway');
+  final relayIsHttps = relayUri.scheme == 'https';
+  final destIsHttps = keysUrl.scheme == 'https';
+  final destAuthority = '${keysUrl.host}:${keysUrl.port}';
 
-  final client = HttpClient();
-  client.findProxy = (_) => 'PROXY ${relayUri.host}:${relayUri.port}';
-  if (certificate != null && certificate.isNotEmpty) {
-    client.badCertificateCallback = (cert, _, _) =>
-        _bytesEqual(cert.der, certificate);
-  }
+  RawSocket socket = relayIsHttps
+      ? await RawSecureSocket.connect(
+          relayUri.host,
+          relayUri.port,
+          onBadCertificate: _certChecker(relayCertificate),
+        )
+      : await RawSocket.connect(relayUri.host, relayUri.port);
 
   try {
-    final request = await client.getUrl(keysUrl);
-    request.headers.set(HttpHeaders.acceptHeader, 'application/ohttp-keys');
-    final response = await request.close();
-    final bodyBytes = await _collectBytes(response);
+    final tunnelSub = await _openConnectTunnel(socket, destAuthority);
+
+    if (destIsHttps) {
+      socket = await RawSecureSocket.secure(
+        socket,
+        subscription: tunnelSub,
+        host: keysUrl.host,
+        onBadCertificate: _certChecker(certificate),
+      );
+    }
+
+    final response = await _sendGet(
+      socket,
+      keysUrl.path,
+      keysUrl.host,
+      destIsHttps ? null : tunnelSub,
+    );
+
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw HttpException(
         'fetchOhttpKeys failed: HTTP ${response.statusCode}',
         uri: keysUrl,
       );
     }
-    return OhttpKeys.decode(bytes: bodyBytes);
+    return OhttpKeys.decode(bytes: response.body);
   } finally {
-    client.close(force: true);
+    socket.close();
   }
+}
+
+bool Function(X509Certificate)? _certChecker(Uint8List? der) {
+  if (der == null || der.isEmpty) return null;
+  return (cert) => _bytesEqual(cert.der, der);
+}
+
+Future<StreamSubscription<RawSocketEvent>> _openConnectTunnel(
+  RawSocket socket,
+  String authority,
+) async {
+  final req = Uint8List.fromList(
+    utf8.encode('CONNECT $authority HTTP/1.1\r\nHost: $authority\r\n\r\n'),
+  );
+
+  int writePos = 0;
+  final buf = <int>[];
+  final done = Completer<String>();
+  late final StreamSubscription<RawSocketEvent> sub;
+
+  sub = socket.listen(
+    (event) {
+      if (done.isCompleted) return;
+      switch (event) {
+        case RawSocketEvent.write:
+          if (writePos < req.length) {
+            writePos += socket.write(req, writePos);
+            if (writePos >= req.length) socket.writeEventsEnabled = false;
+          }
+        case RawSocketEvent.read:
+          final chunk = socket.read();
+          if (chunk != null) buf.addAll(chunk);
+          final i = _indexOfCrlfCrlf(buf);
+          if (i != -1) {
+            socket.readEventsEnabled = false;
+            done.complete(utf8.decode(buf.sublist(0, i)));
+          }
+        case RawSocketEvent.readClosed:
+        case RawSocketEvent.closed:
+          done.completeError(HttpException('Connection closed during CONNECT'));
+      }
+    },
+    onError: (Object e) {
+      if (!done.isCompleted) done.completeError(e);
+    },
+  );
+
+  socket.writeEventsEnabled = true;
+  socket.readEventsEnabled = true;
+
+  final headers = await done.future;
+  final status = headers.split('\r\n').first;
+  if (_parseStatusCode(status) != 200) {
+    await sub.cancel();
+    throw HttpException('CONNECT failed: $status');
+  }
+  return sub;
+}
+
+int _parseStatusCode(String statusLine) {
+  final m = RegExp(r'^HTTP/1\.[01] (\d{3})').firstMatch(statusLine);
+  if (m == null) {
+    throw HttpException('Invalid HTTP status line: $statusLine');
+  }
+  return int.parse(m.group(1)!);
+}
+
+class _Response {
+  final int statusCode;
+  final Uint8List body;
+  _Response(this.statusCode, this.body);
+}
+
+Future<_Response> _sendGet(
+  RawSocket socket,
+  String path,
+  String host,
+  StreamSubscription<RawSocketEvent>? existingSub,
+) async {
+  final req = Uint8List.fromList(
+    utf8.encode(
+      'GET $path HTTP/1.1\r\n'
+      'Host: $host\r\n'
+      'Accept: application/ohttp-keys\r\n'
+      'Connection: close\r\n'
+      '\r\n',
+    ),
+  );
+
+  int writePos = 0;
+  final buf = <int>[];
+  final done = Completer<Uint8List>();
+
+  void handler(RawSocketEvent event) {
+    if (done.isCompleted) return;
+    switch (event) {
+      case RawSocketEvent.write:
+        if (writePos < req.length) {
+          writePos += socket.write(req, writePos);
+          if (writePos >= req.length) socket.writeEventsEnabled = false;
+        }
+      case RawSocketEvent.read:
+        final chunk = socket.read();
+        if (chunk != null) buf.addAll(chunk);
+      case RawSocketEvent.readClosed:
+      case RawSocketEvent.closed:
+        done.complete(Uint8List.fromList(buf));
+    }
+  }
+
+  late final StreamSubscription<RawSocketEvent> sub;
+  if (existingSub != null) {
+    sub = existingSub;
+    sub.onData(handler);
+    sub.onError((Object e) {
+      if (!done.isCompleted) done.completeError(e);
+    });
+  } else {
+    sub = socket.listen(
+      handler,
+      onError: (Object e) {
+        if (!done.isCompleted) done.completeError(e);
+      },
+    );
+  }
+
+  socket.writeEventsEnabled = true;
+  socket.readEventsEnabled = true;
+
+  final responseBytes = await done.future;
+  await sub.cancel();
+
+  final headerEnd = _indexOfCrlfCrlf(responseBytes);
+  if (headerEnd == -1) {
+    throw HttpException('Malformed HTTP response');
+  }
+  final statusLine = utf8
+      .decode(responseBytes.sublist(0, headerEnd))
+      .split('\r\n')
+      .first;
+  return _Response(
+    _parseStatusCode(statusLine),
+    Uint8List.sublistView(responseBytes, headerEnd + 4),
+  );
+}
+
+int _indexOfCrlfCrlf(List<int> bytes) {
+  for (var i = 0; i <= bytes.length - 4; i++) {
+    if (bytes[i] == 0x0d &&
+        bytes[i + 1] == 0x0a &&
+        bytes[i + 2] == 0x0d &&
+        bytes[i + 3] == 0x0a) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 bool _bytesEqual(Uint8List a, Uint8List b) {
@@ -53,12 +231,4 @@ bool _bytesEqual(Uint8List a, Uint8List b) {
     if (a[i] != b[i]) return false;
   }
   return true;
-}
-
-Future<Uint8List> _collectBytes(Stream<List<int>> stream) async {
-  final builder = BytesBuilder(copy: false);
-  await for (final chunk in stream) {
-    builder.add(chunk);
-  }
-  return builder.toBytes();
 }

--- a/payjoin-ffi/dart/test/fetch_ohttp_keys_security_test.dart
+++ b/payjoin-ffi/dart/test/fetch_ohttp_keys_security_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+
+import 'package:payjoin/http.dart' as payjoin_http;
+
+/// Spawns a TCP server on localhost that hands each accepted client to
+/// [onClient]. The test is responsible for whatever protocol behavior it
+/// wants to script (responses, hangs, premature close, etc.).
+Future<ServerSocket> _startScriptedRelay(
+  void Function(Socket client) onClient,
+) async {
+  final server = await ServerSocket.bind('127.0.0.1', 0);
+  server.listen(onClient);
+  return server;
+}
+
+void main() {
+  group('fetchOhttpKeys hardening', () {
+    test('rejects oversized CONNECT response', () async {
+      // Stream more than the 16 KiB buffer cap with no \r\n\r\n in sight.
+      final relay = await _startScriptedRelay((client) {
+        client.listen((_) {}, onError: (_) {});
+        client.add(Uint8List(32 * 1024));
+      });
+      try {
+        await expectLater(
+          payjoin_http.fetchOhttpKeys(
+            ohttpRelayUrl: 'http://127.0.0.1:${relay.port}',
+            directoryUrl: 'http://example.invalid/',
+            timeout: const Duration(seconds: 3),
+          ),
+          throwsA(
+            predicate(
+              (e) =>
+                  e is HttpException &&
+                  e.message.contains('CONNECT response exceeded'),
+            ),
+          ),
+        );
+      } finally {
+        await relay.close();
+      }
+    });
+
+    test('rejects post-CONNECT bytes when directory is HTTPS', () async {
+      // Pack a CONNECT 200 and "extra" payload into the same write so the
+      // client's read picks them up together. Without the leftover check,
+      // the bytes would be silently dropped before the TLS handshake.
+      final relay = await _startScriptedRelay((client) {
+        client.listen((_) {}, onError: (_) {});
+        client.add(
+          utf8.encode('HTTP/1.1 200 Connection Established\r\n\r\nEXTRA'),
+        );
+      });
+      try {
+        await expectLater(
+          payjoin_http.fetchOhttpKeys(
+            ohttpRelayUrl: 'http://127.0.0.1:${relay.port}',
+            directoryUrl: 'https://localhost:9999/',
+            timeout: const Duration(seconds: 3),
+          ),
+          throwsA(
+            predicate(
+              (e) =>
+                  e is HttpException &&
+                  e.message.contains('unexpected bytes after CONNECT'),
+            ),
+          ),
+        );
+      } finally {
+        await relay.close();
+      }
+    });
+
+    test('rejects oversized GET response', () async {
+      // Two-phase scripted relay: respond 200 to CONNECT, then on the next
+      // chunk (the GET request) flood the client past the 16 KiB cap.
+      final relay = await _startScriptedRelay((client) {
+        var sawConnect = false;
+        client.listen((_) {
+          if (!sawConnect) {
+            sawConnect = true;
+            client.add(
+              utf8.encode('HTTP/1.1 200 Connection Established\r\n\r\n'),
+            );
+          } else {
+            client.add(Uint8List(32 * 1024));
+          }
+        }, onError: (_) {});
+      });
+      try {
+        await expectLater(
+          payjoin_http.fetchOhttpKeys(
+            ohttpRelayUrl: 'http://127.0.0.1:${relay.port}',
+            directoryUrl: 'http://example.invalid/',
+            timeout: const Duration(seconds: 3),
+          ),
+          throwsA(
+            predicate(
+              (e) =>
+                  e is HttpException &&
+                  e.message.contains('GET response exceeded'),
+            ),
+          ),
+        );
+      } finally {
+        await relay.close();
+      }
+    });
+  });
+}

--- a/payjoin-ffi/dart/test/fetch_ohttp_keys_security_test.dart
+++ b/payjoin-ffi/dart/test/fetch_ohttp_keys_security_test.dart
@@ -111,5 +111,76 @@ void main() {
         await relay.close();
       }
     });
+
+    test('rejects status line with trailing junk after status code', () async {
+      // Without the tightened regex, "HTTP/1.1 2009" would be parsed as 200
+      // and the CONNECT would succeed against this malformed response.
+      final relay = await _startScriptedRelay((client) {
+        client.listen((_) {}, onError: (_) {});
+        client.add(utf8.encode('HTTP/1.1 2009\r\n\r\n'));
+      });
+      try {
+        await expectLater(
+          payjoin_http.fetchOhttpKeys(
+            ohttpRelayUrl: 'http://127.0.0.1:${relay.port}',
+            directoryUrl: 'http://example.invalid/',
+            timeout: const Duration(seconds: 3),
+          ),
+          throwsA(
+            predicate(
+              (e) =>
+                  e is HttpException &&
+                  e.message.contains('Invalid HTTP status line'),
+            ),
+          ),
+        );
+      } finally {
+        await relay.close();
+      }
+    });
+  });
+
+  group('fetchOhttpKeys URL validation', () {
+    test('rejects non-http(s) relay scheme', () async {
+      await expectLater(
+        payjoin_http.fetchOhttpKeys(
+          ohttpRelayUrl: 'file:///tmp/foo',
+          directoryUrl: 'http://example.com/',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects non-http(s) directory scheme', () async {
+      await expectLater(
+        payjoin_http.fetchOhttpKeys(
+          ohttpRelayUrl: 'http://example.com/',
+          directoryUrl: 'file:///tmp/foo',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects empty relay host', () async {
+      await expectLater(
+        payjoin_http.fetchOhttpKeys(
+          ohttpRelayUrl: 'http:///pj',
+          directoryUrl: 'http://example.com/',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects host containing control or unusual characters', () async {
+      // The exact Uri.parse behavior on encoded CR/LF varies, but anything
+      // outside the allowlist (letters/digits/.-_:) must be rejected.
+      await expectLater(
+        payjoin_http.fetchOhttpKeys(
+          ohttpRelayUrl: 'http://exam%0aple.com/',
+          directoryUrl: 'http://example.com/',
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 }

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -1,4 +1,6 @@
+import "dart:async";
 import "dart:convert";
+import "dart:io";
 import "dart:typed_data";
 
 import "package:http/http.dart" as http;
@@ -400,6 +402,70 @@ Future<payjoin.ReceiveSession?> process_receiver_proposal(
   throw Exception("Unknown receiver state: $receiver");
 }
 
+const _httpsProxyCertPem =
+    '-----BEGIN CERTIFICATE-----\n'
+    'MIIBmDCCAT+gAwIBAgIUZmuZcOJ7AKPKxmXUdl8mALQqLjkwCgYIKoZIzj0EAwIw\n'
+    'FDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDQyMzAyNDYzNloXDTM2MDQyMDAy\n'
+    'NDYzNlowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D\n'
+    'AQcDQgAEMbQWJrdEdXIX4hHIcRcpMlRY8+YpH9X9e5DkreID6fVh9tRIoqFSURL1\n'
+    'L8q2mLIxLl4W5L4HRJuPkKVCiUI9/qNvMG0wHQYDVR0OBBYEFKih01KF98UDEZg6\n'
+    'FOo4nHUVpKGLMB8GA1UdIwQYMBaAFKih01KF98UDEZg6FOo4nHUVpKGLMA8GA1Ud\n'
+    'EwEB/wQFMAMBAf8wGgYDVR0RBBMwEYIJbG9jYWxob3N0hwR/AAABMAoGCCqGSM49\n'
+    'BAMCA0cAMEQCIGCqHp/SwHSxkOxECoU6qEq+/kapotRRTSe3SsWRjQ38AiBITEBf\n'
+    'j3sL7LkmerQLhWwl7u7UMHb0rBeuFbSmRmxCGA==\n'
+    '-----END CERTIFICATE-----';
+
+const _httpsProxyKeyPem =
+    '-----BEGIN PRIVATE KEY-----\n'
+    'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUZxLsCYEttJjv9WN\n'
+    '6xUtRwFu40pdAk80R8tgCIlqbhahRANCAAQxtBYmt0R1chfiEchxFykyVFjz5ikf\n'
+    '1f17kOSt4gPp9WH21EiioVJREvUvyraYsjEuXhbkvgdEm4+QpUKJQj3+\n'
+    '-----END PRIVATE KEY-----';
+
+Uint8List _httpsProxyCertDer() => base64.decode(
+  _httpsProxyCertPem.replaceAll(RegExp(r'-----[^-]+-----|\s'), ''),
+);
+
+Future<SecureServerSocket> _startHttpsConnectProxy() async {
+  final ctx = SecurityContext()
+    ..useCertificateChainBytes(utf8.encode(_httpsProxyCertPem))
+    ..usePrivateKeyBytes(utf8.encode(_httpsProxyKeyPem));
+  final server = await SecureServerSocket.bind('localhost', 0, ctx);
+
+  server.listen((client) {
+    final buf = BytesBuilder(copy: false);
+    late StreamSubscription<Uint8List> sub;
+    sub = client.listen((chunk) {
+      buf.add(chunk);
+      final headers = utf8.decode(buf.toBytes());
+      if (!headers.contains('\r\n\r\n')) return;
+      final match = RegExp(r'CONNECT ([^:]+):(\d+)').firstMatch(headers);
+      if (match == null) return client.destroy();
+      sub.pause();
+      Socket.connect(match.group(1)!, int.parse(match.group(2)!))
+          .then((target) {
+            client.add(
+              utf8.encode('HTTP/1.1 200 Connection Established\r\n\r\n'),
+            );
+            sub
+              ..onData(target.add)
+              ..onError((_) => target.destroy());
+            target.listen(
+              client.add,
+              onDone: client.destroy,
+              onError: (_) => client.destroy(),
+            );
+            sub.resume();
+          })
+          .catchError((_) {
+            client.destroy();
+          });
+    }, onError: (_) => client.destroy());
+  });
+
+  return server;
+}
+
 void main() {
   group('fetchOhttpKeys', () {
     test(
@@ -429,6 +495,27 @@ void main() {
           ),
           throwsA(isA<Exception>()),
         );
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'fetches and decodes keys via HTTPS relay proxy (TLS-in-TLS)',
+      () async {
+        final services = test_utils.TestServices.initialize();
+        services.waitForServicesReady();
+        final proxy = await _startHttpsConnectProxy();
+        try {
+          final keys = await payjoin_http.fetchOhttpKeys(
+            ohttpRelayUrl: 'https://localhost:${proxy.port}',
+            directoryUrl: services.directoryUrl(),
+            certificate: services.cert(),
+            relayCertificate: _httpsProxyCertDer(),
+          );
+          expect(keys, isA<payjoin.OhttpKeys>());
+        } finally {
+          await proxy.close();
+        }
       },
       timeout: const Timeout(Duration(minutes: 2)),
     );


### PR DESCRIPTION
Bespoke implementation of tls-in-tls proxy because it's apparently not supported by any dart native library

Authored by Claude Opus 4.7 . I've skimmed the code for basic sanity, and confirmed this actually works in BBM tests, but I have not thoroughly reviewed the logic or audited line-by-line as this is too low-level for me to do properly in a realistic time frame.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
