### PR TITLE
Allow receiver configure session expiry.

### DIFF
--- a/payjoin-cli/example.config.toml
+++ b/payjoin-cli/example.config.toml
@@ -49,6 +49,9 @@ rpcpassword = "password"
 # Version 2 Configuration
 # [v2]
 # pj_directory = "https://payjo.in"
+# Optional receive session lifetime in seconds (omit for the library default).
+# Must be in 1..=4294967295.
+# session_ttl = 3600
 # ohttp_relays = ["https://pj.benalleng.com", "https://pj.bobspacebkk.com", "https://ohttp.achow101.com", "https://example.com"]
 # # Optional: The HPKE keys which need to be fetched ahead of time from the pj_endpoint
 # # for the payjoin packets to be encrypted.

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -36,6 +36,10 @@ pub struct V2Config {
     pub ohttp_keys: Option<payjoin::OhttpKeys>,
     pub ohttp_relays: Vec<Url>,
     pub pj_directory: Url,
+    /// Lifetime of a receive session from creation, in seconds. When omitted,
+    /// the payjoin crate default applies. Must be in `1..=u32::MAX`.
+    #[serde(default, deserialize_with = "deserialize_session_ttl")]
+    pub session_ttl: Option<u64>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -311,6 +315,8 @@ fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError
             pj_directory,
             #[cfg(feature = "v2")]
             ohttp_keys,
+            #[cfg(feature = "v2")]
+            session_ttl,
             ..
         } => {
             #[cfg(feature = "v1")]
@@ -329,7 +335,8 @@ fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError
                 .set_override_option(
                     "v2.ohttp_keys",
                     ohttp_keys.as_ref().map(|s| s.to_string_lossy().into_owned()),
-                )?;
+                )?
+                .set_override_option("v2.session_ttl", session_ttl.map(|s| s.to_string()))?;
             Ok(config)
         }
         #[cfg(feature = "v2")]
@@ -338,6 +345,20 @@ fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError
         Commands::History => Ok(config),
         #[cfg(feature = "v2")]
         Commands::Fallback { .. } => Ok(config),
+    }
+}
+
+#[cfg(feature = "v2")]
+fn deserialize_session_ttl<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let secs: Option<u64> = Option::deserialize(deserializer)?;
+    match secs {
+        Some(0) => Err(serde::de::Error::custom("session_ttl must be greater than 0")),
+        Some(n) if n > u32::MAX as u64 =>
+            Err(serde::de::Error::custom(format!("session_ttl must be <= {} seconds", u32::MAX))),
+        other => Ok(other),
     }
 }
 

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -281,12 +281,15 @@ impl AppTrait for App {
                 .await?
                 .ohttp_keys;
         let persister = ReceiverPersister::new(self.db.clone())?;
-        let session =
-            ReceiverBuilder::new(address, self.config.v2()?.pj_directory.as_str(), ohttp_keys)?
-                .with_amount(amount)
-                .with_max_fee_rate(self.config.max_fee_rate.unwrap_or(FeeRate::BROADCAST_MIN))
-                .build()
-                .save(&persister)?;
+        let v2 = self.config.v2()?;
+        let mut receiver = ReceiverBuilder::new(address, v2.pj_directory.as_str(), ohttp_keys)?
+            .with_amount(amount)
+            .with_max_fee_rate(self.config.max_fee_rate.unwrap_or(FeeRate::BROADCAST_MIN));
+        if let Some(secs) = v2.session_ttl {
+            let duration = std::time::Duration::from_secs(secs);
+            receiver = receiver.with_expiration(duration);
+        }
+        let session = receiver.build().save(&persister)?;
 
         println!("Receive session established");
         let pj_uri = session.pj_uri();

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -126,6 +126,11 @@ pub enum Commands {
         /// The path to the ohttp keys file
         #[arg(long = "ohttp-keys", value_parser = value_parser!(PathBuf))]
         ohttp_keys: Option<PathBuf>,
+
+        #[cfg(feature = "v2")]
+        /// Receive session lifetime in seconds (BIP77 mailbox session). Omit for the payjoin crate default.
+        #[arg(long = "session-ttl", value_parser = parse_session_ttl)]
+        session_ttl: Option<u64>,
     },
     /// Resume pending payjoins (BIP77/v2 only)
     #[cfg(feature = "v2")]
@@ -154,4 +159,17 @@ pub fn parse_fee_rate_in_sat_per_vb(s: &str) -> Result<FeeRate, std::num::ParseF
 
 fn parse_boxed_url(s: &str) -> Result<Box<Url>, String> {
     s.parse::<Url>().map(Box::new).map_err(|e| e.to_string())
+}
+
+/// Parse a positive session TTL in seconds, bounded by u32::MAX
+#[cfg(feature = "v2")]
+fn parse_session_ttl(s: &str) -> Result<u64, String> {
+    let secs: u64 = s.parse().map_err(|e: std::num::ParseIntError| e.to_string())?;
+    if secs == 0 {
+        return Err("session TTL must be greater than 0".to_string());
+    }
+    if secs > u32::MAX as u64 {
+        return Err(format!("session TTL must be <= {} seconds", u32::MAX));
+    }
+    Ok(secs)
 }


### PR DESCRIPTION
This pr addreses #1515, it allows receiver to set custom expiration time in payjoin-cli.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
