### PR TITLE
Ship `InMemoryPersister` to close #1519

### DIFF
--- a/payjoin-ffi/src/lib.rs
+++ b/payjoin-ffi/src/lib.rs
@@ -11,7 +11,7 @@ pub mod test_utils;
 pub mod uri;
 mod validation;
 
-pub use payjoin::persist::NoopSessionPersister;
+pub use payjoin::persist::InMemoryPersister;
 
 pub use crate::ohttp::*;
 pub use crate::output_substitution::*;

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -15,11 +15,7 @@ corepc-node = { version = "0.10.0", features = ["download", "29_0"] }
 http = "1.3.1"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 once_cell = "1.21.3"
-payjoin = { version = "0.25.0", features = [
-  "io",
-  "_manual-tls",
-  "_test-utils",
-] }
+payjoin = { version = "0.25.0", features = ["io", "_manual-tls"] }
 payjoin-mailroom = { path = "../payjoin-mailroom", features = ["_manual-tls"] }
 rcgen = "0.14.3"
 reqwest = { version = "0.12.23", default-features = false, features = [

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -25,8 +25,7 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 pub type BoxError = Box<dyn std::error::Error + 'static>;
 pub type BoxSendSyncError = Box<dyn std::error::Error + Send + Sync>;
 
-pub use payjoin::persist::test_utils::InMemoryTestPersister;
-pub use payjoin::persist::SessionPersister;
+pub use payjoin::persist::{InMemoryPersister, SessionPersister};
 
 static INIT_TRACING: OnceCell<()> = OnceCell::new();
 

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -37,7 +37,6 @@ v2 = ["_core", "hpke", "bhttp", "ohttp", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
 _manual-tls = ["rustls"]
-_test-utils = []
 
 [dependencies]
 bhttp = { version = "0.6.1", optional = true }

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -837,108 +837,104 @@ impl<E: 'static> SessionPersister for NoopSessionPersister<E> {
     fn close(&self) -> Result<(), Self::InternalStorageError> { Ok(()) }
 }
 
-#[cfg(feature = "_test-utils")]
-pub mod test_utils {
-    use std::sync::{Arc, RwLock};
+/// In-memory session persister for replaying sessions and introspecting events.
+#[derive(Clone)]
+pub struct InMemoryPersister<V> {
+    pub(crate) inner: std::sync::Arc<std::sync::RwLock<InnerStorage<V>>>,
+}
 
-    use crate::persist::SessionPersister;
+impl<V> Default for InMemoryPersister<V> {
+    fn default() -> Self {
+        Self { inner: std::sync::Arc::new(std::sync::RwLock::new(InnerStorage::default())) }
+    }
+}
 
-    #[derive(Clone)]
-    /// In-memory session persister for testing session replays and introspecting session events
-    pub struct InMemoryTestPersister<V> {
-        pub(crate) inner: Arc<RwLock<InnerStorage<V>>>,
+#[derive(Clone)]
+pub(crate) struct InnerStorage<V> {
+    pub(crate) events: std::sync::Arc<Vec<V>>,
+    pub(crate) is_closed: bool,
+}
+
+impl<V> Default for InnerStorage<V> {
+    fn default() -> Self { Self { events: std::sync::Arc::new(vec![]), is_closed: false } }
+}
+
+impl<V> SessionPersister for InMemoryPersister<V>
+where
+    V: Clone + 'static,
+{
+    type InternalStorageError = std::convert::Infallible;
+    type SessionEvent = V;
+
+    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
+        let mut inner = self.inner.write().expect("Lock should not be poisoned");
+        std::sync::Arc::make_mut(&mut inner.events).push(event);
+        Ok(())
     }
 
-    impl<V> Default for InMemoryTestPersister<V> {
-        fn default() -> Self { Self { inner: Arc::new(RwLock::new(InnerStorage::default())) } }
+    fn load(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
+        let inner = self.inner.read().expect("Lock should not be poisoned");
+        let events = std::sync::Arc::clone(&inner.events);
+        Ok(Box::new(
+            std::sync::Arc::try_unwrap(events).unwrap_or_else(|arc| (*arc).clone()).into_iter(),
+        ))
     }
 
-    #[derive(Clone)]
-    pub(crate) struct InnerStorage<V> {
-        pub(crate) events: std::sync::Arc<Vec<V>>,
-        pub(crate) is_closed: bool,
+    fn close(&self) -> Result<(), Self::InternalStorageError> {
+        let mut inner = self.inner.write().expect("Lock should not be poisoned");
+        inner.is_closed = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+/// Async in-memory session persister for replaying async sessions and introspecting events.
+pub struct InMemoryAsyncPersister<V> {
+    pub(crate) inner: std::sync::Arc<tokio::sync::RwLock<InnerStorage<V>>>,
+}
+
+#[cfg(test)]
+impl<V> Default for InMemoryAsyncPersister<V> {
+    fn default() -> Self {
+        Self { inner: std::sync::Arc::new(tokio::sync::RwLock::new(InnerStorage::default())) }
+    }
+}
+
+#[cfg(test)]
+impl<V> AsyncSessionPersister for InMemoryAsyncPersister<V>
+where
+    V: Clone + Send + Sync + 'static,
+{
+    type InternalStorageError = std::convert::Infallible;
+    type SessionEvent = V;
+
+    async fn save_event(
+        &self,
+        event: Self::SessionEvent,
+    ) -> Result<(), Self::InternalStorageError> {
+        let mut inner = self.inner.write().await;
+        std::sync::Arc::make_mut(&mut inner.events).push(event);
+        Ok(())
     }
 
-    impl<V> Default for InnerStorage<V> {
-        fn default() -> Self { Self { events: std::sync::Arc::new(vec![]), is_closed: false } }
-    }
-
-    impl<V> SessionPersister for InMemoryTestPersister<V>
-    where
-        V: Clone + 'static,
+    async fn load(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent> + Send>, Self::InternalStorageError>
     {
-        type InternalStorageError = std::convert::Infallible;
-        type SessionEvent = V;
-
-        fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
-            let mut inner = self.inner.write().expect("Lock should not be poisoned");
-            std::sync::Arc::make_mut(&mut inner.events).push(event);
-            Ok(())
-        }
-
-        fn load(
-            &self,
-        ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError>
-        {
-            let inner = self.inner.read().expect("Lock should not be poisoned");
-            let events = std::sync::Arc::clone(&inner.events);
-            Ok(Box::new(
-                std::sync::Arc::try_unwrap(events).unwrap_or_else(|arc| (*arc).clone()).into_iter(),
-            ))
-        }
-
-        fn close(&self) -> Result<(), Self::InternalStorageError> {
-            let mut inner = self.inner.write().expect("Lock should not be poisoned");
-            inner.is_closed = true;
-            Ok(())
-        }
+        let inner = self.inner.read().await;
+        let events = std::sync::Arc::clone(&inner.events);
+        Ok(Box::new(
+            std::sync::Arc::try_unwrap(events).unwrap_or_else(|arc| (*arc).clone()).into_iter(),
+        ))
     }
 
-    #[cfg(test)]
-    #[derive(Clone)]
-    /// Async in-memory session persister for testing async session replays and introspecting session events
-    pub struct InMemoryAsyncTestPersister<V> {
-        pub(crate) inner: Arc<tokio::sync::RwLock<InnerStorage<V>>>,
-    }
-
-    #[cfg(test)]
-    impl<V> Default for InMemoryAsyncTestPersister<V> {
-        fn default() -> Self {
-            Self { inner: Arc::new(tokio::sync::RwLock::new(InnerStorage::default())) }
-        }
-    }
-
-    #[cfg(test)]
-    impl<V> crate::persist::AsyncSessionPersister for InMemoryAsyncTestPersister<V>
-    where
-        V: Clone + Send + Sync + 'static,
-    {
-        type InternalStorageError = std::convert::Infallible;
-        type SessionEvent = V;
-
-        async fn save_event(
-            &self,
-            event: Self::SessionEvent,
-        ) -> Result<(), Self::InternalStorageError> {
-            let mut inner = self.inner.write().await;
-            Arc::make_mut(&mut inner.events).push(event);
-            Ok(())
-        }
-
-        async fn load(
-            &self,
-        ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent> + Send>, Self::InternalStorageError>
-        {
-            let inner = self.inner.read().await;
-            let events = Arc::clone(&inner.events);
-            Ok(Box::new(Arc::try_unwrap(events).unwrap_or_else(|arc| (*arc).clone()).into_iter()))
-        }
-
-        async fn close(&self) -> Result<(), Self::InternalStorageError> {
-            let mut inner = self.inner.write().await;
-            inner.is_closed = true;
-            Ok(())
-        }
+    async fn close(&self) -> Result<(), Self::InternalStorageError> {
+        let mut inner = self.inner.write().await;
+        inner.is_closed = true;
+        Ok(())
     }
 }
 
@@ -947,7 +943,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::persist::test_utils::{InMemoryAsyncTestPersister, InMemoryTestPersister};
 
     type InMemoryTestState = String;
 
@@ -983,7 +978,7 @@ mod tests {
     }
 
     fn verify_sync<SuccessState: std::fmt::Debug + PartialEq, ErrorState: std::error::Error>(
-        persister: &InMemoryTestPersister<InMemoryTestEvent>,
+        persister: &InMemoryPersister<InMemoryTestEvent>,
         result: Result<SuccessState, ErrorState>,
         expected_result: &ExpectedResult<SuccessState, ErrorState>,
     ) {
@@ -1015,7 +1010,7 @@ mod tests {
         SuccessState: std::fmt::Debug + PartialEq + Send,
         ErrorState: std::error::Error + Send,
     >(
-        persister: &InMemoryAsyncTestPersister<InMemoryTestEvent>,
+        persister: &InMemoryAsyncPersister<InMemoryTestEvent>,
         result: Result<SuccessState, ErrorState>,
         expected_result: &ExpectedResult<SuccessState, ErrorState>,
     ) {
@@ -1043,11 +1038,11 @@ mod tests {
     macro_rules! run_test_cases {
         ($test_cases:expr) => {
             for test in &$test_cases {
-                let persister = InMemoryTestPersister::default();
+                let persister = InMemoryPersister::default();
                 let result = (test.make_transition)().save(&persister);
                 verify_sync(&persister, result, &test.expected_result);
 
-                let persister = InMemoryAsyncTestPersister::default();
+                let persister = InMemoryAsyncPersister::default();
                 let result = (test.make_transition)().save_async(&persister).await;
                 verify_async(&persister, result, &test.expected_result).await;
             }

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -808,35 +808,6 @@ pub trait AsyncSessionPersister: Send + Sync {
     ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send;
 }
 
-/// A persister that does nothing
-/// This persister cannot be used to replay a session
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct NoopPersisterEvent;
-
-#[derive(Debug, Clone)]
-pub struct NoopSessionPersister<E = NoopPersisterEvent>(std::marker::PhantomData<E>);
-
-impl<E> Default for NoopSessionPersister<E> {
-    fn default() -> Self { Self(std::marker::PhantomData) }
-}
-
-impl<E: 'static> SessionPersister for NoopSessionPersister<E> {
-    type InternalStorageError = std::convert::Infallible;
-    type SessionEvent = E;
-
-    fn save_event(&self, _event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
-        Ok(())
-    }
-
-    fn load(
-        &self,
-    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
-        Ok(Box::new(std::iter::empty()))
-    }
-
-    fn close(&self) -> Result<(), Self::InternalStorageError> { Ok(()) }
-}
-
 /// In-memory session persister for replaying sessions and introspecting events.
 #[derive(Clone)]
 pub struct InMemoryPersister<V> {

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1439,9 +1439,9 @@ pub mod test {
 
     use super::*;
     use crate::output_substitution::OutputSubstitution;
-    use crate::persist::test_utils::InMemoryTestPersister;
     use crate::persist::{
-        NoopSessionPersister, OptionalTransitionOutcome, RejectTransient, Rejection,
+        InMemoryPersister, NoopSessionPersister, OptionalTransitionOutcome, RejectTransient,
+        Rejection,
     };
     use crate::receive::optional_parameters::Params;
     use crate::receive::v2;
@@ -1508,21 +1508,21 @@ pub mod test {
         let original_tx = PARSED_ORIGINAL_PSBT.clone().extract_tx().expect("valid tx");
 
         // Nothing was spent, should be in the same state
-        let persister = InMemoryTestPersister::default();
+        let persister = InMemoryPersister::default();
         let res = monitor
             .check_payment(|_| Ok(None))
             .save(&persister)
-            .expect("InMemoryTestPersister shouldn't fail");
+            .expect("InMemoryPersister shouldn't fail");
         assert!(matches!(res, OptionalTransitionOutcome::Stasis(_)));
         assert!(!persister.inner.read().expect("Shouldn't be poisoned").is_closed);
         assert_eq!(persister.inner.read().expect("Shouldn't be poisoned").events.len(), 0);
 
         // Payjoin was broadcasted, should progress to success
-        let persister = InMemoryTestPersister::default();
+        let persister = InMemoryPersister::default();
         let res = monitor
             .check_payment(|_| Ok(Some(payjoin_tx.clone())))
             .save(&persister)
-            .expect("InMemoryTestPersister shouldn't fail");
+            .expect("InMemoryPersister shouldn't fail");
 
         assert!(matches!(res, OptionalTransitionOutcome::Progress(_)));
         assert!(persister.inner.read().expect("Shouldn't be poisoned").is_closed);
@@ -1536,7 +1536,7 @@ pub mod test {
         );
 
         // Fallback was broadcasted, should progress to success
-        let persister = InMemoryTestPersister::default();
+        let persister = InMemoryPersister::default();
         let res = monitor
             .check_payment(|txid| {
                 // Emulate if one of the fallback outpoints was double spent
@@ -1547,7 +1547,7 @@ pub mod test {
                 }
             })
             .save(&persister)
-            .expect("InMemoryTestPersister shouldn't fail");
+            .expect("InMemoryPersister shouldn't fail");
 
         assert!(matches!(res, OptionalTransitionOutcome::Progress(_)));
         assert!(persister.inner.read().expect("Shouldn't be poisoned").is_closed);
@@ -1573,11 +1573,11 @@ pub mod test {
             session_context: SHARED_CONTEXT.clone(),
         };
 
-        let persister = InMemoryTestPersister::default();
+        let persister = InMemoryPersister::default();
         let res = monitor
             .check_payment(|_| panic!("check_payment should return before this closure is called"))
             .save(&persister)
-            .expect("InMemoryTestPersister shouldn't fail");
+            .expect("InMemoryPersister shouldn't fail");
 
         assert!(matches!(res, OptionalTransitionOutcome::Progress(_)));
         assert!(persister.inner.read().expect("Shouldn't be poisoned").is_closed);
@@ -1902,7 +1902,7 @@ pub mod test {
     fn cancel_returns_expected_fallback() {
         macro_rules! do_cancel_test {
             ($state:expr, $expected:expr) => {{
-                let persister = InMemoryTestPersister::<SessionEvent>::default();
+                let persister = InMemoryPersister::<SessionEvent>::default();
                 let fallback = Receiver { state: $state, session_context: SHARED_CONTEXT.clone() }
                     .cancel()
                     .save(&persister)

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1440,8 +1440,7 @@ pub mod test {
     use super::*;
     use crate::output_substitution::OutputSubstitution;
     use crate::persist::{
-        InMemoryPersister, NoopSessionPersister, OptionalTransitionOutcome, RejectTransient,
-        Rejection,
+        InMemoryPersister, OptionalTransitionOutcome, RejectTransient, Rejection,
     };
     use crate::receive::optional_parameters::Params;
     use crate::receive::v2;
@@ -1479,7 +1478,7 @@ pub mod test {
     }
 
     pub(crate) fn mock_err() -> JsonReply {
-        let noop_persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let receiver = Receiver {
             state: unchecked_proposal_v2_from_test_vector(),
             session_context: SHARED_CONTEXT.clone(),
@@ -1487,7 +1486,7 @@ pub mod test {
         let error = receiver
             .clone()
             .check_broadcast_suitability(None, |_| Err("mock error".into()))
-            .save(&noop_persister)
+            .save(&persister)
             .expect_err("Server error should be populated with mock error");
         let res = error.api_error().expect("check_broadcast error should propagate to api error");
         JsonReply::from(&res)
@@ -1592,7 +1591,7 @@ pub mod test {
 
     #[test]
     fn test_v2_mutable_receiver_state_closures() {
-        let persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let mut call_count = 0;
         let maybe_inputs_owned = maybe_inputs_owned_v2_from_test_vector();
         let receiver =
@@ -1609,10 +1608,10 @@ pub mod test {
 
         let outputs_unknown = maybe_inputs_seen
             .save(&persister)
-            .expect("Noop persister shouldn't fail")
+            .expect("Persister shouldn't fail")
             .check_no_inputs_seen_before(&mut |_| mock_callback(&mut call_count, false))
             .save(&persister)
-            .expect("Noop persister shouldn't fail");
+            .expect("Persister shouldn't fail");
         assert_eq!(call_count, 2);
 
         let _wants_outputs = outputs_unknown
@@ -1647,7 +1646,7 @@ pub mod test {
 
     #[test]
     fn test_unchecked_proposal_fatal_error() -> Result<(), BoxError> {
-        let persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let unchecked_proposal = unchecked_proposal_v2_from_test_vector();
         let receiver =
             v2::Receiver { state: unchecked_proposal, session_context: SHARED_CONTEXT.clone() };
@@ -1664,7 +1663,7 @@ pub mod test {
 
     #[test]
     fn test_maybe_inputs_seen_transient_error() -> Result<(), BoxError> {
-        let persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let unchecked_proposal = unchecked_proposal_v2_from_test_vector();
         let receiver =
             v2::Receiver { state: unchecked_proposal, session_context: SHARED_CONTEXT.clone() };
@@ -1672,7 +1671,7 @@ pub mod test {
         let maybe_inputs_owned = receiver
             .assume_interactive_receiver()
             .save(&persister)
-            .expect("Noop persister shouldn't fail");
+            .expect("Persister shouldn't fail");
         let maybe_inputs_seen = maybe_inputs_owned.check_inputs_not_owned(&mut |_| {
             Err(ImplementationError::new(Error::Implementation("mock error".into())))
         });
@@ -1692,7 +1691,7 @@ pub mod test {
 
     #[test]
     fn test_outputs_unknown_transient_error() -> Result<(), BoxError> {
-        let persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let unchecked_proposal = unchecked_proposal_v2_from_test_vector();
         let receiver =
             v2::Receiver { state: unchecked_proposal, session_context: SHARED_CONTEXT.clone() };
@@ -1700,11 +1699,11 @@ pub mod test {
         let maybe_inputs_owned = receiver
             .assume_interactive_receiver()
             .save(&persister)
-            .expect("Noop persister shouldn't fail");
+            .expect("Persister shouldn't fail");
         let maybe_inputs_seen = maybe_inputs_owned
             .check_inputs_not_owned(&mut |_| Ok(false))
             .save(&persister)
-            .expect("Noop persister shouldn't fail");
+            .expect("Persister shouldn't fail");
         let outputs_unknown = maybe_inputs_seen.check_no_inputs_seen_before(&mut |_| {
             Err(ImplementationError::new(Error::Implementation("mock error".into())))
         });
@@ -1723,7 +1722,7 @@ pub mod test {
 
     #[test]
     fn test_wants_outputs_transient_error() -> Result<(), BoxError> {
-        let persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let unchecked_proposal = unchecked_proposal_v2_from_test_vector();
         let receiver =
             v2::Receiver { state: unchecked_proposal, session_context: SHARED_CONTEXT.clone() };
@@ -1731,15 +1730,15 @@ pub mod test {
         let maybe_inputs_owned = receiver
             .assume_interactive_receiver()
             .save(&persister)
-            .expect("Noop persister shouldn't fail");
+            .expect("Persister shouldn't fail");
         let maybe_inputs_seen = maybe_inputs_owned
             .check_inputs_not_owned(&mut |_| Ok(false))
             .save(&persister)
-            .expect("Noop persister should not fail");
+            .expect("Persister should not fail");
         let outputs_unknown = maybe_inputs_seen
             .check_no_inputs_seen_before(&mut |_| Ok(false))
             .save(&persister)
-            .expect("Noop persister should not fail");
+            .expect("Persister should not fail");
         let wants_outputs = outputs_unknown.identify_receiver_outputs(&mut |_| {
             Err(ImplementationError::new(Error::Implementation("mock error".into())))
         });
@@ -1799,7 +1798,7 @@ pub mod test {
 
     #[test]
     fn default_max_fee_rate() {
-        let noop_persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
         let receiver = ReceiverBuilder::new(
             SHARED_CONTEXT.address.clone(),
             SHARED_CONTEXT.directory.as_str(),
@@ -1807,8 +1806,8 @@ pub mod test {
         )
         .expect("constructor on test vector should not fail")
         .build()
-        .save(&noop_persister)
-        .expect("Noop persister shouldn't fail");
+        .save(&persister)
+        .expect("Persister shouldn't fail");
 
         assert_eq!(receiver.session_context.max_fee_rate, FeeRate::BROADCAST_MIN);
 
@@ -1822,14 +1821,14 @@ pub mod test {
         .expect("constructor on test vector should not fail")
         .with_max_fee_rate(non_default_max_fee_rate)
         .build()
-        .save(&noop_persister)
-        .expect("Noop persister shouldn't fail");
+        .save(&persister)
+        .expect("Persister shouldn't fail");
         assert_eq!(receiver.session_context.max_fee_rate, non_default_max_fee_rate);
     }
 
     #[test]
     fn default_expiration() {
-        let noop_persister = NoopSessionPersister::default();
+        let persister = InMemoryPersister::default();
 
         let with_default_expiration = ReceiverBuilder::new(
             SHARED_CONTEXT.address.clone(),
@@ -1838,8 +1837,8 @@ pub mod test {
         )
         .expect("constructor on test vector should not fail")
         .build()
-        .save(&noop_persister)
-        .expect("Noop persister shouldn't fail");
+        .save(&persister)
+        .expect("Persister shouldn't fail");
 
         let short_expiration = Duration::from_secs(60);
         let with_short_expiration = ReceiverBuilder::new(
@@ -1850,8 +1849,8 @@ pub mod test {
         .expect("constructor on test vector should not fail")
         .with_expiration(short_expiration)
         .build()
-        .save(&noop_persister)
-        .expect("Noop persister shouldn't fail");
+        .save(&persister)
+        .expect("Persister shouldn't fail");
 
         assert_ne!(
             with_short_expiration.session_context.expiration,

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -225,8 +225,7 @@ mod tests {
     use payjoin_test_utils::{BoxError, EXAMPLE_URL};
 
     use super::*;
-    use crate::persist::test_utils::{InMemoryAsyncTestPersister, InMemoryTestPersister};
-    use crate::persist::NoopSessionPersister;
+    use crate::persist::{InMemoryAsyncPersister, InMemoryPersister, NoopSessionPersister};
     use crate::receive::tests::original_from_test_vector;
     use crate::receive::v2::test::{mock_err, SHARED_CONTEXT};
     use crate::receive::v2::{
@@ -342,7 +341,7 @@ mod tests {
     }
 
     fn run_session_history_test(test: &SessionHistoryTest) {
-        let persister = InMemoryTestPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         for event in test.events.clone() {
             persister.save_event(event).expect("In memory persister shouldn't fail");
         }
@@ -350,7 +349,7 @@ mod tests {
     }
 
     async fn run_session_history_test_async(test: &SessionHistoryTest) {
-        let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
         for event in test.events.clone() {
             persister.save_event(event).await.expect("In memory persister shouldn't fail");
         }
@@ -380,7 +379,7 @@ mod tests {
         let expiration = (SystemTime::now() - Duration::from_secs(1)).try_into().unwrap();
         let session_context = SessionContext { expiration, ..SHARED_CONTEXT.clone() };
 
-        let persister = InMemoryTestPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         persister
             .save_event(SessionEvent::Created(session_context.clone()))
             .expect("in memory persister save should not fail");
@@ -389,7 +388,7 @@ mod tests {
             InternalReplayError::Expired(expiration).into();
         assert_eq!(err.to_string(), expected_err.to_string());
 
-        let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
         persister
             .save_event(SessionEvent::Created(session_context))
             .await
@@ -402,7 +401,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_replaying_session_with_missing_created_event() {
-        let persister = InMemoryTestPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         persister
             .save_event(SessionEvent::CheckedBroadcastSuitability())
             .expect("in memory persister save should not fail");
@@ -417,7 +416,7 @@ mod tests {
         assert_eq!(err.to_string(), expected_err.to_string());
         assert!(persister.inner.read().expect("lock should not be poisoned").is_closed);
 
-        let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
         persister
             .save_event(SessionEvent::CheckedBroadcastSuitability())
             .await
@@ -526,7 +525,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_contributed_inputs() {
-        let persister = InMemoryTestPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         let session_context = SHARED_CONTEXT.clone();
         let mut events = vec![];
 

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -225,7 +225,7 @@ mod tests {
     use payjoin_test_utils::{BoxError, EXAMPLE_URL};
 
     use super::*;
-    use crate::persist::{InMemoryAsyncPersister, InMemoryPersister, NoopSessionPersister};
+    use crate::persist::{InMemoryAsyncPersister, InMemoryPersister};
     use crate::receive::tests::original_from_test_vector;
     use crate::receive::v2::test::{mock_err, SHARED_CONTEXT};
     use crate::receive::v2::{
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_session_event_serialization_roundtrip() {
-        let persister = NoopSessionPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
 
         let original = original_from_test_vector();
         let unchecked_proposal = unchecked_receiver_from_test_vector();
@@ -490,7 +490,7 @@ mod tests {
 
     #[tokio::test]
     async fn getting_fallback_tx() {
-        let persister = NoopSessionPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         let session_context = SHARED_CONTEXT.clone();
         let mut events = vec![];
         let original = original_from_test_vector();
@@ -599,7 +599,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_payjoin_proposal() {
-        let persister = NoopSessionPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         let session_context = SHARED_CONTEXT.clone();
         let mut events = vec![];
 
@@ -675,7 +675,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_fatal_error() {
-        let persister = NoopSessionPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         let session_context = SHARED_CONTEXT.clone();
         let mut events = vec![];
 
@@ -711,7 +711,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_transient_error() {
-        let persister = NoopSessionPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         let session_context = SHARED_CONTEXT.clone();
         let mut events = vec![];
 

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -719,7 +719,7 @@ mod test {
 
     #[test]
     fn cancel_returns_expected_fallback() -> Result<(), BoxError> {
-        use crate::persist::test_utils::InMemoryTestPersister;
+        use crate::persist::InMemoryPersister;
 
         let expiration =
             Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
@@ -728,7 +728,7 @@ mod test {
 
         macro_rules! do_cancel_test {
             ($state:expr) => {{
-                let persister = InMemoryTestPersister::<SessionEvent>::default();
+                let persister = InMemoryPersister::<SessionEvent>::default();
                 let fallback =
                     Sender { state: $state, session_context: sender.session_context.clone() }
                         .cancel()

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -565,7 +565,7 @@ mod test {
     use payjoin_test_utils::{BoxError, EXAMPLE_URL, KEM, KEY_ID, PARSED_ORIGINAL_PSBT, SYMMETRIC};
 
     use super::*;
-    use crate::persist::NoopSessionPersister;
+    use crate::persist::InMemoryPersister;
     use crate::receive::v2::ReceiverBuilder;
     use crate::time::Time;
     use crate::OhttpKeys;
@@ -662,13 +662,13 @@ mod test {
         let pj_uri = ReceiverBuilder::new(address.clone(), directory, ohttp_keys)
             .expect("constructor on test vector should not fail")
             .build()
-            .save(&NoopSessionPersister::default())
+            .save(&InMemoryPersister::default())
             .expect("receiver should succeed")
             .pj_uri();
         let req_ctx = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri.clone())
             .build_recommended(FeeRate::BROADCAST_MIN)
             .expect("build on test vector should succeed")
-            .save(&NoopSessionPersister::default())
+            .save(&InMemoryPersister::default())
             .expect("sender should succeed");
         // v2 senders may always override the receiver's `pjos` parameter to enable output
         // substitution
@@ -689,7 +689,7 @@ mod test {
         let req_ctx = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri.clone())
             .build_non_incentivizing(FeeRate::BROADCAST_MIN)
             .expect("build on test vector should succeed")
-            .save(&NoopSessionPersister::default())
+            .save(&InMemoryPersister::default())
             .expect("sender should succeed");
         assert_eq!(
             req_ctx.session_context.psbt_ctx.output_substitution,
@@ -698,7 +698,7 @@ mod test {
         let req_ctx = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri.clone())
             .build_with_additional_fee(Amount::ZERO, Some(0), FeeRate::BROADCAST_MIN, false)
             .expect("build on test vector should succeed")
-            .save(&NoopSessionPersister::default())
+            .save(&InMemoryPersister::default())
             .expect("sender should succeed");
         assert_eq!(
             req_ctx.session_context.psbt_ctx.output_substitution,
@@ -709,7 +709,7 @@ mod test {
             .always_disable_output_substitution()
             .build_recommended(FeeRate::BROADCAST_MIN)
             .expect("build on test vector should succeed")
-            .save(&NoopSessionPersister::default())
+            .save(&InMemoryPersister::default())
             .expect("sender should succeed");
         assert_eq!(
             req_ctx.session_context.psbt_ctx.output_substitution,
@@ -719,8 +719,6 @@ mod test {
 
     #[test]
     fn cancel_returns_expected_fallback() -> Result<(), BoxError> {
-        use crate::persist::InMemoryPersister;
-
         let expiration =
             Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
         let sender = create_sender_context(expiration)?;

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -176,8 +176,7 @@ mod tests {
     use super::*;
     use crate::core::Url;
     use crate::output_substitution::OutputSubstitution;
-    use crate::persist::test_utils::{InMemoryAsyncTestPersister, InMemoryTestPersister};
-    use crate::persist::NoopSessionPersister;
+    use crate::persist::{InMemoryAsyncPersister, InMemoryPersister, NoopSessionPersister};
     use crate::send::v2::{Sender, SenderBuilder, SessionContext, WithReplyKey};
     use crate::send::PsbtContext;
     use crate::time::Time;
@@ -286,7 +285,7 @@ mod tests {
     }
 
     fn run_session_history_test(test: &SessionHistoryTest) {
-        let persister = InMemoryTestPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         for event in test.events.clone() {
             persister.save_event(event).expect("In memory persister shouldn't fail");
         }
@@ -294,7 +293,7 @@ mod tests {
     }
 
     async fn run_session_history_test_async(test: &SessionHistoryTest) {
-        let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
         for event in test.events.clone() {
             persister.save_event(event).await.expect("In memory persister shouldn't fail");
         }
@@ -422,7 +421,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_replaying_session_with_missing_created_event() {
-        let persister = InMemoryTestPersister::<SessionEvent>::default();
+        let persister = InMemoryPersister::<SessionEvent>::default();
         persister
             .save_event(SessionEvent::PostedOriginalPsbt())
             .expect("in memory persister save should not fail");
@@ -434,7 +433,7 @@ mod tests {
         assert_eq!(err.to_string(), expected_err.to_string());
         assert!(persister.inner.read().expect("lock should not be poisoned").is_closed);
 
-        let persister = InMemoryAsyncTestPersister::<SessionEvent>::default();
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
         persister
             .save_event(SessionEvent::PostedOriginalPsbt())
             .await

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -176,7 +176,7 @@ mod tests {
     use super::*;
     use crate::core::Url;
     use crate::output_substitution::OutputSubstitution;
-    use crate::persist::{InMemoryAsyncPersister, InMemoryPersister, NoopSessionPersister};
+    use crate::persist::{InMemoryAsyncPersister, InMemoryPersister};
     use crate::send::v2::{Sender, SenderBuilder, SessionContext, WithReplyKey};
     use crate::send::PsbtContext;
     use crate::time::Time;
@@ -313,7 +313,7 @@ mod tests {
         )
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap()
-        .save(&NoopSessionPersister::default())
+        .save(&InMemoryPersister::default())
         .unwrap();
         let test = SessionHistoryTest {
             events: vec![SessionEvent::Created(Box::new(sender.session_context.clone()))],
@@ -347,7 +347,7 @@ mod tests {
         )
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap()
-        .save(&NoopSessionPersister::default())
+        .save(&InMemoryPersister::default())
         .unwrap();
         sender.session_context.pj_param.expiration =
             Time::from_now(std::time::Duration::from_secs(60)).unwrap();
@@ -383,7 +383,7 @@ mod tests {
         )
         .build_recommended(FeeRate::BROADCAST_MIN)
         .unwrap()
-        .save(&NoopSessionPersister::default())
+        .save(&InMemoryPersister::default())
         .unwrap();
 
         let reply_key = HpkeKeyPair::gen_keypair();

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -196,7 +196,7 @@ mod integration {
 
         use bitcoin::{Address, Transaction};
         use http::StatusCode;
-        use payjoin::persist::{NoopSessionPersister, OptionalTransitionOutcome};
+        use payjoin::persist::OptionalTransitionOutcome;
         use payjoin::receive::v2::{
             replay_event_log as replay_receiver_event_log, Monitor, PayjoinProposal,
             ReceiveSession, Receiver, ReceiverBuilder, SessionStatus, UncheckedOriginalPayload,
@@ -249,14 +249,14 @@ mod integration {
                 services.wait_for_services_ready().await?;
                 let mock_address = Address::from_str("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4")?
                     .assume_checked();
-                let noop_persister = NoopSessionPersister::default();
+                let persister = InMemoryPersister::default();
                 let bad_initializer = ReceiverBuilder::new(
                     mock_address,
                     services.directory_url().as_str(),
                     bad_ohttp_keys,
                 )?
                 .build()
-                .save(&noop_persister)?;
+                .save(&persister)?;
                 let (req, _ctx) =
                     bad_initializer.create_poll_request(services.ohttp_relay_url().as_str())?;
                 agent
@@ -287,8 +287,8 @@ mod integration {
                 let (_bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
                 services.wait_for_services_ready().await?;
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
-                let recv_noop_persister = NoopSessionPersister::default();
-                let send_noop_persister = NoopSessionPersister::default();
+                let recv_persister = InMemoryPersister::default();
+                let send_persister = InMemoryPersister::default();
                 // **********************
                 // Inside the Receiver:
                 let address = receiver.new_address()?;
@@ -297,7 +297,7 @@ mod integration {
                     ReceiverBuilder::new(address, services.directory_url().as_str(), ohttp_keys)?
                         .with_expiration(Duration::from_secs(0))
                         .build()
-                        .save(&recv_noop_persister)?;
+                        .save(&recv_persister)?;
                 match expired_receiver.create_poll_request(services.ohttp_relay_url().as_str()) {
                     // Internal error types are private, so check against a string
                     Err(err) => assert!(err.to_string().contains("expired")),
@@ -310,7 +310,7 @@ mod integration {
                 // Test that an expired pj_url errors
                 let expired_req_ctx = SenderBuilder::new(psbt, expired_receiver.pj_uri())
                     .build_non_incentivizing(FeeRate::BROADCAST_MIN)?
-                    .save(&send_noop_persister)?;
+                    .save(&send_persister)?;
 
                 match expired_req_ctx.create_v2_post_request(services.ohttp_relay_url().as_str()) {
                     // Internal error types are private, so check against a string
@@ -341,7 +341,7 @@ mod integration {
                 services.wait_for_services_ready().await?;
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
                 let persister = InMemoryPersister::default();
-                let sender_persister = NoopSessionPersister::default();
+                let sender_persister = InMemoryPersister::default();
                 // **********************
                 // Inside the Receiver:
                 let address = receiver.new_address()?;
@@ -992,7 +992,7 @@ mod integration {
                 let agent = services.http_agent();
                 services.wait_for_services_ready().await?;
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
-                let recv_persister = NoopSessionPersister::default();
+                let recv_persister = InMemoryPersister::default();
                 let address = receiver.new_address()?;
                 let session = ReceiverBuilder::new(
                     address,

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -205,7 +205,7 @@ mod integration {
         use payjoin::send::ResponseError;
         use payjoin::{OhttpKeys, PjUri, UriExt};
         use payjoin_test_utils::{
-            BoxSendSyncError, InMemoryTestPersister, SessionPersister, TestServices,
+            BoxSendSyncError, InMemoryPersister, SessionPersister, TestServices,
         };
         use reqwest::{Client, Response};
 
@@ -340,7 +340,7 @@ mod integration {
                 let agent = services.http_agent();
                 services.wait_for_services_ready().await?;
                 let ohttp_keys = services.fetch_ohttp_keys().await?;
-                let persister = InMemoryTestPersister::default();
+                let persister = InMemoryPersister::default();
                 let sender_persister = NoopSessionPersister::default();
                 // **********************
                 // Inside the Receiver:
@@ -507,8 +507,8 @@ mod integration {
             let (_bitcoind, sender, receiver) =
                 init_bitcoind_sender_receiver(Some(AddressType::Legacy), Some(AddressType::Legacy))
                     .expect("should be able to initialize the sender and the receiver");
-            let recv_persister = InMemoryTestPersister::default();
-            let send_persister = InMemoryTestPersister::default();
+            let recv_persister = InMemoryPersister::default();
+            let send_persister = InMemoryPersister::default();
 
             let result = tokio::select!(
                 err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
@@ -564,8 +564,8 @@ mod integration {
             let (_bitcoind, sender, receiver) =
                 init_bitcoind_sender_receiver(Some(AddressType::Bech32), Some(AddressType::Bech32))
                     .expect("should be able to initialize the sender and the receiver");
-            let recv_persister = InMemoryTestPersister::default();
-            let send_persister = InMemoryTestPersister::default();
+            let recv_persister = InMemoryPersister::default();
+            let send_persister = InMemoryPersister::default();
 
             let result = tokio::select!(
                 err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
@@ -646,8 +646,8 @@ mod integration {
                 Some(AddressType::Bech32m),
             )
             .expect("should be able to initialize the sender and the receiver");
-            let recv_persister = InMemoryTestPersister::default();
-            let send_persister = InMemoryTestPersister::default();
+            let recv_persister = InMemoryPersister::default();
+            let send_persister = InMemoryPersister::default();
 
             let result = tokio::select!(
                 err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),
@@ -719,8 +719,8 @@ mod integration {
             let (_bitcoind, sender, receiver) =
                 init_bitcoind_sender_receiver(Some(AddressType::Bech32), Some(AddressType::Bech32))
                     .expect("should be able to initialize the sender and the receiver");
-            let recv_persister = InMemoryTestPersister::default();
-            let send_persister = InMemoryTestPersister::default();
+            let recv_persister = InMemoryPersister::default();
+            let send_persister = InMemoryPersister::default();
 
             let result = tokio::select!(
                 err = services.take_ohttp_relay_handle() => panic!("Ohttp relay exited early: {:?}", err),


### PR DESCRIPTION
Used Claude Opus 4.7 on max effort by driving a modified version of Jesse Posner's [`/meta-agent` skill](https://github.com/jesseposner/metacraft/blob/main/skills/meta-agent/SKILL.md) that had the #1519 context of the issue and preceding comment and a Q&A session with me marshaled to a worker commit-gated by a pre-commit hook that resembles CI. Meta strangely had the worker produce changelog updates in commits, which I had to manually remove because that's just not our process.

Closes #1519 with a net delete!

Pinging @Arowolokehinde, who stepped up to help on this one, and looking forward to your review. I appreciate you! But I don't want to block on you so no big pressure, and formally requesting @spacebear21 as the ultimately responsible reviewer for this PR.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
