### PR TITLE
Add comment-triggered activity collection to payjoin-bot

### DIFF
--- a/.github/scripts/create_standup_discussion.py
+++ b/.github/scripts/create_standup_discussion.py
@@ -2,68 +2,27 @@
 """Create a weekly standup Discussion with auto-gathered activity per contributor."""
 
 import os
-import time
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 import requests
 import yaml
 
-REPO = os.environ["GITHUB_REPOSITORY"]
-TOKEN = os.environ["STANDUP_TOKEN"]
+from standup_lib import (
+    API,
+    HEADERS,
+    REPO,
+    format_contributor_comment,
+    gather_activity,
+    gather_potential_bottlenecks,
+    graphql,
+)
+
 CATEGORY_NODE_ID = os.environ["DISCUSSION_CATEGORY_NODE_ID"]
-API = "https://api.github.com"
-GRAPHQL = "https://api.github.com/graphql"
-HEADERS = {
-    "Authorization": f"token {TOKEN}",
-    "Accept": "application/vnd.github+json",
-}
 
 _CONFIG_PATH = Path(__file__).resolve().parent.parent / "standup-contributors.yml"
 with open(_CONFIG_PATH) as _f:
     CONTRIBUTORS = [c["username"] for c in yaml.safe_load(_f)["contributors"]]
-
-# Public repos to search — explicit list avoids leaking private repo
-# data when the bot token has org membership.
-REPOS = [
-    "payjoin/rust-payjoin",
-    "payjoin/payjoin.org",
-    "payjoin/payjoindevkit.org",
-    "payjoin/cja",
-    "payjoin/cja-2",
-    "payjoin/bitcoin-hpke",
-    "payjoin/ohttp",
-    "payjoin/bitcoin_uri",
-    "payjoin/bitcoin-uri-ffi",
-    "payjoin/research-docs",
-    "payjoin/multiparty-protocol-docs",
-    "payjoin/btsim",
-    "payjoin/tx-indexer",
-    "Uniffi-Dart/uniffi-dart",
-]
-
-REPO_FILTER = " ".join(f"repo:{r}" for r in REPOS)
-
-
-def graphql(query, variables=None):
-    """Run a GraphQL query with retry on 403 rate limits."""
-    for attempt in range(5):
-        resp = requests.post(
-            GRAPHQL,
-            headers=HEADERS,
-            json={"query": query, "variables": variables or {}},
-        )
-        if resp.status_code == 403:
-            wait = 2**attempt
-            print(f"Rate limited (403), retrying in {wait}s...")
-            time.sleep(wait)
-            continue
-        resp.raise_for_status()
-        data = resp.json()
-        if "errors" in data:
-            raise RuntimeError(f"GraphQL errors: {data['errors']}")
-        return data["data"]
-    resp.raise_for_status()
 
 
 def get_repo_node_id():
@@ -179,224 +138,6 @@ def get_previous_thread_links():
         if user:
             links[user] = comment["url"]
     return links
-
-
-SEARCH_QUERY = """
-query($q: String!) {
-  search(query: $q, type: ISSUE, first: 30) {
-    nodes {
-      ... on PullRequest {
-        id
-        title
-        url
-        number
-        repository {
-          nameWithOwner
-        }
-        author { login }
-      }
-      ... on Issue {
-        id
-        title
-        url
-        number
-        repository {
-          nameWithOwner
-        }
-        author { login }
-      }
-    }
-  }
-}
-"""
-# This avoids refetching review history for the same PR multiple times in one run.
-PR_REVIEWS_CACHE = {}
-
-
-def search_issues(query):
-    """Run a GitHub search query across REPOS using GraphQL."""
-    q = f"{query} {REPO_FILTER}"
-    data = graphql(SEARCH_QUERY, {"q": q})
-    items = []
-    for node in data["search"]["nodes"]:
-        if not node:
-            continue
-        items.append(
-            {
-                "id": node["id"],
-                "title": node["title"],
-                "html_url": node["url"],
-                "number": node["number"],
-                "repository": node["repository"]["nameWithOwner"],
-                "user": {
-                    "login": node["author"]["login"] if node.get("author") else ""
-                },
-            }
-        )
-    return items
-
-
-def parse_github_datetime(value):
-    """Parse a GitHub ISO 8601 timestamp into an aware datetime."""
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def get_paginated(url, params=None):
-    """GET a paginated REST collection and return all items."""
-    items = []
-    next_url = url
-    next_params = params or {}
-    while next_url:
-        for attempt in range(5):
-            resp = requests.get(
-                next_url,
-                headers=HEADERS,
-                params=next_params,
-                timeout=30,
-            )
-            if resp.status_code in {403, 429} or 500 <= resp.status_code < 600:
-                wait = 2**attempt
-                print(
-                    f"REST request failed ({resp.status_code}), retrying in {wait}s..."
-                )
-                time.sleep(wait)
-                continue
-            resp.raise_for_status()
-            break
-        else:
-            resp.raise_for_status()
-        items.extend(resp.json())
-        next_url = resp.links.get("next", {}).get("url")
-        next_params = None
-    return items
-
-
-def get_pull_request_reviews(pr):
-    """Return all submitted reviews for a pull request."""
-    cache_key = (pr["repository"], pr["number"])
-    if cache_key in PR_REVIEWS_CACHE:
-        return PR_REVIEWS_CACHE[cache_key]
-
-    reviews = get_paginated(
-        f"{API}/repos/{pr['repository']}/pulls/{pr['number']}/reviews",
-        {"per_page": 100},
-    )
-    PR_REVIEWS_CACHE[cache_key] = reviews
-    return reviews
-
-
-def latest_reviewed_at(pr, reviewer):
-    """Return the reviewer's latest submitted review timestamp for a PR."""
-    latest = None
-    for review in get_pull_request_reviews(pr):
-        if review.get("user", {}).get("login") != reviewer:
-            continue
-        submitted_at = review.get("submitted_at")
-        if not submitted_at:
-            continue
-        submitted = parse_github_datetime(submitted_at)
-        if latest is None or submitted > latest:
-            latest = submitted
-    return latest
-
-
-def gather_activity(user, since_date):
-    """Gather a contributor's past-week activity across the org."""
-    since = since_date.strftime("%Y-%m-%d")
-
-    # PRs merged (authored)
-    merged_prs = search_issues(f"author:{user} type:pr merged:>{since}")
-
-    # PRs reviewed use search  to find candidate PRs then confirm
-    # the reviewer actually submitted a review during the standup window.
-    review_candidates = search_issues(
-        f"reviewed-by:{user} type:pr updated:>{since} sort:updated-desc"
-    )
-    seen_ids = set()
-    reviewed_prs = []
-    for pr in review_candidates:
-        if pr["id"] in seen_ids or pr["user"]["login"] == user:
-            continue
-        reviewed_at = latest_reviewed_at(pr, user)
-        if reviewed_at and reviewed_at > since_date:
-            seen_ids.add(pr["id"])
-            reviewed_prs.append(pr)
-
-    # Issues opened
-    issues_opened = search_issues(f"author:{user} type:issue created:>{since}")
-
-    return merged_prs, reviewed_prs, issues_opened
-
-
-def gather_potential_bottlenecks(user, since_date):
-    """Identify potential bottlenecks for a contributor."""
-    since = since_date.strftime("%Y-%m-%d")
-    bottlenecks = []
-
-    # Open PRs with no reviews
-    open_prs = search_issues(
-        f"author:{user} type:pr state:open review:none created:>{since}"
-    )
-    for pr in open_prs:
-        bottlenecks.append(f"- PR awaiting review: [{pr['title']}]({pr['html_url']})")
-
-    # PRs with requested changes
-    changes_requested = search_issues(
-        f"author:{user} type:pr state:open review:changes_requested"
-    )
-    for pr in changes_requested:
-        bottlenecks.append(
-            f"- PR has requested changes: [{pr['title']}]({pr['html_url']})"
-        )
-
-    return bottlenecks
-
-
-def format_contributor_comment(
-    user, merged_prs, reviewed_prs, issues_opened, bottlenecks, previous_thread_url=None
-):
-    """Format the threaded reply for a contributor."""
-    lines = [f"## {user}", "", f"@{user}", ""]
-
-    # SHIPPED section
-    lines.append("### Shipped")
-    if merged_prs or reviewed_prs or issues_opened:
-        if merged_prs:
-            lines.append("")
-            lines.append("**PRs merged:**")
-            for pr in merged_prs:
-                lines.append(f"- [{pr['title']}]({pr['html_url']})")
-
-        if reviewed_prs:
-            lines.append("")
-            lines.append("**PRs reviewed:**")
-            for pr in reviewed_prs:
-                lines.append(f"- [{pr['title']}]({pr['html_url']})")
-
-        if issues_opened:
-            lines.append("")
-            lines.append("**Issues opened:**")
-            for issue in issues_opened:
-                lines.append(f"- [{issue['title']}]({issue['html_url']})")
-    else:
-        lines.append("_No activity found._")
-
-    lines.append("")
-    lines.append("### Last Week")
-    if previous_thread_url:
-        lines.append("")
-        lines.append(
-            f"Review your previous thread: [Last week's thread]({previous_thread_url})"
-        )
-    else:
-        lines.append("_No previous thread found._")
-
-    if bottlenecks:
-        lines.append("")
-        lines.append("_Auto-detected signals:_")
-        lines.extend(bottlenecks)
-
-    return "\n".join(lines)
 
 
 def main():

--- a/.github/scripts/respond_to_standup_comment.py
+++ b/.github/scripts/respond_to_standup_comment.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Respond to a `/check-in` comment in a Weekly Check-in Discussion.
+
+Triggered by `.github/workflows/standup-on-comment.yml` on
+`discussion_comment` events. The workflow's `if:` block already filters
+to the Check-ins category and `Weekly Check-in:` titles; this script does
+the precise regex match and the per-week cap.
+"""
+
+import os
+import re
+import sys
+from datetime import timedelta
+
+from standup_lib import (
+    format_contributor_comment,
+    gather_activity,
+    gather_potential_bottlenecks,
+    graphql,
+    parse_github_datetime,
+)
+
+BOT_LOGIN = "payjoin-bot"
+TRIGGER_RE = re.compile(r"(?im)(^|\s)/check-in\b")
+SUCCESS_MARKER = "### Shipped"
+ERROR_BODY = "_Bot couldn't gather activity right now. Try again in a few minutes._"
+
+
+def has_prior_success(discussion_id, author):
+    """Return True if payjoin-bot has already posted a successful summary
+    in reply to a comment authored by ``author`` in this Discussion."""
+    data = graphql(
+        """
+        query($id: ID!) {
+          node(id: $id) {
+            ... on Discussion {
+              comments(first: 100) {
+                nodes {
+                  author { login }
+                  replies(first: 100) {
+                    nodes {
+                      body
+                      author { login }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """,
+        {"id": discussion_id},
+    )
+    for top in data["node"]["comments"]["nodes"]:
+        top_author = (top.get("author") or {}).get("login")
+        if top_author != author:
+            continue
+        for reply in top["replies"]["nodes"]:
+            reply_author = (reply.get("author") or {}).get("login")
+            if reply_author != BOT_LOGIN:
+                continue
+            if (reply.get("body") or "").startswith(SUCCESS_MARKER):
+                return True
+    return False
+
+
+def post_reply(discussion_id, reply_to_id, body):
+    """Post a threaded reply via GraphQL ``addDiscussionComment``."""
+    graphql(
+        """
+        mutation($discussionId: ID!, $replyToId: ID!, $body: String!) {
+          addDiscussionComment(input: {
+            discussionId: $discussionId,
+            replyToId: $replyToId,
+            body: $body
+          }) {
+            comment {
+              id
+            }
+          }
+        }
+        """,
+        {
+            "discussionId": discussion_id,
+            "replyToId": reply_to_id,
+            "body": body,
+        },
+    )
+
+
+def main():
+    comment_id = os.environ["COMMENT_ID"]
+    comment_body = os.environ["COMMENT_BODY"]
+    comment_author = os.environ["COMMENT_AUTHOR"]
+    discussion_id = os.environ["DISCUSSION_ID"]
+    discussion_created_at = os.environ["DISCUSSION_CREATED_AT"]
+
+    if not TRIGGER_RE.search(comment_body):
+        print("No /check-in token matched; nothing to do.")
+        return
+
+    if comment_author == BOT_LOGIN:
+        print("Loop guard: comment author is the bot; exiting.")
+        return
+
+    if has_prior_success(discussion_id, comment_author):
+        print(
+            f"Per-week cap: {comment_author} already received a successful "
+            "summary in this Discussion; exiting."
+        )
+        return
+
+    since_date = parse_github_datetime(discussion_created_at) - timedelta(days=7)
+
+    try:
+        merged_prs, reviewed_prs, issues_opened = gather_activity(
+            comment_author, since_date
+        )
+        bottlenecks = gather_potential_bottlenecks(comment_author, since_date)
+        body = format_contributor_comment(
+            comment_author,
+            merged_prs,
+            reviewed_prs,
+            issues_opened,
+            bottlenecks,
+            include_last_week=False,
+        )
+        post_reply(discussion_id, comment_id, body)
+        print(f"Posted activity summary for @{comment_author}.")
+    except Exception:
+        try:
+            post_reply(discussion_id, comment_id, ERROR_BODY)
+        except Exception as post_err:
+            print(f"Failed to post error reply: {post_err}", file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/standup_lib.py
+++ b/.github/scripts/standup_lib.py
@@ -1,0 +1,292 @@
+"""Shared helpers for standup automation (weekly post + on-comment trigger)."""
+
+import os
+import time
+from datetime import datetime
+
+import requests
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["STANDUP_TOKEN"]
+API = "https://api.github.com"
+GRAPHQL = "https://api.github.com/graphql"
+HEADERS = {
+    "Authorization": f"token {TOKEN}",
+    "Accept": "application/vnd.github+json",
+}
+
+# Public repos to search — explicit list avoids leaking private repo
+# data when the bot token has org membership.
+REPOS = [
+    "payjoin/rust-payjoin",
+    "payjoin/payjoin.org",
+    "payjoin/payjoindevkit.org",
+    "payjoin/cja",
+    "payjoin/cja-2",
+    "payjoin/bitcoin-hpke",
+    "payjoin/ohttp",
+    "payjoin/bitcoin_uri",
+    "payjoin/bitcoin-uri-ffi",
+    "payjoin/research-docs",
+    "payjoin/multiparty-protocol-docs",
+    "payjoin/btsim",
+    "payjoin/tx-indexer",
+    "Uniffi-Dart/uniffi-dart",
+]
+
+REPO_FILTER = " ".join(f"repo:{r}" for r in REPOS)
+
+
+def graphql(query, variables=None):
+    """Run a GraphQL query with retry on 403 rate limits."""
+    for attempt in range(5):
+        resp = requests.post(
+            GRAPHQL,
+            headers=HEADERS,
+            json={"query": query, "variables": variables or {}},
+        )
+        if resp.status_code == 403:
+            wait = 2**attempt
+            print(f"Rate limited (403), retrying in {wait}s...")
+            time.sleep(wait)
+            continue
+        resp.raise_for_status()
+        data = resp.json()
+        if "errors" in data:
+            raise RuntimeError(f"GraphQL errors: {data['errors']}")
+        return data["data"]
+    resp.raise_for_status()
+
+
+SEARCH_QUERY = """
+query($q: String!) {
+  search(query: $q, type: ISSUE, first: 30) {
+    nodes {
+      ... on PullRequest {
+        id
+        title
+        url
+        number
+        repository {
+          nameWithOwner
+        }
+        author { login }
+      }
+      ... on Issue {
+        id
+        title
+        url
+        number
+        repository {
+          nameWithOwner
+        }
+        author { login }
+      }
+    }
+  }
+}
+"""
+# This avoids refetching review history for the same PR multiple times in one run.
+PR_REVIEWS_CACHE = {}
+
+
+def search_issues(query):
+    """Run a GitHub search query across REPOS using GraphQL."""
+    q = f"{query} {REPO_FILTER}"
+    data = graphql(SEARCH_QUERY, {"q": q})
+    items = []
+    for node in data["search"]["nodes"]:
+        if not node:
+            continue
+        items.append(
+            {
+                "id": node["id"],
+                "title": node["title"],
+                "html_url": node["url"],
+                "number": node["number"],
+                "repository": node["repository"]["nameWithOwner"],
+                "user": {
+                    "login": node["author"]["login"] if node.get("author") else ""
+                },
+            }
+        )
+    return items
+
+
+def parse_github_datetime(value):
+    """Parse a GitHub ISO 8601 timestamp into an aware datetime."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def get_paginated(url, params=None):
+    """GET a paginated REST collection and return all items."""
+    items = []
+    next_url = url
+    next_params = params or {}
+    while next_url:
+        for attempt in range(5):
+            resp = requests.get(
+                next_url,
+                headers=HEADERS,
+                params=next_params,
+                timeout=30,
+            )
+            if resp.status_code in {403, 429} or 500 <= resp.status_code < 600:
+                wait = 2**attempt
+                print(
+                    f"REST request failed ({resp.status_code}), retrying in {wait}s..."
+                )
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            break
+        else:
+            resp.raise_for_status()
+        items.extend(resp.json())
+        next_url = resp.links.get("next", {}).get("url")
+        next_params = None
+    return items
+
+
+def get_pull_request_reviews(pr):
+    """Return all submitted reviews for a pull request."""
+    cache_key = (pr["repository"], pr["number"])
+    if cache_key in PR_REVIEWS_CACHE:
+        return PR_REVIEWS_CACHE[cache_key]
+
+    reviews = get_paginated(
+        f"{API}/repos/{pr['repository']}/pulls/{pr['number']}/reviews",
+        {"per_page": 100},
+    )
+    PR_REVIEWS_CACHE[cache_key] = reviews
+    return reviews
+
+
+def latest_reviewed_at(pr, reviewer):
+    """Return the reviewer's latest submitted review timestamp for a PR."""
+    latest = None
+    for review in get_pull_request_reviews(pr):
+        if review.get("user", {}).get("login") != reviewer:
+            continue
+        submitted_at = review.get("submitted_at")
+        if not submitted_at:
+            continue
+        submitted = parse_github_datetime(submitted_at)
+        if latest is None or submitted > latest:
+            latest = submitted
+    return latest
+
+
+def gather_activity(user, since_date):
+    """Gather a contributor's past-week activity across the org."""
+    since = since_date.strftime("%Y-%m-%d")
+
+    # PRs merged (authored)
+    merged_prs = search_issues(f"author:{user} type:pr merged:>{since}")
+
+    # PRs reviewed use search  to find candidate PRs then confirm
+    # the reviewer actually submitted a review during the standup window.
+    review_candidates = search_issues(
+        f"reviewed-by:{user} type:pr updated:>{since} sort:updated-desc"
+    )
+    seen_ids = set()
+    reviewed_prs = []
+    for pr in review_candidates:
+        if pr["id"] in seen_ids or pr["user"]["login"] == user:
+            continue
+        reviewed_at = latest_reviewed_at(pr, user)
+        if reviewed_at and reviewed_at > since_date:
+            seen_ids.add(pr["id"])
+            reviewed_prs.append(pr)
+
+    # Issues opened
+    issues_opened = search_issues(f"author:{user} type:issue created:>{since}")
+
+    return merged_prs, reviewed_prs, issues_opened
+
+
+def gather_potential_bottlenecks(user, since_date):
+    """Identify potential bottlenecks for a contributor."""
+    since = since_date.strftime("%Y-%m-%d")
+    bottlenecks = []
+
+    # Open PRs with no reviews
+    open_prs = search_issues(
+        f"author:{user} type:pr state:open review:none created:>{since}"
+    )
+    for pr in open_prs:
+        bottlenecks.append(f"- PR awaiting review: [{pr['title']}]({pr['html_url']})")
+
+    # PRs with requested changes
+    changes_requested = search_issues(
+        f"author:{user} type:pr state:open review:changes_requested"
+    )
+    for pr in changes_requested:
+        bottlenecks.append(
+            f"- PR has requested changes: [{pr['title']}]({pr['html_url']})"
+        )
+
+    return bottlenecks
+
+
+def format_contributor_comment(
+    user,
+    merged_prs,
+    reviewed_prs,
+    issues_opened,
+    bottlenecks,
+    previous_thread_url=None,
+    include_last_week=True,
+):
+    """Format the threaded reply for a contributor.
+
+    With ``include_last_week=True`` (Monday's bulk post) the body opens with a
+    user header + @-mention and ends with a "Last Week" link block. With
+    ``include_last_week=False`` (on-demand /check-in reply) the body starts at
+    ``### Shipped`` so the per-week-cap success marker matches, and there is no
+    @-mention of the commenter.
+    """
+    lines = []
+    if include_last_week:
+        lines.extend([f"## {user}", "", f"@{user}", ""])
+
+    # SHIPPED section
+    lines.append("### Shipped")
+    if merged_prs or reviewed_prs or issues_opened:
+        if merged_prs:
+            lines.append("")
+            lines.append("**PRs merged:**")
+            for pr in merged_prs:
+                lines.append(f"- [{pr['title']}]({pr['html_url']})")
+
+        if reviewed_prs:
+            lines.append("")
+            lines.append("**PRs reviewed:**")
+            for pr in reviewed_prs:
+                lines.append(f"- [{pr['title']}]({pr['html_url']})")
+
+        if issues_opened:
+            lines.append("")
+            lines.append("**Issues opened:**")
+            for issue in issues_opened:
+                lines.append(f"- [{issue['title']}]({issue['html_url']})")
+    else:
+        lines.append("_No activity found._")
+
+    if include_last_week:
+        lines.append("")
+        lines.append("### Last Week")
+        if previous_thread_url:
+            lines.append("")
+            lines.append(
+                f"Review your previous thread: [Last week's thread]({previous_thread_url})"
+            )
+        else:
+            lines.append("_No previous thread found._")
+
+    if bottlenecks:
+        lines.append("")
+        lines.append("_Auto-detected signals:_")
+        lines.extend(bottlenecks)
+
+    return "\n".join(lines)

--- a/.github/workflows/standup-on-comment.yml
+++ b/.github/workflows/standup-on-comment.yml
@@ -1,0 +1,29 @@
+name: Standup On Comment
+
+on:
+  discussion_comment:
+    types: [created]
+
+jobs:
+  respond:
+    if: |
+      github.event.discussion.category.slug == 'check-ins' &&
+      startsWith(github.event.discussion.title, 'Weekly Check-in:') &&
+      github.event.comment.user.login != 'payjoin-bot' &&
+      contains(github.event.comment.body, '/check-in')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install requests pyyaml
+      - run: python .github/scripts/respond_to_standup_comment.py
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STANDUP_TOKEN: ${{ secrets.STANDUP_BOT_TOKEN || secrets.STANDUP_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.node_id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+          DISCUSSION_CREATED_AT: ${{ github.event.discussion.created_at }}

--- a/.github/workflows/standup-on-comment.yml
+++ b/.github/workflows/standup-on-comment.yml
@@ -9,6 +9,7 @@ jobs:
     if: |
       github.event.discussion.category.slug == 'check-ins' &&
       startsWith(github.event.discussion.title, 'Weekly Check-in:') &&
+      github.event.comment.parent_id == null &&
       github.event.comment.user.login != 'payjoin-bot' &&
       contains(github.event.comment.body, '/check-in')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the asymmetry where only a pre-defined list of contributors get a pre-made activity thread on
Monday but newcomers and async-only contributors had to self-post
manually with no auto-gathered activity.

Tested [in a discussion on my branch](https://github.com/DanGould/rust-payjoin/discussions/38) [with this discussion comment](https://github.com/DanGould/rust-payjoin/actions/runs/24924953834).

Very much completely claude coded.

This is what the robots ran to verify:

- [x] `python -m py_compile` on the three Python files
- [x] YAML safe-load on the new workflow
- [x] Behavioral parity check on `format_contributor_comment` between
      the pre-refactor baseline and the new lib — Monday default path
      is byte-identical (via dry-run)
- [x] Trigger regex `(?im)(^|\s)/check-in\b` accepts standalone /
      line-anchored / case variants; rejects `foo/check-in/bar` and
      `not-a/check-in`
- [x] Manual dry-trace for: valid `/check-in`; bot self-comment; wrong
      category; same user after prior success (cap consumed); same
      user after prior failure (`### Shipped` absent → retry allowed)

## Post-merge acceptance:

- [ ] Comment `/check-in` from a non-listed account in the next
      Weekly Check-in Discussion → bot replies within ~2 min,
      threaded under the trigger
- [ ] Comment `/check-in` again from same account → no response
- [x] Comment `/check-in` from a different account → response
- [ ] Comment `/check-in` in a non-Check-in Discussion → workflow
      does not run
- [ ] Force a gather failure → bot posts the error template and the
      job is red; re-comment `/check-in` → bot retries successfully

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
