### PR TITLE
Use BIP 78 spec terms in payjoin-cli prints

### DIFF
--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -70,7 +70,7 @@ impl AppTrait for App {
             .create_v1_post_request();
         let http = http_agent(&self.config)?;
         let body = String::from_utf8(req.body.clone()).unwrap();
-        println!("Sending fallback request to {}", req.url);
+        println!("Sending Original PSBT to {}", req.url);
         let response = http
             .post(req.url)
             .header("Content-Type", req.content_type)
@@ -81,9 +81,9 @@ impl AppTrait for App {
         let fallback_tx = Psbt::from_str(&body)
             .map_err(|e| anyhow!("Failed to load PSBT from base64: {}", e))?
             .extract_tx()?;
-        println!("Sent fallback transaction txid: {}", fallback_tx.compute_txid());
+        println!("Fallback transaction txid: {}", fallback_tx.compute_txid());
         println!(
-            "Sent fallback transaction hex: {:#}",
+            "Fallback transaction hex: {:#}",
             payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
         );
         let psbt = ctx.process_response(&response.bytes().await?).map_err(|e| {

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -180,7 +180,7 @@ impl AppTrait for App {
                 .create_v1_post_request();
                 let http = http_agent(&self.config)?;
                 let body = String::from_utf8(req.body.clone()).unwrap();
-                println!("Sending fallback request to {}", req.url);
+                println!("Sending Original PSBT to {}", req.url);
                 let response = http
                     .post(req.url)
                     .header("Content-Type", req.content_type)
@@ -191,9 +191,9 @@ impl AppTrait for App {
                 let fallback_tx = payjoin::bitcoin::Psbt::from_str(&body)
                     .map_err(|e| anyhow!("Failed to load PSBT from base64: {}", e))?
                     .extract_tx()?;
-                println!("Sent fallback transaction txid: {}", fallback_tx.compute_txid());
+                println!("Fallback transaction txid: {}", fallback_tx.compute_txid());
                 println!(
-                    "Sent fallback transaction hex: {:#}",
+                    "Fallback transaction hex: {:#}",
                     payjoin::bitcoin::consensus::encode::serialize_hex(&fallback_tx)
                 );
                 let psbt = ctx.process_response(&response.bytes().await?).map_err(|e| {
@@ -504,7 +504,7 @@ impl App {
         )?;
         let response = self.post_request(req).await?;
         let sender = sender.process_response(&response.bytes().await?, ctx).save(persister)?;
-        println!("Posted original proposal...");
+        println!("Posted Original PSBT...");
         self.get_proposed_payjoin_psbt(sender, persister).await
     }
 


### PR DESCRIPTION
Followup to discussion on v1-nomenclature.
Tightens payjoin-cli print strings to match BIP 78 parlance.

see https://github.com/payjoin/rust-payjoin/pull/1510#discussion_r3186232995

Changes:
- "Sending fallback request to {url}" -> "Sending Original PSBT to {url}"
  (v1 and v2 sender paths). The request body is the Original PSBT;
  it is not the fallback transaction.
- "Sent fallback transaction txid/hex: ..." -> "Fallback transaction
  txid/hex: ..." (v1 and v2 sender paths). At that point we have
  computed the signed original tx, not broadcast it.
- "Posted original proposal..." -> "Posted Original PSBT..." (v2
  sender). User-facing wording only; the internal "Original Proposal"
  name is intentional in BIP 77 (Original PSBT plus extra params)
  and is left alone.

Considered but left as-is:
- v2/mod.rs "Proposal received. Processing..." -- the response is the
  Payjoin proposal, acceptable shorthand.
- v2/mod.rs "...Responding with a Payjoin proposal." -- correct BIP 78.
- v2/mod.rs "Fallback transaction received." -- correct receiver-side
  use of "fallback transaction".

Disclosure: co-authored by Claude (claude-opus-4-7)