### PR TITLE
Add nixpkgs-unstable overlay and migrate CI workflows to nix flake

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -28,17 +28,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: "Install Rust 1.85.0"
-        uses: dtolnay/rust-toolchain@1.85.0
-
-      - name: Install Dart
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: "Use cache"
-        uses: Swatinem/rust-cache@v2
-
-      - name: "Build and test"
-        run: bash ./contrib/test.sh
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build and test
+        run: nix develop --command bash ./contrib/test.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,32 +19,13 @@ jobs:
   build-python-and-test:
     name: "Build and test python"
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: payjoin-ffi/python
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v4
-
-      - name: "Install Rust 1.85.0"
-        uses: dtolnay/rust-toolchain@1.85.0
-
-      - name: "Use cache"
-        uses: Swatinem/rust-cache@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-
-      - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: "0.8.2"
-          enable-cache: true
-
-      - name: "Build and test"
-        run: bash ./contrib/test.sh
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build and test
+        run: nix develop .#python --command bash ./payjoin-ffi/python/contrib/test.sh

--- a/flake.lock
+++ b/flake.lock
@@ -66,6 +66,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1777425547,
+        "narHash": "sha256-d57AbflkNfZNoFaZDzssEq1RfPoM9dLtOGI2O+N/68Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ebc08544afa77957cc348ba72dc490ec73b87f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1777077449,
@@ -134,6 +150,7 @@
         "flake-utils": "flake-utils",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
         "rust-overlay": "rust-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -37,6 +38,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       flake-utils,
       rust-overlay,
       crane,
@@ -57,6 +59,7 @@
           overlays = [
             rust-overlay.overlays.default
             (final: prev: {
+              dart = nixpkgs-unstable.legacyPackages.${system}.dart;
               rustToolchains = {
                 msrv = prev.rust-bin.stable.${msrv-version}.default;
                 stable = prev.rust-bin.stable.latest.default;


### PR DESCRIPTION
### Motivation

Closes #1501

Dart 3.10+ is not available in `nixos-25.11`, only in `nixpkgs-unstable`. This was causing CI failures on macOS where Dan was experiencing the issue.

As discussed, the goal is to anchor all CI environments to `flake.nix` as the single source of truth, so environment issues are fixed once and propagated everywhere.

### Changes

**flake.nix / flake.lock**
- Added `nixpkgs-unstable` as a flake input
- Added an overlay to pull Dart from the unstable channel

**dart.yml**
- Removed manual Rust, Dart, and cache installation steps
- Now uses `nix develop --command` to run tests inside the flake environment

**python.yml**
- Removed manual Rust, Python, uv, and cache installation steps
- Now uses `nix develop .#python --command` (the dedicated Python shell that includes `uv`)

### Out of scope

`javascript.yml` and `csharp.yml` are not included in this PR. Javascript requires adding `wasm32-unknown-unknown` to the flake, and csharp has Windows in its matrix which Nix does not support. These will be handled in a follow-up PR.

 ### AI Assistance

 This PR was developed with Claude assistance.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
