### PR TITLE
Fix unused results in session unit tests

### DIFF
--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -381,14 +381,19 @@ mod tests {
         let session_context = SessionContext { expiration, ..SHARED_CONTEXT.clone() };
 
         let persister = InMemoryTestPersister::<SessionEvent>::default();
-        persister.save_event(SessionEvent::Created(session_context.clone()));
+        persister
+            .save_event(SessionEvent::Created(session_context.clone()))
+            .expect("in memory persister save should not fail");
         let err = replay_event_log(&persister).expect_err("session should be expired");
         let expected_err: ReplayError<ReceiveSession, SessionEvent> =
             InternalReplayError::Expired(expiration).into();
         assert_eq!(err.to_string(), expected_err.to_string());
 
         let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
-        persister.save_event(SessionEvent::Created(session_context)).await;
+        persister
+            .save_event(SessionEvent::Created(session_context))
+            .await
+            .expect("in memory async persister save should not fail");
         let err = replay_event_log_async(&persister).await.expect_err("session should be expired");
         let expected_err: ReplayError<ReceiveSession, SessionEvent> =
             InternalReplayError::Expired(expiration).into();
@@ -398,7 +403,9 @@ mod tests {
     #[tokio::test]
     async fn test_replaying_session_with_missing_created_event() {
         let persister = InMemoryTestPersister::<SessionEvent>::default();
-        persister.save_event(SessionEvent::CheckedBroadcastSuitability());
+        persister
+            .save_event(SessionEvent::CheckedBroadcastSuitability())
+            .expect("in memory persister save should not fail");
         assert!(!persister.inner.read().expect("session read should succeed").is_closed);
         let err = replay_event_log(&persister).expect_err("session replay should be fail");
         let expected_err: ReplayError<ReceiveSession, SessionEvent> =
@@ -411,7 +418,10 @@ mod tests {
         assert!(persister.inner.read().expect("lock should not be poisoned").is_closed);
 
         let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
-        persister.save_event(SessionEvent::CheckedBroadcastSuitability()).await;
+        persister
+            .save_event(SessionEvent::CheckedBroadcastSuitability())
+            .await
+            .expect("in memory async persister save should not fail");
         assert!(!persister.inner.read().await.is_closed);
         let err =
             replay_event_log_async(&persister).await.expect_err("session replay should be fail");

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -423,7 +423,9 @@ mod tests {
     #[tokio::test]
     async fn test_replaying_session_with_missing_created_event() {
         let persister = InMemoryTestPersister::<SessionEvent>::default();
-        persister.save_event(SessionEvent::PostedOriginalPsbt());
+        persister
+            .save_event(SessionEvent::PostedOriginalPsbt())
+            .expect("in memory persister save should not fail");
         assert!(!persister.inner.read().expect("session read should succeed").is_closed);
         let err = replay_event_log(&persister).expect_err("session replay should be fail");
         let expected_err: ReplayError<SendSession, SessionEvent> =
@@ -433,7 +435,10 @@ mod tests {
         assert!(persister.inner.read().expect("lock should not be poisoned").is_closed);
 
         let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
-        persister.save_event(SessionEvent::PostedOriginalPsbt()).await;
+        persister
+            .save_event(SessionEvent::PostedOriginalPsbt())
+            .await
+            .expect("in memory async persister save should not fail");
         assert!(!persister.inner.read().await.is_closed);
         let err =
             replay_event_log_async(&persister).await.expect_err("session replay should be fail");


### PR DESCRIPTION
We always expect the in-memory persister to save properly. My local lint.sh was picking this up. Not sure how CI missed it. 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
