### PR TITLE
Demo sender fallback

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -336,6 +336,8 @@ fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError
         Commands::Resume => Ok(config),
         #[cfg(feature = "v2")]
         Commands::History => Ok(config),
+        #[cfg(feature = "v2")]
+        Commands::Fallback { .. } => Ok(config),
     }
 }
 

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -10,6 +10,8 @@ pub mod config;
 pub mod wallet;
 use crate::app::config::Config;
 use crate::app::wallet::BitcoindWallet;
+#[cfg(feature = "v2")]
+use crate::db::v2::SessionId;
 
 #[cfg(feature = "v1")]
 pub(crate) mod v1;
@@ -28,6 +30,8 @@ pub trait App: Send + Sync {
     async fn resume_payjoins(&self) -> Result<()>;
     #[cfg(feature = "v2")]
     async fn history(&self) -> Result<()>;
+    #[cfg(feature = "v2")]
+    async fn fallback_sender(&self, session_id: SessionId) -> Result<()>;
 
     fn create_original_psbt(
         &self,

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
@@ -11,7 +10,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use payjoin::bitcoin::psbt::Psbt;
+use payjoin::bitcoin::consensus::encode::serialize_hex;
 use payjoin::bitcoin::{Amount, FeeRate};
 use payjoin::receive::v1::{PayjoinProposal, UncheckedOriginalPayload};
 use payjoin::receive::Error;
@@ -64,6 +63,7 @@ impl AppTrait for App {
         let uri = uri.check_pj_supported().map_err(|_| anyhow!("URI does not support Payjoin"))?;
         let amount = uri.amount.ok_or_else(|| anyhow!("please specify the amount in the Uri"))?;
         let psbt = self.create_original_psbt(&uri.address, amount, fee_rate)?;
+        let fallback_tx = psbt.clone().extract_tx()?;
         let (req, ctx) = SenderBuilder::new(psbt, uri.clone())
             .build_recommended(fee_rate)
             .with_context(|| "Failed to build payjoin request")?
@@ -71,25 +71,36 @@ impl AppTrait for App {
         let http = http_agent(&self.config)?;
         let body = String::from_utf8(req.body.clone()).unwrap();
         println!("Sending Original PSBT to {}", req.url);
-        let response = http
+        let response = match http
             .post(req.url)
             .header("Content-Type", req.content_type)
             .body(body.clone())
             .send()
             .await
-            .with_context(|| "HTTP request failed")?;
-        let fallback_tx = Psbt::from_str(&body)
-            .map_err(|e| anyhow!("Failed to load PSBT from base64: {}", e))?
-            .extract_tx()?;
-        println!("Fallback transaction txid: {}", fallback_tx.compute_txid());
-        println!(
-            "Fallback transaction hex: {:#}",
-            payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
-        );
-        let psbt = ctx.process_response(&response.bytes().await?).map_err(|e| {
-            tracing::debug!("Error processing response: {e:?}");
-            anyhow!("Failed to process response {e}")
-        })?;
+        {
+            Ok(response) => response,
+            Err(e) => {
+                tracing::error!("HTTP request failed: {e}");
+                println!("Payjoin failed. To broadcast the fallback transaction, run:");
+                println!(
+                    "  bitcoin-cli -rpcwallet=<wallet> sendrawtransaction {:#}",
+                    serialize_hex(&fallback_tx)
+                );
+                return Err(anyhow!("HTTP request failed: {e}"));
+            }
+        };
+        let psbt = match ctx.process_response(&response.bytes().await?) {
+            Ok(psbt) => psbt,
+            Err(e) => {
+                tracing::error!("Error processing response: {e:?}");
+                println!("Payjoin failed. To broadcast the fallback transaction, run:");
+                println!(
+                    "  bitcoin-cli -rpcwallet=<wallet> sendrawtransaction {:#}",
+                    serialize_hex(&fallback_tx)
+                );
+                return Err(anyhow!("Failed to process response {e}"));
+            }
+        };
 
         self.process_pj_response(psbt)?;
         Ok(())

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -116,6 +116,11 @@ impl AppTrait for App {
     async fn history(&self) -> Result<()> {
         unimplemented!("history not implemented for v1");
     }
+
+    #[cfg(feature = "v2")]
+    async fn fallback_sender(&self, _session_id: crate::db::v2::SessionId) -> Result<()> {
+        anyhow::bail!("fallback is only supported for v2 (BIP77) sessions")
+    }
 }
 
 impl App {

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -241,9 +241,21 @@ impl AppTrait for App {
                 };
                 let mut interrupt = self.interrupt.clone();
                 tokio::select! {
-                    res = self.process_sender_session(sender_state, &persister) => return res,
+                    res = self.process_sender_session(sender_state, &persister) => {
+                        match res {
+                            Ok(()) => return Ok(()),
+                            Err(err) => {
+                                let id = persister.session_id();
+                                println!("Session {id} failed. Run `payjoin-cli fallback {id}` to broadcast the original transaction.");
+                                return Err(err);
+                            }
+                        }
+                    },
                     _ = interrupt.changed() => {
-                        println!("Interrupted. Call `send` with the same arguments to resume this session or `resume` to resume all sessions.");
+                        let id = persister.session_id();
+                        println!(
+                            "Session {id} interrupted. Call `send` again to resume, `resume` to resume all sessions, or `payjoin-cli fallback {id}` to broadcast the original transaction."
+                        );
                         return Err(anyhow!("Interrupted"))
                     }
                 }
@@ -461,6 +473,32 @@ impl AppTrait for App {
 
         Ok(())
     }
+
+    async fn fallback_sender(&self, session_id: SessionId) -> Result<()> {
+        let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
+        let (session, history) = replay_sender_event_log(&persister)?;
+
+        if let SendSession::Closed(SenderSessionOutcome::Success(proposal)) = session {
+            let txid = proposal.clone().extract_tx_unchecked_fee_rate().compute_txid();
+            println!(
+                "Session {session_id} already produced payjoin transaction {txid}. \
+                 Broadcasting the original now would double-spend against it. \
+                 If the payjoin tx needs re-broadcast, run \
+                 `bitcoin-cli gettransaction {txid}` to fetch the hex, then \
+                 `bitcoin-cli sendrawtransaction <hex>`."
+            );
+            return Ok(());
+        }
+
+        let fallback_tx = history.fallback_tx();
+        self.wallet().broadcast_tx(&fallback_tx)?;
+        println!("Broadcasted fallback transaction txid: {}", fallback_tx.compute_txid());
+
+        if let Err(e) = SessionPersister::close(&persister) {
+            tracing::warn!("Failed to close session {session_id} after fallback: {e}");
+        }
+        Ok(())
+    }
 }
 
 impl App {
@@ -489,7 +527,14 @@ impl App {
                 self.process_pj_response(proposal)?;
                 return Ok(());
             }
-            _ => return Err(anyhow!("Unexpected sender state")),
+            SendSession::Closed(SenderSessionOutcome::Failure)
+            | SendSession::Closed(SenderSessionOutcome::Cancel) => {
+                let id = persister.session_id();
+                println!(
+                    "Session {id} ended without payjoin. Run `payjoin-cli fallback {id}` to broadcast the original transaction."
+                );
+                return Ok(());
+            }
         }
         Ok(())
     }

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -166,9 +166,8 @@ impl AppTrait for App {
         match uri.extras.pj_param() {
             #[cfg(feature = "v1")]
             PjParam::V1(pj_param) => {
-                use std::str::FromStr;
-
                 let psbt = self.create_original_psbt(&address, amount, fee_rate)?;
+                let fallback_tx = psbt.clone().extract_tx()?;
                 let (req, ctx) = payjoin::send::v1::SenderBuilder::from_parts(
                     psbt,
                     pj_param,
@@ -181,25 +180,36 @@ impl AppTrait for App {
                 let http = http_agent(&self.config)?;
                 let body = String::from_utf8(req.body.clone()).unwrap();
                 println!("Sending Original PSBT to {}", req.url);
-                let response = http
+                let response = match http
                     .post(req.url)
                     .header("Content-Type", req.content_type)
                     .body(body.clone())
                     .send()
                     .await
-                    .with_context(|| "HTTP request failed")?;
-                let fallback_tx = payjoin::bitcoin::Psbt::from_str(&body)
-                    .map_err(|e| anyhow!("Failed to load PSBT from base64: {}", e))?
-                    .extract_tx()?;
-                println!("Fallback transaction txid: {}", fallback_tx.compute_txid());
-                println!(
-                    "Fallback transaction hex: {:#}",
-                    payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
-                );
-                let psbt = ctx.process_response(&response.bytes().await?).map_err(|e| {
-                    tracing::debug!("Error processing response: {e:?}");
-                    anyhow!("Failed to process response {e}")
-                })?;
+                {
+                    Ok(response) => response,
+                    Err(e) => {
+                        tracing::error!("HTTP request failed: {e}");
+                        println!("Payjoin failed. To broadcast the fallback transaction, run:");
+                        println!(
+                            "  bitcoin-cli -rpcwallet=<wallet> sendrawtransaction {:#}",
+                            payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
+                        );
+                        return Err(anyhow!("HTTP request failed: {e}"));
+                    }
+                };
+                let psbt = match ctx.process_response(&response.bytes().await?) {
+                    Ok(psbt) => psbt,
+                    Err(e) => {
+                        tracing::error!("Error processing response: {e:?}");
+                        println!("Payjoin failed. To broadcast the fallback transaction, run:");
+                        println!(
+                            "  bitcoin-cli -rpcwallet=<wallet> sendrawtransaction {:#}",
+                            payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
+                        );
+                        return Err(anyhow!("Failed to process response {e}"));
+                    }
+                };
 
                 self.process_pj_response(psbt)?;
                 Ok(())

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -133,6 +133,13 @@ pub enum Commands {
     #[cfg(feature = "v2")]
     /// Show payjoin session history
     History,
+    #[cfg(feature = "v2")]
+    /// Broadcast the original transaction for a sender session (BIP77/v2 only)
+    Fallback {
+        /// The session ID to broadcast the fallback transaction for
+        #[arg(required = true)]
+        session_id: i64,
+    },
 }
 
 pub fn parse_amount_in_sat(s: &str) -> Result<Amount, ParseAmountError> {

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -9,7 +9,7 @@ use rusqlite::params;
 use super::*;
 
 #[derive(Debug, Clone)]
-pub(crate) struct SessionId(i64);
+pub(crate) struct SessionId(pub(crate) i64);
 
 impl core::ops::Deref for SessionId {
     type Target = i64;
@@ -61,6 +61,8 @@ impl SenderPersister {
     }
 
     pub fn from_id(db: Arc<Database>, id: SessionId) -> Self { Self { db, session_id: id } }
+
+    pub fn session_id(&self) -> SessionId { self.session_id.clone() }
 }
 impl SessionPersister for SenderPersister {
     type SessionEvent = SenderSessionEvent;

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -6,6 +6,9 @@ use cli::{Cli, Commands};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
+#[cfg(feature = "v2")]
+use crate::db::v2::SessionId;
+
 mod app;
 mod cli;
 mod db;
@@ -74,6 +77,10 @@ async fn main() -> Result<()> {
         #[cfg(feature = "v2")]
         Commands::History => {
             app.history().await?;
+        }
+        #[cfg(feature = "v2")]
+        Commands::Fallback { session_id } => {
+            app.fallback_sender(SessionId(*session_id)).await?;
         }
     };
 

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -1,13 +1,15 @@
 #[cfg(feature = "_manual-tls")]
 mod e2e {
     use std::process::{ExitStatus, Stdio};
+    use std::str::FromStr;
 
     use nix::sys::signal::{kill, Signal};
     use nix::unistd::Pid;
+    use payjoin::bitcoin::Txid;
     use payjoin_test_utils::{init_bitcoind_sender_receiver, BoxError};
     use tempfile::tempdir;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-    use tokio::process::Command;
+    use tokio::process::{Child, Command};
 
     async fn terminate(mut child: tokio::process::Child) -> tokio::io::Result<ExitStatus> {
         let pid = child.id().expect("Failed to get child PID");
@@ -62,6 +64,20 @@ mod e2e {
         }
 
         res
+    }
+
+    async fn send_until_request_timeout(mut cli_sender: Child) -> Result<(), BoxError> {
+        let mut stdout = cli_sender.stdout.take().expect("failed to take stdout of child process");
+        let timeout = tokio::time::Duration::from_secs(35);
+        let res = tokio::time::timeout(
+            timeout,
+            wait_for_stdout_match(&mut stdout, |line| line.contains("No response yet.")),
+        )
+        .await?;
+
+        terminate(cli_sender).await.expect("Failed to kill payjoin-cli initial sender");
+        assert!(res.is_some(), "Fallback send was not detected");
+        Ok(())
     }
 
     #[cfg(feature = "v1")]
@@ -201,7 +217,6 @@ mod e2e {
     async fn send_receive_payjoin_v2() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use payjoin_test_utils::{init_tracing, TestServices};
         use tempfile::TempDir;
-        use tokio::process::Child;
 
         type Result<T> = std::result::Result<T, BoxError>;
 
@@ -382,21 +397,6 @@ mod e2e {
                 .spawn()
                 .expect("Failed to execute payjoin-cli");
             check_resume_has_no_sessions(cli_send_resumer).await?;
-            Ok(())
-        }
-
-        async fn send_until_request_timeout(mut cli_sender: Child) -> Result<()> {
-            let mut stdout =
-                cli_sender.stdout.take().expect("failed to take stdout of child process");
-            let timeout = tokio::time::Duration::from_secs(35);
-            let res = tokio::time::timeout(
-                timeout,
-                wait_for_stdout_match(&mut stdout, |line| line.contains("No response yet.")),
-            )
-            .await?;
-
-            terminate(cli_sender).await.expect("Failed to kill payjoin-cli initial sender");
-            assert!(res.is_some(), "Fallback send was not detected");
             Ok(())
         }
 
@@ -615,6 +615,144 @@ mod e2e {
             terminate(cli_send_v2).await.expect("Failed to kill payjoin-cli v2 sender");
 
             assert!(payjoin_sent, "Expected payjoin completion or fallback transaction");
+
+            Ok(())
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "v2")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sender_fallback_v2() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use payjoin_test_utils::{init_tracing, TestServices};
+        use tempfile::TempDir;
+
+        type Result<T> = std::result::Result<T, BoxError>;
+
+        init_tracing();
+        let mut services = TestServices::initialize().await?;
+        let temp_dir = tempdir()?;
+
+        let result = tokio::select! {
+            res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {res:?}").into()),
+            res = services.take_directory_handle() => Err(format!("Directory server is long running: {res:?}").into()),
+            res = fallback_cli_async(&services, &temp_dir) => res,
+        };
+
+        assert!(result.is_ok(), "sender_fallback_v2 failed: {:#?}", result.unwrap_err());
+
+        async fn fallback_cli_async(services: &TestServices, temp_dir: &TempDir) -> Result<()> {
+            let sender_db_path = temp_dir.path().join("sender_db");
+            let (bitcoind, sender, _receiver) = init_bitcoind_sender_receiver(None, None)?;
+            let cert_path = &temp_dir.path().join("localhost.der");
+            tokio::fs::write(cert_path, services.cert()).await?;
+            services.wait_for_services_ready().await?;
+            let ohttp_keys = services.fetch_ohttp_keys().await?;
+            let ohttp_keys_path = temp_dir.path().join("ohttp_keys");
+            tokio::fs::write(&ohttp_keys_path, ohttp_keys.encode()?).await?;
+
+            let receiver_db_path = temp_dir.path().join("receiver_db");
+            let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
+            let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
+            let cookie_file = &bitcoind.params.cookie_file;
+            let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
+            let directory = &services.directory_url();
+            let ohttp_relay = &services.ohttp_relay_url();
+
+            // Get a BIP21 from a receiver then kill it so the sender can never complete payjoin
+            let cli_receiver = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("receive")
+                .arg(RECEIVE_SATS)
+                .arg("--pj-directory")
+                .arg(directory)
+                .arg("--ohttp-keys")
+                .arg(&ohttp_keys_path)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli receiver");
+            let bip21 = get_bip21_from_receiver(cli_receiver).await;
+
+            // Start sender and capture the session-id from the hint line, then interrupt
+            let cli_sender = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&sender_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&sender_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("send")
+                .arg(&bip21)
+                .arg("--fee-rate")
+                .arg("1")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli sender");
+
+            send_until_request_timeout(cli_sender).await?;
+
+            // There is only one sender session in progress.
+            let session_id = 1i64;
+            // Ensure the fallback was not broadcast yet
+            let mempool_size =
+                sender.get_mempool_info().expect("should be able to get mempool").unbroadcast_count;
+            assert_eq!(mempool_size, 0, "fallback should not be in mempool");
+
+            // Run `payjoin-cli fallback <session-id>` and assert broadcast
+            let mut cli_fallback = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&sender_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&sender_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("fallback")
+                .arg(session_id.to_string())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli fallback");
+
+            let mut fallback_stdout =
+                cli_fallback.stdout.take().expect("failed to take stdout of fallback");
+            let timeout = tokio::time::Duration::from_secs(10);
+            let broadcast_line = tokio::time::timeout(
+                timeout,
+                wait_for_stdout_match(&mut fallback_stdout, |l| {
+                    l.contains("Broadcasted fallback transaction txid")
+                }),
+            )
+            .await?;
+
+            terminate(cli_fallback).await.expect("Failed to kill payjoin-cli fallback");
+            let subcommand_output = broadcast_line.expect("fallback should broadcast");
+            let fallback_txid = subcommand_output.split_whitespace().nth(4).unwrap_or("");
+            let fallback_txid = Txid::from_str(fallback_txid).expect("valid txid");
+
+            assert!(
+                sender.get_raw_transaction(fallback_txid).is_ok(),
+                "fallback tx should be in the mempool"
+            );
 
             Ok(())
         }


### PR DESCRIPTION
Code migrated from #1164. There were many conflicts.

The tricky thing with v2 is we don't want to fallback when there is a transient error. Luckly, our session outcome abstracts all that away. If after a replay a session is closed due to either a failure or cancellation we broadcast the fallback. But this requires a replay. Say your payjoin proposal was faulty, currently you have to resume again for the fallback to be broadasted which I think defeats the purpose of a "demo". i.e what we wants devs to replicate in their apps.

Instead, internally in Pj-cli we can replay again if an error occured (or if https://github.com/payjoin/rust-payjoin/issues/1197 we can avoid disk reads) check if the session is closed and fallback accordingly.  


cc @zealsham  @chavic 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
