### PR TITLE
Update use of deprecated from_sat_per_vb_unchecked

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -595,9 +595,9 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
 dependencies = [
  "bitcoin-internals 0.3.0",
  "serde",
@@ -2764,6 +2764,7 @@ dependencies = [
  "bitcoin 0.32.8",
  "bitcoin-hpke",
  "bitcoin-ohttp",
+ "bitcoin-units",
  "bitcoin_uri",
  "http",
  "once_cell",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -600,9 +600,9 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
 dependencies = [
  "bitcoin-internals 0.3.0",
  "serde",
@@ -2732,6 +2732,7 @@ dependencies = [
  "bitcoin 0.32.8",
  "bitcoin-hpke",
  "bitcoin-ohttp",
+ "bitcoin-units",
  "bitcoin_uri",
  "http",
  "once_cell",

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -42,6 +42,7 @@ _test-utils = []
 [dependencies]
 bhttp = { version = "0.6.1", optional = true }
 bitcoin = { version = "0.32.7", features = ["base64"] }
+bitcoin-units = "0.1.3"
 bitcoin_uri = { version = "0.1.0", optional = true }
 hpke = { package = "bitcoin-hpke", version = "0.13.0", optional = true }
 http = { version = "1.3.1", optional = true }
@@ -57,6 +58,9 @@ tracing = "0.1.41"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = "1.1.0"
+
+[package.metadata.cargo-machete]
+ignored = ["bitcoin-units"]
 
 [dev-dependencies]
 once_cell = "1.21.3"

--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -686,7 +686,7 @@ mod tests {
         let mut original_params = original.params.clone();
         assert_eq!(original.psbt_fee_rate().unwrap().to_sat_per_vb_floor(), 2);
         // Specify excessive fee rate in sender params
-        original_params.min_fee_rate = FeeRate::from_sat_per_vb_unchecked(1000);
+        original_params.min_fee_rate = FeeRate::from_sat_per_vb_u32(1000);
         let updated_original = OriginalPayload { psbt: original.psbt, params: original_params };
 
         let proposal_psbt = Psbt::from_str(RECEIVER_INPUT_CONTRIBUTION).unwrap();
@@ -706,15 +706,15 @@ mod tests {
             script_pubkey: payjoin.original_psbt.unsigned_tx.output[0].script_pubkey.clone(),
         };
         payjoin.payjoin_psbt.unsigned_tx.output.push(additional_output);
-        let psbt = payjoin
-            .calculate_psbt_with_fee_range(None, Some(FeeRate::from_sat_per_vb_unchecked(1000)));
+        let psbt =
+            payjoin.calculate_psbt_with_fee_range(None, Some(FeeRate::from_sat_per_vb_u32(1000)));
         assert!(psbt.is_ok(), "Payjoin should be a valid PSBT");
-        let psbt = payjoin
-            .calculate_psbt_with_fee_range(None, Some(FeeRate::from_sat_per_vb_unchecked(995)));
+        let psbt =
+            payjoin.calculate_psbt_with_fee_range(None, Some(FeeRate::from_sat_per_vb_u32(995)));
         match psbt {
             Err(InternalPayloadError::FeeTooHigh(proposed, max)) => {
                 assert_eq!(FeeRate::from_str("249630").unwrap(), proposed);
-                assert_eq!(FeeRate::from_sat_per_vb_unchecked(995), max);
+                assert_eq!(FeeRate::from_sat_per_vb_u32(995), max);
             }
             _ => panic!(
                 "Payjoin exceeds receiver fee preference and should error or unexpected error type"

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -428,7 +428,7 @@ mod test {
         let mut pj_uri = pj_uri();
         pj_uri.extras.output_substitution = OutputSubstitution::Enabled;
         let sender = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri)
-            .build_recommended(FeeRate::from_sat_per_vb_unchecked(1))
+            .build_recommended(FeeRate::from_sat_per_vb_u32(1))
             .expect("sender should succeed");
         assert_eq!(sender.psbt_ctx.output_substitution, OutputSubstitution::Enabled);
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -1203,7 +1203,7 @@ mod integration {
             let payjoin = payjoin
                 .apply_fee_range(
                     Some(FeeRate::BROADCAST_MIN),
-                    Some(FeeRate::from_sat_per_vb_unchecked(2)),
+                    Some(FeeRate::from_sat_per_vb_u32(2)),
                 )
                 .save(recv_persister)?;
 
@@ -1564,10 +1564,8 @@ mod integration {
             .contribute_inputs(inputs)
             .map_err(|e| format!("Failed to contribute inputs: {e:?}"))?
             .commit_inputs();
-        let payjoin = payjoin.apply_fee_range(
-            Some(FeeRate::BROADCAST_MIN),
-            Some(FeeRate::from_sat_per_vb_unchecked(2)),
-        )?;
+        let payjoin = payjoin
+            .apply_fee_range(Some(FeeRate::BROADCAST_MIN), Some(FeeRate::from_sat_per_vb_u32(2)))?;
 
         let payjoin_proposal = payjoin.finalize_proposal(|psbt: &Psbt| {
             receiver


### PR DESCRIPTION
This commit replaces from_sat_per_vb_unchecked with from_sat_per_vb_u32 as the previous method is now deprecated.  Curious though is that it says it has been deprecated since 0.32.7 but we have been on 0.32.8 for quite some time with no issues..?

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
