### PR TITLE
Expose InMemoryPersister in FFI

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -179,7 +179,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
- "askama_derive",
+ "askama_derive 0.13.1",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive 0.14.0",
  "itoa",
  "percent-encoding",
  "serde",
@@ -192,7 +205,24 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
- "askama_parser",
+ "askama_parser 0.13.0",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser 0.14.0",
  "basic-toml",
  "memchr",
  "proc-macro2",
@@ -208,6 +238,18 @@ name = "askama_parser"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",
@@ -2825,7 +2867,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "uniffi",
+ "uniffi 0.30.0",
  "uniffi-bindgen-cs",
  "uniffi-dart",
  "url",
@@ -3991,6 +4033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,11 +4792,25 @@ dependencies = [
  "camino",
  "cargo_metadata 0.19.2",
  "clap 4.6.0",
- "uniffi_bindgen",
+ "uniffi_bindgen 0.30.0",
+ "uniffi_core 0.30.0",
+ "uniffi_macros 0.30.0",
+ "uniffi_pipeline 0.30.0",
+]
+
+[[package]]
+name = "uniffi"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.19.2",
+ "uniffi_bindgen 0.31.1",
  "uniffi_build",
- "uniffi_core",
- "uniffi_macros",
- "uniffi_pipeline",
+ "uniffi_core 0.31.1",
+ "uniffi_macros 0.31.1",
+ "uniffi_pipeline 0.31.1",
 ]
 
 [[package]]
@@ -4757,7 +4819,7 @@ version = "0.10.0+v0.30.0"
 source = "git+https://github.com/chavic/uniffi-bindgen-cs.git?rev=878a3d269eacce64beadcd336ade0b7c8da09824#878a3d269eacce64beadcd336ade0b7c8da09824"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.13.1",
  "camino",
  "cargo_metadata 0.19.2",
  "clap 3.2.25",
@@ -4769,15 +4831,15 @@ dependencies = [
  "serde_json",
  "textwrap",
  "toml 0.9.12+spec-1.1.0",
- "uniffi_bindgen",
- "uniffi_meta",
- "uniffi_udl",
+ "uniffi_bindgen 0.30.0",
+ "uniffi_meta 0.30.0",
+ "uniffi_udl 0.30.0",
 ]
 
 [[package]]
 name = "uniffi-dart"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=9df60104aca83375f084f517de5a77c7d257afc6#9df60104aca83375f084f517de5a77c7d257afc6"
 dependencies = [
  "anyhow",
  "camino",
@@ -4790,8 +4852,8 @@ dependencies = [
  "serde",
  "stringcase 0.4.0",
  "toml 0.9.12+spec-1.1.0",
- "uniffi",
- "uniffi_bindgen",
+ "uniffi 0.31.1",
+ "uniffi_bindgen 0.31.1",
  "uniffi_dart_macro",
 ]
 
@@ -4802,7 +4864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.13.1",
  "camino",
  "cargo_metadata 0.19.2",
  "fs-err 2.11.0",
@@ -4815,21 +4877,47 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml 0.9.12+spec-1.1.0",
- "uniffi_internal_macros",
- "uniffi_meta",
- "uniffi_pipeline",
- "uniffi_udl",
+ "uniffi_internal_macros 0.30.0",
+ "uniffi_meta 0.30.0",
+ "uniffi_pipeline 0.30.0",
+ "uniffi_udl 0.30.0",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+dependencies = [
+ "anyhow",
+ "askama 0.14.0",
+ "camino",
+ "cargo_metadata 0.19.2",
+ "fs-err 2.11.0",
+ "glob",
+ "goblin",
+ "heck 0.5.0",
+ "indexmap 2.13.1",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml 0.9.12+spec-1.1.0",
+ "uniffi_internal_macros 0.31.1",
+ "uniffi_meta 0.31.1",
+ "uniffi_pipeline 0.31.1",
+ "uniffi_udl 0.31.1",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
+checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen",
+ "uniffi_bindgen 0.31.1",
 ]
 
 [[package]]
@@ -4837,6 +4925,18 @@ name = "uniffi_core"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -4848,14 +4948,14 @@ dependencies = [
 [[package]]
 name = "uniffi_dart_macro"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=9df60104aca83375f084f517de5a77c7d257afc6#9df60104aca83375f084f517de5a77c7d257afc6"
 dependencies = [
  "futures",
  "proc-macro2",
  "quote",
  "stringcase 0.3.0",
  "syn 1.0.109",
- "uniffi",
+ "uniffi 0.31.1",
 ]
 
 [[package]]
@@ -4863,6 +4963,19 @@ name = "uniffi_internal_macros"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
 dependencies = [
  "anyhow",
  "indexmap 2.13.1",
@@ -4885,7 +4998,24 @@ dependencies = [
  "serde",
  "syn 2.0.117",
  "toml 0.9.12+spec-1.1.0",
- "uniffi_meta",
+ "uniffi_meta 0.30.0",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+dependencies = [
+ "camino",
+ "fs-err 2.11.0",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.9.12+spec-1.1.0",
+ "uniffi_meta 0.31.1",
 ]
 
 [[package]]
@@ -4895,9 +5025,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
- "siphasher",
- "uniffi_internal_macros",
- "uniffi_pipeline",
+ "siphasher 0.3.11",
+ "uniffi_internal_macros 0.30.0",
+ "uniffi_pipeline 0.30.0",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+dependencies = [
+ "anyhow",
+ "siphasher 1.0.3",
+ "uniffi_internal_macros 0.31.1",
+ "uniffi_pipeline 0.31.1",
 ]
 
 [[package]]
@@ -4910,7 +5052,20 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.1",
  "tempfile",
- "uniffi_internal_macros",
+ "uniffi_internal_macros 0.30.0",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.1",
+ "tempfile",
+ "uniffi_internal_macros 0.31.1",
 ]
 
 [[package]]
@@ -4921,7 +5076,19 @@ checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta",
+ "uniffi_meta 0.30.0",
+ "weedle2",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.31.1",
  "weedle2",
 ]
 

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -179,7 +179,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
- "askama_derive",
+ "askama_derive 0.13.1",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive 0.14.0",
  "itoa",
  "percent-encoding",
  "serde",
@@ -192,7 +205,24 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
- "askama_parser",
+ "askama_parser 0.13.0",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser 0.14.0",
  "basic-toml",
  "memchr",
  "proc-macro2",
@@ -208,6 +238,18 @@ name = "askama_parser"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",
@@ -2793,7 +2835,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "uniffi",
+ "uniffi 0.30.0",
  "uniffi-bindgen-cs",
  "uniffi-dart",
  "url",
@@ -3923,6 +3965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4663,11 +4711,25 @@ dependencies = [
  "camino",
  "cargo_metadata 0.19.2",
  "clap 4.5.46",
- "uniffi_bindgen",
+ "uniffi_bindgen 0.30.0",
+ "uniffi_core 0.30.0",
+ "uniffi_macros 0.30.0",
+ "uniffi_pipeline 0.30.0",
+]
+
+[[package]]
+name = "uniffi"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.19.2",
+ "uniffi_bindgen 0.31.1",
  "uniffi_build",
- "uniffi_core",
- "uniffi_macros",
- "uniffi_pipeline",
+ "uniffi_core 0.31.1",
+ "uniffi_macros 0.31.1",
+ "uniffi_pipeline 0.31.1",
 ]
 
 [[package]]
@@ -4676,7 +4738,7 @@ version = "0.10.0+v0.30.0"
 source = "git+https://github.com/chavic/uniffi-bindgen-cs.git?rev=878a3d269eacce64beadcd336ade0b7c8da09824#878a3d269eacce64beadcd336ade0b7c8da09824"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.13.1",
  "camino",
  "cargo_metadata 0.19.2",
  "clap 3.2.25",
@@ -4688,15 +4750,15 @@ dependencies = [
  "serde_json",
  "textwrap",
  "toml 0.9.5",
- "uniffi_bindgen",
- "uniffi_meta",
- "uniffi_udl",
+ "uniffi_bindgen 0.30.0",
+ "uniffi_meta 0.30.0",
+ "uniffi_udl 0.30.0",
 ]
 
 [[package]]
 name = "uniffi-dart"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=9df60104aca83375f084f517de5a77c7d257afc6#9df60104aca83375f084f517de5a77c7d257afc6"
 dependencies = [
  "anyhow",
  "camino",
@@ -4709,8 +4771,8 @@ dependencies = [
  "serde",
  "stringcase 0.4.0",
  "toml 0.9.5",
- "uniffi",
- "uniffi_bindgen",
+ "uniffi 0.31.1",
+ "uniffi_bindgen 0.31.1",
  "uniffi_dart_macro",
 ]
 
@@ -4721,7 +4783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.13.1",
  "camino",
  "cargo_metadata 0.19.2",
  "fs-err 2.11.0",
@@ -4734,21 +4796,47 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml 0.9.5",
- "uniffi_internal_macros",
- "uniffi_meta",
- "uniffi_pipeline",
- "uniffi_udl",
+ "uniffi_internal_macros 0.30.0",
+ "uniffi_meta 0.30.0",
+ "uniffi_pipeline 0.30.0",
+ "uniffi_udl 0.30.0",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+dependencies = [
+ "anyhow",
+ "askama 0.14.0",
+ "camino",
+ "cargo_metadata 0.19.2",
+ "fs-err 2.11.0",
+ "glob",
+ "goblin",
+ "heck 0.5.0",
+ "indexmap 2.10.0",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml 0.9.5",
+ "uniffi_internal_macros 0.31.1",
+ "uniffi_meta 0.31.1",
+ "uniffi_pipeline 0.31.1",
+ "uniffi_udl 0.31.1",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
+checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen",
+ "uniffi_bindgen 0.31.1",
 ]
 
 [[package]]
@@ -4756,6 +4844,18 @@ name = "uniffi_core"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -4767,14 +4867,14 @@ dependencies = [
 [[package]]
 name = "uniffi_dart_macro"
 version = "0.1.0+v0.30.0"
-source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=b0157aa#b0157aad7b65f40eac76f6739113063b31df9d40"
+source = "git+https://github.com/Uniffi-Dart/uniffi-dart.git?rev=9df60104aca83375f084f517de5a77c7d257afc6#9df60104aca83375f084f517de5a77c7d257afc6"
 dependencies = [
  "futures",
  "proc-macro2",
  "quote",
  "stringcase 0.3.0",
  "syn 1.0.109",
- "uniffi",
+ "uniffi 0.31.1",
 ]
 
 [[package]]
@@ -4782,6 +4882,19 @@ name = "uniffi_internal_macros"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
+dependencies = [
+ "anyhow",
+ "indexmap 2.10.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4804,7 +4917,24 @@ dependencies = [
  "serde",
  "syn 2.0.106",
  "toml 0.9.5",
- "uniffi_meta",
+ "uniffi_meta 0.30.0",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+dependencies = [
+ "camino",
+ "fs-err 2.11.0",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.106",
+ "toml 0.9.5",
+ "uniffi_meta 0.31.1",
 ]
 
 [[package]]
@@ -4814,9 +4944,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
- "siphasher",
- "uniffi_internal_macros",
- "uniffi_pipeline",
+ "siphasher 0.3.11",
+ "uniffi_internal_macros 0.30.0",
+ "uniffi_pipeline 0.30.0",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+dependencies = [
+ "anyhow",
+ "siphasher 1.0.3",
+ "uniffi_internal_macros 0.31.1",
+ "uniffi_pipeline 0.31.1",
 ]
 
 [[package]]
@@ -4829,7 +4971,20 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.10.0",
  "tempfile",
- "uniffi_internal_macros",
+ "uniffi_internal_macros 0.30.0",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.10.0",
+ "tempfile",
+ "uniffi_internal_macros 0.31.1",
 ]
 
 [[package]]
@@ -4840,7 +4995,19 @@ checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta",
+ "uniffi_meta 0.30.0",
+ "weedle2",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.31.1",
  "weedle2",
 ]
 

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "2.0.14"
 tokio = { version = "1.47.1", features = ["full"], optional = true }
 uniffi = { version = "0.30.0", features = ["cli"] }
 uniffi-bindgen-cs = { git = "https://github.com/chavic/uniffi-bindgen-cs.git", rev = "878a3d269eacce64beadcd336ade0b7c8da09824", optional = true }
-uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", rev = "b0157aa", optional = true }
+uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart.git", rev = "9df60104aca83375f084f517de5a77c7d257afc6", optional = true }
 url = "2.5.4"
 
 # getrandom is ignored here because it's required by the wasm_js feature

--- a/payjoin-ffi/csharp/IntegrationTests.cs
+++ b/payjoin-ffi/csharp/IntegrationTests.cs
@@ -11,25 +11,6 @@ namespace Payjoin.Tests
         private TestServices? _services;
         private HttpClient? _httpClient;
 
-        private sealed class InMemoryReceiverPersister : JsonReceiverSessionPersister
-        {
-            private readonly List<string> _events = new();
-            public RpcClient? Connection { get; set; }
-
-            public void Save(string @event) => _events.Add(@event);
-            public string[] Load() => _events.ToArray();
-            public void Close() { }
-        }
-
-        private sealed class InMemorySenderPersister : JsonSenderSessionPersister
-        {
-            private readonly List<string> _events = new();
-
-            public void Save(string @event) => _events.Add(@event);
-            public string[] Load() => _events.ToArray();
-            public void Close() { }
-        }
-
         private sealed class MempoolAcceptanceCallback : CanBroadcast
         {
             private readonly RpcClient _connection;
@@ -185,7 +166,7 @@ namespace Payjoin.Tests
         private async Task<PayjoinProposal?> RetrieveReceiverProposal(
             Initialized receiver,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister,
+            JsonReceiverSessionPersister recvPersister,
             string ohttpRelay,
             CancellationToken cancellationToken)
         {
@@ -220,7 +201,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessUncheckedProposal(
             UncheckedOriginalPayload proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var checkedTransition = proposal.CheckBroadcastSuitability(null, new MempoolAcceptanceCallback(receiverRpc));
             using var maybeInputsOwned = checkedTransition.Save(recvPersister);
@@ -231,7 +212,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessMaybeInputsOwned(
             MaybeInputsOwned proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var transition = proposal.CheckInputsNotOwned(new IsScriptOwnedCallback(receiverRpc));
             using var maybeInputsSeen = transition.Save(recvPersister);
@@ -242,7 +223,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessMaybeInputsSeen(
             MaybeInputsSeen proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var transition = proposal.CheckNoInputsSeenBefore(new CheckInputsNotSeenCallback());
             using var outputsUnknown = transition.Save(recvPersister);
@@ -253,7 +234,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessOutputsUnknown(
             OutputsUnknown proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var transition = proposal.IdentifyReceiverOutputs(new IsScriptOwnedCallback(receiverRpc));
             using var wantsOutputs = transition.Save(recvPersister);
@@ -264,7 +245,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessWantsOutputs(
             WantsOutputs proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var transition = proposal.CommitOutputs();
             using var wantsInputs = transition.Save(recvPersister);
@@ -275,7 +256,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessWantsInputs(
             WantsInputs proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var contributed = proposal.ContributeInputs(GetInputs(receiverRpc));
             using var transition = contributed.CommitInputs();
@@ -287,7 +268,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessWantsFeeRange(
             WantsFeeRange proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var transition = proposal.ApplyFeeRange(1, 10);
             using var provisional = transition.Save(recvPersister);
@@ -298,7 +279,7 @@ namespace Payjoin.Tests
         private Task<PayjoinProposal> ProcessProvisionalProposal(
             ProvisionalProposal proposal,
             RpcClient receiverRpc,
-            InMemoryReceiverPersister recvPersister)
+            JsonReceiverSessionPersister recvPersister)
         {
             using var transition = proposal.FinalizeProposal(new ProcessPsbtCallback(receiverRpc));
             var payjoinProposal = transition.Save(recvPersister);
@@ -437,7 +418,7 @@ namespace Payjoin.Tests
             _services.WaitForServicesReady();
             var ohttpKeys = _services.FetchOhttpKeys();
 
-            var recvPersister = new InMemoryReceiverPersister();
+            var recvPersister = new InMemoryReceiverPersister().AsPersister();
             using var receiverBuilder = new ReceiverBuilder("2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK", directory, ohttpKeys);
             using var receiveTransition = receiverBuilder.Build();
             using var receiver = receiveTransition.Save(recvPersister);
@@ -477,8 +458,8 @@ namespace Payjoin.Tests
 
             var ohttpKeys = _services.FetchOhttpKeys();
 
-            var recvPersister = new InMemoryReceiverPersister { Connection = receiver };
-            var senderPersister = new InMemorySenderPersister();
+            var recvPersister = new InMemoryReceiverPersister().AsPersister();
+            var senderPersister = new InMemorySenderPersister().AsPersister();
 
             using var receiverBuilder = new ReceiverBuilder(receiverAddress, directory, ohttpKeys);
             using var receiveTransition = receiverBuilder.Build();

--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -42,88 +42,6 @@ public class UriTests
     }
 }
 
-public class InMemoryReceiverPersister : JsonReceiverSessionPersister
-{
-    private List<string> _events = new();
-
-    public void Save(string @event)
-    {
-        _events.Add(@event);
-    }
-
-    public string[] Load()
-    {
-        return _events.ToArray();
-    }
-
-    public void Close()
-    {
-        // no-op for tests
-    }
-}
-
-public class InMemorySenderPersister : JsonSenderSessionPersister
-{
-    private List<string> _events = new();
-
-    public void Save(string @event)
-    {
-        _events.Add(@event);
-    }
-
-    public string[] Load()
-    {
-        return _events.ToArray();
-    }
-
-    public void Close()
-    {
-        // no-op for tests
-    }
-}
-
-public class InMemoryReceiverPersisterAsync : JsonReceiverSessionPersisterAsync
-{
-    private readonly List<string> _events = new();
-
-    public Task Save(string @event)
-    {
-        _events.Add(@event);
-        return Task.CompletedTask;
-    }
-
-    public Task<string[]> Load()
-    {
-        return Task.FromResult(_events.ToArray());
-    }
-
-    public Task Close()
-    {
-        return Task.CompletedTask;
-    }
-}
-
-public class InMemorySenderPersisterAsync : JsonSenderSessionPersisterAsync
-{
-    private readonly List<string> _events = new();
-
-    public Task Save(string @event)
-    {
-        _events.Add(@event);
-        return Task.CompletedTask;
-    }
-
-    public Task<string[]> Load()
-    {
-        return Task.FromResult(_events.ToArray());
-    }
-
-    public Task Close()
-    {
-        return Task.CompletedTask;
-    }
-}
-
 public class PersistenceTests
 {
     private static readonly byte[] OhttpKeysData = new byte[]
@@ -141,7 +59,7 @@ public class PersistenceTests
     [Fact]
     public void ReceiverPersistence()
     {
-        var persister = new InMemoryReceiverPersister();
+        var persister = new InMemoryReceiverPersister().AsPersister();
         var address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -158,7 +76,7 @@ public class PersistenceTests
     [Fact]
     public void SenderPersistence()
     {
-        var receiverPersister = new InMemoryReceiverPersister();
+        var receiverPersister = new InMemoryReceiverPersister().AsPersister();
         var address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -167,7 +85,7 @@ public class PersistenceTests
             .Save(receiverPersister);
         var uri = receiver.PjUri();
 
-        var senderPersister = new InMemorySenderPersister();
+        var senderPersister = new InMemorySenderPersister().AsPersister();
         var psbt = PayjoinMethods.OriginalPsbt();
         
         var withReplyKey = new SenderBuilder(psbt, uri)
@@ -183,7 +101,7 @@ public class PersistenceTests
     [Fact]
     public async Task ReceiverPersistenceAsync()
     {
-        var persister = new InMemoryReceiverPersisterAsync();
+        var persister = new InMemoryReceiverPersisterAsync().AsPersister();
         var address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -200,7 +118,7 @@ public class PersistenceTests
     [Fact]
     public async Task SenderPersistenceAsync()
     {
-        var receiverPersister = new InMemoryReceiverPersisterAsync();
+        var receiverPersister = new InMemoryReceiverPersisterAsync().AsPersister();
         var address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -209,7 +127,7 @@ public class PersistenceTests
             .SaveAsync(receiverPersister);
         var uri = receiver.PjUri();
 
-        var senderPersister = new InMemorySenderPersisterAsync();
+        var senderPersister = new InMemorySenderPersisterAsync().AsPersister();
         var psbt = PayjoinMethods.OriginalPsbt();
 
         var withReplyKey = await new SenderBuilder(psbt, uri)
@@ -240,7 +158,7 @@ public class CancelTests
     [Fact]
     public void ReceiverCancelFromInitialized()
     {
-        var persister = new InMemoryReceiverPersister();
+        var persister = new InMemoryReceiverPersister().AsPersister();
         var address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -259,7 +177,7 @@ public class CancelTests
     [Fact]
     public async Task ReceiverCancelFromInitializedAsync()
     {
-        var persister = new InMemoryReceiverPersisterAsync();
+        var persister = new InMemoryReceiverPersisterAsync().AsPersister();
         var address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -278,7 +196,7 @@ public class CancelTests
     [Fact]
     public void SenderCancelFromWithReplyKey()
     {
-        var receiverPersister = new InMemoryReceiverPersister();
+        var receiverPersister = new InMemoryReceiverPersister().AsPersister();
         var address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -287,7 +205,7 @@ public class CancelTests
             .Save(receiverPersister);
         var uri = receiver.PjUri();
 
-        var senderPersister = new InMemorySenderPersister();
+        var senderPersister = new InMemorySenderPersister().AsPersister();
         var psbt = PayjoinMethods.OriginalPsbt();
         var withReplyKey = new SenderBuilder(psbt, uri)
             .BuildRecommended(1000)
@@ -305,7 +223,7 @@ public class CancelTests
     [Fact]
     public async Task SenderCancelFromWithReplyKeyAsync()
     {
-        var receiverPersister = new InMemoryReceiverPersisterAsync();
+        var receiverPersister = new InMemoryReceiverPersisterAsync().AsPersister();
         var address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
 
@@ -314,7 +232,7 @@ public class CancelTests
             .SaveAsync(receiverPersister);
         var uri = receiver.PjUri();
 
-        var senderPersister = new InMemorySenderPersisterAsync();
+        var senderPersister = new InMemorySenderPersisterAsync().AsPersister();
         var psbt = PayjoinMethods.OriginalPsbt();
         var withReplyKey = await new SenderBuilder(psbt, uri)
             .BuildRecommended(1000)
@@ -347,7 +265,7 @@ public class ValidationTests
     private static PjUri CreateV2PjUri()
     {
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
-        var persister = new InMemoryReceiverPersister();
+        var persister = new InMemoryReceiverPersister().AsPersister();
         using var builder = new ReceiverBuilder("2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK", "https://example.com", ohttpKeys);
         using var transition = builder.Build();
         using var receiver = transition.Save(persister);

--- a/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_integration_test.dart
@@ -14,53 +14,6 @@ late test_utils.BitcoindInstance bitcoind;
 late test_utils.RpcClient receiver;
 late test_utils.RpcClient sender;
 
-class InMemoryReceiverPersister
-    implements payjoin.JsonReceiverSessionPersister {
-  final String id;
-  final List<String> events = [];
-  bool closed = false;
-
-  InMemoryReceiverPersister(this.id);
-
-  @override
-  void save(String event) {
-    events.add(event);
-  }
-
-  @override
-  List<String> load() {
-    return events;
-  }
-
-  @override
-  void close() {
-    closed = true;
-  }
-}
-
-class InMemorySenderPersister implements payjoin.JsonSenderSessionPersister {
-  final String id;
-  final List<String> events = [];
-  bool closed = false;
-
-  InMemorySenderPersister(this.id);
-
-  @override
-  void save(String event) {
-    events.add(event);
-  }
-
-  @override
-  List<String> load() {
-    return events;
-  }
-
-  @override
-  void close() {
-    closed = true;
-  }
-}
-
 class MempoolAcceptanceCallback implements payjoin.CanBroadcast {
   final payjoin.RpcClient connection;
 
@@ -172,7 +125,7 @@ payjoin.Initialized create_receiver_context(
   String address,
   String directory,
   payjoin.OhttpKeys ohttp_keys,
-  InMemoryReceiverPersister persister,
+  payjoin.JsonReceiverSessionPersister persister,
 ) {
   var receiver = payjoin.ReceiverBuilder(
     address: address,
@@ -247,7 +200,7 @@ List<payjoin.InputPair> get_inputs(payjoin.RpcClient rpc_connection) {
 
 Future<payjoin.PayjoinProposalReceiveSession> process_provisional_proposal(
   payjoin.ProvisionalProposal proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final payjoin_proposal = proposal
       .finalizeProposal(processPsbt: ProcessPsbtCallback(receiver))
@@ -257,7 +210,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_provisional_proposal(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_wants_fee_range(
   payjoin.WantsFeeRange proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final wants_fee_range = proposal
       .applyFeeRange(minFeeRateSatPerVb: 1, maxEffectiveFeeRateSatPerVb: 10)
@@ -267,7 +220,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_wants_fee_range(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_wants_inputs(
   payjoin.WantsInputs proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final provisional_proposal = proposal
       .contributeInputs(replacementInputs: get_inputs(receiver))
@@ -278,7 +231,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_wants_inputs(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_wants_outputs(
   payjoin.WantsOutputs proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final wants_inputs = proposal.commitOutputs().save(persister: recv_persister);
   return await process_wants_inputs(wants_inputs, recv_persister);
@@ -286,7 +239,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_wants_outputs(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_outputs_unknown(
   payjoin.OutputsUnknown proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final wants_outputs = proposal
       .identifyReceiverOutputs(
@@ -298,7 +251,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_outputs_unknown(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_maybe_inputs_seen(
   payjoin.MaybeInputsSeen proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final outputs_unknown = proposal
       .checkNoInputsSeenBefore(isKnown: CheckInputsNotSeenCallback(receiver))
@@ -308,7 +261,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_maybe_inputs_seen(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_maybe_inputs_owned(
   payjoin.MaybeInputsOwned proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final maybe_inputs_owned = proposal
       .checkInputsNotOwned(isOwned: IsScriptOwnedCallback(receiver))
@@ -318,7 +271,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_maybe_inputs_owned(
 
 Future<payjoin.PayjoinProposalReceiveSession> process_unchecked_proposal(
   payjoin.UncheckedOriginalPayload proposal,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
 ) async {
   final unchecked_proposal = proposal
       .checkBroadcastSuitability(
@@ -331,7 +284,7 @@ Future<payjoin.PayjoinProposalReceiveSession> process_unchecked_proposal(
 
 Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
   payjoin.Initialized receiver,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
   String ohttp_relay,
 ) async {
   var agent = http.Client();
@@ -357,7 +310,7 @@ Future<payjoin.ReceiveSession?> retrieve_receiver_proposal(
 
 Future<payjoin.ReceiveSession?> process_receiver_proposal(
   payjoin.ReceiveSession receiver,
-  InMemoryReceiverPersister recv_persister,
+  payjoin.JsonReceiverSessionPersister recv_persister,
   String ohttp_relay,
 ) async {
   if (receiver is payjoin.InitializedReceiveSession) {
@@ -493,7 +446,7 @@ void main() {
       services.waitForServicesReady();
       final directory = services.directoryUrl();
       final ohttpKeys = services.fetchOhttpKeys();
-      final recvPersister = InMemoryReceiverPersister("prim");
+      final recvPersister = payjoin.InMemoryReceiverPersister().asPersister();
       final pjUri = payjoin.ReceiverBuilder(
         address: receiverAddress,
         directory: directory,
@@ -535,8 +488,8 @@ void main() {
 
       // **********************
       // Inside the Receiver:
-      var recv_persister = InMemoryReceiverPersister("1");
-      var sender_persister = InMemorySenderPersister("1");
+      var recv_persister = payjoin.InMemoryReceiverPersister().asPersister();
+      var sender_persister = payjoin.InMemorySenderPersister().asPersister();
       var session = create_receiver_context(
         receiver_address,
         directory,

--- a/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
@@ -3,101 +3,6 @@ import 'package:convert/convert.dart';
 import 'package:test/test.dart';
 import "package:payjoin/payjoin.dart" as payjoin;
 
-class InMemoryReceiverPersister
-    implements payjoin.JsonReceiverSessionPersister {
-  final String id;
-  final List<String> events = [];
-  bool closed = false;
-
-  InMemoryReceiverPersister(this.id);
-
-  @override
-  void save(String event) {
-    events.add(event);
-  }
-
-  @override
-  List<String> load() {
-    return events;
-  }
-
-  @override
-  void close() {
-    closed = true;
-  }
-}
-
-class InMemorySenderPersister implements payjoin.JsonSenderSessionPersister {
-  final String id;
-  final List<String> events = [];
-  bool closed = false;
-
-  InMemorySenderPersister(this.id);
-
-  @override
-  void save(String event) {
-    events.add(event);
-  }
-
-  @override
-  List<String> load() {
-    return events;
-  }
-
-  @override
-  void close() {
-    closed = true;
-  }
-}
-
-class InMemoryReceiverPersisterAsync
-    implements payjoin.JsonReceiverSessionPersisterAsync {
-  final String id;
-  final List<String> events = [];
-  bool closed = false;
-
-  InMemoryReceiverPersisterAsync(this.id);
-
-  @override
-  Future<void> save(String event) async {
-    events.add(event);
-  }
-
-  @override
-  Future<List<String>> load() async {
-    return events;
-  }
-
-  @override
-  Future<void> close() async {
-    closed = true;
-  }
-}
-
-class InMemorySenderPersisterAsync
-    implements payjoin.JsonSenderSessionPersisterAsync {
-  final String id;
-  final List<String> events = [];
-  bool closed = false;
-
-  InMemorySenderPersisterAsync(this.id);
-
-  @override
-  Future<void> save(String event) async {
-    events.add(event);
-  }
-
-  @override
-  Future<List<String>> load() async {
-    return events;
-  }
-
-  @override
-  Future<void> close() async {
-    closed = true;
-  }
-}
-
 void main() {
   group('Test URIs', () {
     test('Test todo url encoded', () {
@@ -152,7 +57,7 @@ void main() {
 
   group("Test Persistence", () {
     test("Test receiver persistence", () {
-      var persister = InMemoryReceiverPersister("1");
+      var persister = payjoin.InMemoryReceiverPersister().asPersister();
       payjoin.ReceiverBuilder(
         address: "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
         directory: "https://example.com",
@@ -173,7 +78,8 @@ void main() {
     });
 
     test("Test sender persistence", () {
-      var receiver_persister = InMemoryReceiverPersister("1");
+      var receiver_persister = payjoin.InMemoryReceiverPersister()
+          .asPersister();
       var receiver = payjoin.ReceiverBuilder(
         address: "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
         directory: "https://example.com",
@@ -187,7 +93,7 @@ void main() {
       ).build().save(persister: receiver_persister);
       var uri = receiver.pjUri();
 
-      var sender_persister = InMemorySenderPersister("1");
+      var sender_persister = payjoin.InMemorySenderPersister().asPersister();
       var psbt = payjoin.originalPsbt();
       payjoin.SenderBuilder(
         psbt: psbt,
@@ -206,7 +112,7 @@ void main() {
 
   group("Test Receiver Cancel", () {
     test("Test receiver cancel from initialized", () {
-      var persister = InMemoryReceiverPersister("1");
+      var persister = payjoin.InMemoryReceiverPersister().asPersister();
       var initialized = payjoin.ReceiverBuilder(
         address: "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
         directory: "https://example.com",
@@ -230,7 +136,7 @@ void main() {
     });
 
     test("Test receiver cancel async from initialized", () async {
-      var persister = InMemoryReceiverPersisterAsync("1");
+      var persister = payjoin.InMemoryReceiverPersisterAsync().asPersister();
       var initialized = await payjoin.ReceiverBuilder(
         address: "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
         directory: "https://example.com",
@@ -258,7 +164,8 @@ void main() {
 
   group("Test Sender Cancel", () {
     test("Test sender cancel from with reply key", () {
-      var receiver_persister = InMemoryReceiverPersister("1");
+      var receiver_persister = payjoin.InMemoryReceiverPersister()
+          .asPersister();
       var receiver = payjoin.ReceiverBuilder(
         address: "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
         directory: "https://example.com",
@@ -272,7 +179,7 @@ void main() {
       ).build().save(persister: receiver_persister);
       var uri = receiver.pjUri();
 
-      var sender_persister = InMemorySenderPersister("1");
+      var sender_persister = payjoin.InMemorySenderPersister().asPersister();
       var psbt = payjoin.originalPsbt();
       var withReplyKey = payjoin.SenderBuilder(
         psbt: psbt,
@@ -291,7 +198,8 @@ void main() {
     });
 
     test("Test sender cancel async from with reply key", () async {
-      var receiver_persister = InMemoryReceiverPersisterAsync("1");
+      var receiver_persister = payjoin.InMemoryReceiverPersisterAsync()
+          .asPersister();
       var receiver = await payjoin.ReceiverBuilder(
         address: "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
         directory: "https://example.com",
@@ -305,7 +213,8 @@ void main() {
       ).build().saveAsync(persister: receiver_persister);
       var uri = receiver.pjUri();
 
-      var sender_persister = InMemorySenderPersisterAsync("1");
+      var sender_persister = payjoin.InMemorySenderPersisterAsync()
+          .asPersister();
       var psbt = payjoin.originalPsbt();
       var withReplyKey = await payjoin.SenderBuilder(psbt: psbt, uri: uri)
           .buildRecommended(minFeeRate: 1000)
@@ -329,7 +238,7 @@ void main() {
 
   group("Test Async Persistence", () {
     test("Test receiver async persistence", () async {
-      var persister = InMemoryReceiverPersisterAsync("1");
+      var persister = payjoin.InMemoryReceiverPersisterAsync().asPersister();
       await payjoin.ReceiverBuilder(
         address: "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
         directory: "https://example.com",
@@ -352,7 +261,8 @@ void main() {
     });
 
     test("Test sender async persistence", () async {
-      var receiver_persister = InMemoryReceiverPersisterAsync("1");
+      var receiver_persister = payjoin.InMemoryReceiverPersisterAsync()
+          .asPersister();
       var receiver = await payjoin.ReceiverBuilder(
         address: "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
         directory: "https://example.com",
@@ -366,7 +276,8 @@ void main() {
       ).build().saveAsync(persister: receiver_persister);
       var uri = receiver.pjUri();
 
-      var sender_persister = InMemorySenderPersisterAsync("1");
+      var sender_persister = payjoin.InMemorySenderPersisterAsync()
+          .asPersister();
       var psbt = payjoin.originalPsbt();
       await payjoin.SenderBuilder(psbt: psbt, uri: uri)
           .buildRecommended(minFeeRate: 1000)

--- a/payjoin-ffi/javascript/test/integration.test.ts
+++ b/payjoin-ffi/javascript/test/integration.test.ts
@@ -9,53 +9,6 @@ interface Utxo {
     scriptPubKey: string;
 }
 
-class InMemoryReceiverPersister
-    implements payjoin.JsonReceiverSessionPersister
-{
-    private id: string;
-    private events: string[] = [];
-    private closed: boolean = false;
-    public connection?: testUtils.RpcClient;
-
-    constructor(id: string) {
-        this.id = id;
-    }
-
-    save(event: string): void {
-        this.events.push(event);
-    }
-
-    load(): string[] {
-        return this.events;
-    }
-
-    close(): void {
-        this.closed = true;
-    }
-}
-
-class InMemorySenderPersister implements payjoin.JsonSenderSessionPersister {
-    private id: string;
-    private events: string[] = [];
-    private closed: boolean = false;
-
-    constructor(id: string) {
-        this.id = id;
-    }
-
-    save(event: string): void {
-        this.events.push(event);
-    }
-
-    load(): string[] {
-        return this.events;
-    }
-
-    close(): void {
-        this.closed = true;
-    }
-}
-
 class MempoolAcceptanceCallback implements payjoin.CanBroadcast {
     private connection: testUtils.RpcClient;
 
@@ -174,7 +127,7 @@ function createReceiverContext(
     address: string,
     directory: string,
     ohttpKeys: payjoin.OhttpKeys,
-    persister: InMemoryReceiverPersister,
+    persister: payjoin.JsonReceiverSessionPersister,
 ): payjoin.Initialized {
     const receiver = new payjoin.ReceiverBuilder(address, directory, ohttpKeys)
         .build()
@@ -240,7 +193,7 @@ function getInputs(rpcConnection: testUtils.RpcClient): payjoin.InputPair[] {
 async function processProvisionalProposal(
     proposal: payjoin.ProvisionalProposal,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const payjoinProposal = proposal
         .finalizeProposal(new ProcessPsbtCallback(receiver))
@@ -251,7 +204,7 @@ async function processProvisionalProposal(
 async function processWantsFeeRange(
     proposal: payjoin.WantsFeeRange,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const wantsFeeRange = proposal.applyFeeRange(1n, 10n).save(recvPersister);
     return await processProvisionalProposal(
@@ -264,7 +217,7 @@ async function processWantsFeeRange(
 async function processWantsInputs(
     proposal: payjoin.WantsInputs,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const provisionalProposal = proposal
         .contributeInputs(getInputs(receiver))
@@ -280,7 +233,7 @@ async function processWantsInputs(
 async function processWantsOutputs(
     proposal: payjoin.WantsOutputs,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const wantsInputs = proposal.commitOutputs().save(recvPersister);
     return await processWantsInputs(wantsInputs, receiver, recvPersister);
@@ -289,7 +242,7 @@ async function processWantsOutputs(
 async function processOutputsUnknown(
     proposal: payjoin.OutputsUnknown,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const wantsOutputs = proposal
         .identifyReceiverOutputs(new IsScriptOwnedCallback(receiver))
@@ -300,7 +253,7 @@ async function processOutputsUnknown(
 async function processMaybeInputsSeen(
     proposal: payjoin.MaybeInputsSeen,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const outputsUnknown = proposal
         .checkNoInputsSeenBefore(new CheckInputsNotSeenCallback(receiver))
@@ -311,7 +264,7 @@ async function processMaybeInputsSeen(
 async function processMaybeInputsOwned(
     proposal: payjoin.MaybeInputsOwned,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const maybeInputsOwned = proposal
         .checkInputsNotOwned(new IsScriptOwnedCallback(receiver))
@@ -326,7 +279,7 @@ async function processMaybeInputsOwned(
 async function processUncheckedProposal(
     proposal: payjoin.UncheckedOriginalPayload,
     receiver: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
 ): Promise<payjoin.PayjoinProposal> {
     const uncheckedProposal = proposal
         .checkBroadcastSuitability(
@@ -343,7 +296,7 @@ async function processUncheckedProposal(
 
 async function retrieveReceiverProposal(
     receiver: payjoin.Initialized,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
     ohttpRelay: string,
 ): Promise<payjoin.PayjoinProposal | null> {
     const request = receiver.createPollRequest(ohttpRelay);
@@ -384,7 +337,7 @@ async function processReceiverProposal(
         | payjoin.ProvisionalProposal
         | payjoin.PayjoinProposal,
     receiverRpc: testUtils.RpcClient,
-    recvPersister: InMemoryReceiverPersister,
+    recvPersister: payjoin.JsonReceiverSessionPersister,
     ohttpRelay: string,
 ): Promise<payjoin.PayjoinProposal | null> {
     if (receiver instanceof payjoin.Initialized) {
@@ -566,8 +519,8 @@ async function testIntegrationV2ToV2(): Promise<void> {
     const ohttpKeysBytes = services.fetchOhttpKeys();
     const ohttpKeys = payjoin.OhttpKeys.decode(ohttpKeysBytes.buffer);
 
-    const recvPersister = new InMemoryReceiverPersister("1");
-    const senderPersister = new InMemorySenderPersister("1");
+    const recvPersister = new payjoin.InMemoryReceiverPersister().asPersister();
+    const senderPersister = new payjoin.InMemorySenderPersister().asPersister();
     recvPersister.connection = receiver;
 
     const session = createReceiverContext(

--- a/payjoin-ffi/javascript/test/unit.test.ts
+++ b/payjoin-ffi/javascript/test/unit.test.ts
@@ -7,102 +7,6 @@ before(async () => {
     await uniffiInitAsync();
 });
 
-class InMemoryReceiverPersister {
-    id: number;
-    events: any[];
-    closed: boolean;
-
-    constructor(id: number) {
-        this.id = id;
-        this.events = [];
-        this.closed = false;
-    }
-
-    save(event: any) {
-        this.events.push(event);
-    }
-
-    load() {
-        return this.events;
-    }
-
-    close() {
-        this.closed = true;
-    }
-}
-
-class InMemorySenderPersister {
-    id: number;
-    events: any[];
-    closed: boolean;
-
-    constructor(id: number) {
-        this.id = id;
-        this.events = [];
-        this.closed = false;
-    }
-
-    save(event: any) {
-        this.events.push(event);
-    }
-
-    load() {
-        return this.events;
-    }
-
-    close() {
-        this.closed = true;
-    }
-}
-
-class InMemoryReceiverPersisterAsync {
-    id: number;
-    events: any[];
-    closed: boolean;
-
-    constructor(id: number) {
-        this.id = id;
-        this.events = [];
-        this.closed = false;
-    }
-
-    async save(event: any): Promise<void> {
-        this.events.push(event);
-    }
-
-    async load(): Promise<any[]> {
-        return this.events;
-    }
-
-    async close(): Promise<void> {
-        this.closed = true;
-    }
-}
-
-class InMemorySenderPersisterAsync {
-    id: number;
-    events: any[];
-    closed: boolean;
-
-    constructor(id: number) {
-        this.id = id;
-        this.events = [];
-        this.closed = false;
-    }
-
-    async save(event: any): Promise<void> {
-        this.events.push(event);
-    }
-
-    async load(): Promise<any[]> {
-        return this.events;
-    }
-
-    async close(): Promise<void> {
-        this.closed = true;
-    }
-}
-
 describe("URI tests", () => {
     test("URL encoded payjoin parameter", () => {
         const uri =
@@ -153,7 +57,7 @@ describe("URI tests", () => {
 
 describe("Persistence tests", () => {
     test("receiver persistence", () => {
-        const persister = new InMemoryReceiverPersister(1);
+        const persister = new payjoin.InMemoryReceiverPersister().asPersister();
         const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -186,7 +90,7 @@ describe("Persistence tests", () => {
     });
 
     test("sender persistence", () => {
-        const persister = new InMemoryReceiverPersister(1);
+        const persister = new payjoin.InMemoryReceiverPersister().asPersister();
         const address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -210,7 +114,8 @@ describe("Persistence tests", () => {
             .save(persister);
         const uri = receiver.pjUri();
 
-        const senderPersister = new InMemorySenderPersister(1);
+        const senderPersister =
+            new payjoin.InMemorySenderPersister().asPersister();
         const psbt = testUtils.originalPsbt();
         const withReplyKey = new payjoin.SenderBuilder(psbt, uri)
             .buildRecommended(BigInt(1000))
@@ -222,7 +127,7 @@ describe("Persistence tests", () => {
 
 describe("Receiver cancel tests", () => {
     test("receiver cancel from initialized", () => {
-        const persister = new InMemoryReceiverPersister(1);
+        const persister = new payjoin.InMemoryReceiverPersister().asPersister();
         const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -258,7 +163,8 @@ describe("Receiver cancel tests", () => {
     });
 
     test("receiver cancel async from initialized", async () => {
-        const persister = new InMemoryReceiverPersisterAsync(1);
+        const persister =
+            new payjoin.InMemoryReceiverPersisterAsync().asPersister();
         const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -296,7 +202,7 @@ describe("Receiver cancel tests", () => {
 
 describe("Sender cancel tests", () => {
     test("sender cancel from with reply key", () => {
-        const persister = new InMemoryReceiverPersister(1);
+        const persister = new payjoin.InMemoryReceiverPersister().asPersister();
         const address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -320,7 +226,8 @@ describe("Sender cancel tests", () => {
             .save(persister);
         const uri = receiver.pjUri();
 
-        const senderPersister = new InMemorySenderPersister(1);
+        const senderPersister =
+            new payjoin.InMemorySenderPersister().asPersister();
         const psbt = testUtils.originalPsbt();
         const withReplyKey = new payjoin.SenderBuilder(psbt, uri)
             .buildRecommended(BigInt(1000))
@@ -344,7 +251,8 @@ describe("Sender cancel tests", () => {
     });
 
     test("sender cancel async from with reply key", async () => {
-        const persister = new InMemoryReceiverPersisterAsync(1);
+        const persister =
+            new payjoin.InMemoryReceiverPersisterAsync().asPersister();
         const address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -368,7 +276,8 @@ describe("Sender cancel tests", () => {
             .saveAsync(persister);
         const uri = receiver.pjUri();
 
-        const senderPersister = new InMemorySenderPersisterAsync(1);
+        const senderPersister =
+            new payjoin.InMemorySenderPersisterAsync().asPersister();
         const psbt = testUtils.originalPsbt();
         const withReplyKey = await new payjoin.SenderBuilder(psbt, uri)
             .buildRecommended(BigInt(1000))
@@ -394,7 +303,8 @@ describe("Sender cancel tests", () => {
 
 describe("Async Persistence tests", () => {
     test("receiver async persistence", async () => {
-        const persister = new InMemoryReceiverPersisterAsync(1);
+        const persister =
+            new payjoin.InMemoryReceiverPersisterAsync().asPersister();
         const address = "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -427,7 +337,8 @@ describe("Async Persistence tests", () => {
     });
 
     test("sender async persistence", async () => {
-        const persister = new InMemoryReceiverPersisterAsync(1);
+        const persister =
+            new payjoin.InMemoryReceiverPersisterAsync().asPersister();
         const address = "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK";
         const ohttpKeys = payjoin.OhttpKeys.decode(
             new Uint8Array([
@@ -451,7 +362,8 @@ describe("Async Persistence tests", () => {
             .saveAsync(persister);
         const uri = receiver.pjUri();
 
-        const senderPersister = new InMemorySenderPersisterAsync(1);
+        const senderPersister =
+            new payjoin.InMemorySenderPersisterAsync().asPersister();
         const psbt = testUtils.originalPsbt();
         const withReplyKey = await new payjoin.SenderBuilder(psbt, uri)
             .buildRecommended(BigInt(1000))

--- a/payjoin-ffi/python/test/test_payjoin_integration_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_integration_test.py
@@ -17,38 +17,6 @@ sys.path.insert(
 from pprint import *
 
 
-class InMemoryReceiverSessionEventLog(JsonReceiverSessionPersister):
-    def __init__(self, id):
-        self.id = id
-        self.events = []
-        self.closed = False
-
-    def save(self, event: str):
-        self.events.append(event)
-
-    def load(self):
-        return self.events
-
-    def close(self):
-        self.closed = True
-
-
-class InMemorySenderPersister(JsonSenderSessionPersister):
-    def __init__(self, id):
-        self.id = id
-        self.events = []
-        self.closed = False
-
-    def save(self, event: str):
-        self.events.append(event)
-
-    def load(self):
-        return self.events
-
-    def close(self):
-        self.closed = True
-
-
 class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
@@ -101,7 +69,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         directory = services.directory_url()
         ohttp_relay = services.ohttp_relay_url()
         ohttp_keys = await fetch_ohttp_keys(ohttp_relay, directory, services.cert())
-        recv_persister = InMemoryReceiverSessionEventLog(999)
+        recv_persister = InMemoryReceiverPersister().as_persister()
         pj_uri = self.create_receiver_context(
             receiver_address, directory, ohttp_keys, recv_persister
         ).pj_uri()
@@ -117,7 +85,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     async def process_receiver_proposal(
         self,
         receiver: ReceiveSession,
-        recv_persister: InMemoryReceiverSessionEventLog,
+        recv_persister: JsonReceiverSessionPersister,
         ohttp_relay: str,
     ) -> Optional[ReceiveSession]:
         if receiver.is_INITIALIZED():
@@ -156,7 +124,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         address: str,
         directory: str,
         ohttp_keys: OhttpKeys,
-        recv_persister: InMemoryReceiverSessionEventLog,
+        recv_persister: JsonReceiverSessionPersister,
     ) -> Initialized:
         receiver = (
             ReceiverBuilder(address=address, directory=directory, ohttp_keys=ohttp_keys)
@@ -168,7 +136,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     async def retrieve_receiver_proposal(
         self,
         receiver: Initialized,
-        recv_persister: InMemoryReceiverSessionEventLog,
+        recv_persister: JsonReceiverSessionPersister,
         ohttp_relay: str,
     ):
         agent = httpx.AsyncClient()
@@ -188,7 +156,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     async def process_unchecked_proposal(
         self,
         proposal: UncheckedOriginalPayload,
-        recv_persister: InMemoryReceiverSessionEventLog,
+        recv_persister: JsonReceiverSessionPersister,
     ):
         receiver = proposal.check_broadcast_suitability(
             None, MempoolAcceptanceCallback(self.receiver)
@@ -198,7 +166,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     async def process_maybe_inputs_owned(
         self,
         proposal: MaybeInputsOwned,
-        recv_persister: InMemoryReceiverSessionEventLog,
+        recv_persister: JsonReceiverSessionPersister,
     ):
         maybe_inputs_owned = proposal.check_inputs_not_owned(
             IsScriptOwnedCallback(self.receiver)
@@ -206,7 +174,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         return await self.process_maybe_inputs_seen(maybe_inputs_owned, recv_persister)
 
     async def process_maybe_inputs_seen(
-        self, proposal: MaybeInputsSeen, recv_persister: InMemoryReceiverSessionEventLog
+        self, proposal: MaybeInputsSeen, recv_persister: JsonReceiverSessionPersister
     ):
         outputs_unknown = proposal.check_no_inputs_seen_before(
             CheckInputsNotSeenCallback(self.receiver)
@@ -214,7 +182,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         return await self.process_outputs_unknown(outputs_unknown, recv_persister)
 
     async def process_outputs_unknown(
-        self, proposal: OutputsUnknown, recv_persister: InMemoryReceiverSessionEventLog
+        self, proposal: OutputsUnknown, recv_persister: JsonReceiverSessionPersister
     ):
         wants_outputs = proposal.identify_receiver_outputs(
             IsScriptOwnedCallback(self.receiver)
@@ -222,13 +190,13 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         return await self.process_wants_outputs(wants_outputs, recv_persister)
 
     async def process_wants_outputs(
-        self, proposal: WantsOutputs, recv_persister: InMemoryReceiverSessionEventLog
+        self, proposal: WantsOutputs, recv_persister: JsonReceiverSessionPersister
     ):
         wants_inputs = proposal.commit_outputs().save(recv_persister)
         return await self.process_wants_inputs(wants_inputs, recv_persister)
 
     async def process_wants_inputs(
-        self, proposal: WantsInputs, recv_persister: InMemoryReceiverSessionEventLog
+        self, proposal: WantsInputs, recv_persister: JsonReceiverSessionPersister
     ):
         provisional_proposal = (
             proposal.contribute_inputs(get_inputs(self.receiver))
@@ -238,7 +206,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
         return await self.process_wants_fee_range(provisional_proposal, recv_persister)
 
     async def process_wants_fee_range(
-        self, proposal: WantsFeeRange, recv_persister: InMemoryReceiverSessionEventLog
+        self, proposal: WantsFeeRange, recv_persister: JsonReceiverSessionPersister
     ):
         provisional_proposal = proposal.apply_fee_range(1, 10).save(recv_persister)
         return await self.process_provisional_proposal(
@@ -248,7 +216,7 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
     async def process_provisional_proposal(
         self,
         proposal: ProvisionalProposal,
-        recv_persister: InMemoryReceiverSessionEventLog,
+        recv_persister: JsonReceiverSessionPersister,
     ):
         payjoin_proposal = proposal.finalize_proposal(
             ProcessPsbtCallback(self.receiver)
@@ -269,8 +237,8 @@ class TestPayjoin(unittest.IsolatedAsyncioTestCase):
 
             # **********************
             # Inside the Receiver:
-            recv_persister = InMemoryReceiverSessionEventLog(1)
-            sender_persister = InMemorySenderPersister(1)
+            recv_persister = InMemoryReceiverPersister().as_persister()
+            sender_persister = InMemorySenderPersister().as_persister()
             session = self.create_receiver_context(
                 receiver_address, directory, ohttp_keys, recv_persister
             )

--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -32,73 +32,9 @@ class TestURIs(unittest.TestCase):
                     self.fail(f"Failed to create a valid Uri for {uri}. Error: {e}")
 
 
-class InMemoryReceiverPersister(payjoin.JsonReceiverSessionPersister):
-    def __init__(self, id):
-        self.id = id
-        self.events = []
-        self.closed = False
-
-    def save(self, event: str):
-        self.events.append(event)
-
-    def load(self):
-        return self.events
-
-    def close(self):
-        self.closed = True
-
-
-class InMemorySenderPersister(payjoin.JsonSenderSessionPersister):
-    def __init__(self, id):
-        self.id = id
-        self.events = []
-        self.closed = False
-
-    def save(self, event: str):
-        self.events.append(event)
-
-    def load(self):
-        return self.events
-
-    def close(self):
-        self.closed = True
-
-
-class InMemoryReceiverPersisterAsync(payjoin.JsonReceiverSessionPersisterAsync):
-    def __init__(self, id):
-        self.id = id
-        self.events = []
-        self.closed = False
-
-    async def save(self, event: str):
-        self.events.append(event)
-
-    async def load(self):
-        return self.events
-
-    async def close(self):
-        self.closed = True
-
-
-class InMemorySenderPersisterAsync(payjoin.JsonSenderSessionPersisterAsync):
-    def __init__(self, id):
-        self.id = id
-        self.events = []
-        self.closed = False
-
-    async def save(self, event: str):
-        self.events.append(event)
-
-    async def load(self):
-        return self.events
-
-    async def close(self):
-        self.closed = True
-
-
 class TestReceiverPersistence(unittest.TestCase):
     def test_receiver_persistence(self):
-        persister = InMemoryReceiverPersister(1)
+        persister = payjoin.InMemoryReceiverPersister().as_persister()
         payjoin.ReceiverBuilder(
             "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
             "https://example.com",
@@ -115,7 +51,7 @@ class TestReceiverPersistence(unittest.TestCase):
 class TestSenderPersistence(unittest.TestCase):
     def test_sender_persistence(self):
         # Create a receiver to just get the pj uri
-        persister = InMemoryReceiverPersister(1)
+        persister = payjoin.InMemoryReceiverPersister().as_persister()
         receiver = (
             payjoin.ReceiverBuilder(
                 "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
@@ -131,7 +67,7 @@ class TestSenderPersistence(unittest.TestCase):
         )
         uri = receiver.pj_uri()
 
-        persister = InMemorySenderPersister(1)
+        persister = payjoin.InMemorySenderPersister().as_persister()
         psbt = payjoin.original_psbt()
         with_reply_key = (
             payjoin.SenderBuilder(psbt, uri).build_recommended(1000).save(persister)
@@ -143,7 +79,7 @@ class TestReceiverAsyncPersistence(unittest.TestCase):
         import asyncio
 
         async def run_test():
-            persister = InMemoryReceiverPersisterAsync(1)
+            persister = payjoin.InMemoryReceiverPersisterAsync().as_persister()
             await (
                 payjoin.ReceiverBuilder(
                     "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
@@ -169,7 +105,7 @@ class TestSenderAsyncPersistence(unittest.TestCase):
 
         async def run_test():
             # Create a receiver to just get the pj uri
-            persister = InMemoryReceiverPersisterAsync(1)
+            persister = payjoin.InMemoryReceiverPersisterAsync().as_persister()
             receiver = await (
                 payjoin.ReceiverBuilder(
                     "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
@@ -185,7 +121,7 @@ class TestSenderAsyncPersistence(unittest.TestCase):
             )
             uri = receiver.pj_uri()
 
-            persister = InMemorySenderPersisterAsync(1)
+            persister = payjoin.InMemorySenderPersisterAsync().as_persister()
             psbt = payjoin.original_psbt()
             with_reply_key = await (
                 payjoin.SenderBuilder(psbt, uri)
@@ -198,7 +134,7 @@ class TestSenderAsyncPersistence(unittest.TestCase):
 
 class TestReceiverCancel(unittest.TestCase):
     def test_receiver_cancel(self):
-        persister = InMemoryReceiverPersister(1)
+        persister = payjoin.InMemoryReceiverPersister().as_persister()
         initialized = (
             payjoin.ReceiverBuilder(
                 "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
@@ -224,7 +160,7 @@ class TestReceiverCancelAsync(unittest.TestCase):
         import asyncio
 
         async def run_test():
-            persister = InMemoryReceiverPersisterAsync(1)
+            persister = payjoin.InMemoryReceiverPersisterAsync().as_persister()
             initialized = await (
                 payjoin.ReceiverBuilder(
                     "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
@@ -250,7 +186,7 @@ class TestReceiverCancelAsync(unittest.TestCase):
 class TestSenderCancel(unittest.TestCase):
     def test_sender_cancel(self):
         # Create a receiver to just get the pj uri
-        persister = InMemoryReceiverPersister(1)
+        persister = payjoin.InMemoryReceiverPersister().as_persister()
         receiver = (
             payjoin.ReceiverBuilder(
                 "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
@@ -266,7 +202,7 @@ class TestSenderCancel(unittest.TestCase):
         )
         uri = receiver.pj_uri()
 
-        persister = InMemorySenderPersister(1)
+        persister = payjoin.InMemorySenderPersister().as_persister()
         psbt = payjoin.original_psbt()
         with_reply_key = (
             payjoin.SenderBuilder(psbt, uri).build_recommended(1000).save(persister)
@@ -285,7 +221,7 @@ class TestSenderCancelAsync(unittest.TestCase):
 
         async def run_test():
             # Create a receiver to just get the pj uri
-            persister = InMemoryReceiverPersisterAsync(1)
+            persister = payjoin.InMemoryReceiverPersisterAsync().as_persister()
             receiver = await (
                 payjoin.ReceiverBuilder(
                     "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK",
@@ -301,7 +237,7 @@ class TestSenderCancelAsync(unittest.TestCase):
             )
             uri = receiver.pj_uri()
 
-            persister = InMemorySenderPersisterAsync(1)
+            persister = payjoin.InMemorySenderPersisterAsync().as_persister()
             psbt = payjoin.original_psbt()
             with_reply_key = await (
                 payjoin.SenderBuilder(psbt, uri)

--- a/payjoin-ffi/src/lib.rs
+++ b/payjoin-ffi/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod error;
 pub mod ohttp;
 pub mod output_substitution;
+pub mod persist;
 pub mod receive;
 pub mod request;
 pub mod send;
@@ -15,6 +16,7 @@ pub use payjoin::persist::InMemoryPersister;
 
 pub use crate::ohttp::*;
 pub use crate::output_substitution::*;
+pub use crate::persist::*;
 pub use crate::receive::*;
 pub use crate::request::Request;
 pub use crate::send::*;

--- a/payjoin-ffi/src/persist.rs
+++ b/payjoin-ffi/src/persist.rs
@@ -14,11 +14,45 @@
 
 use std::sync::Arc;
 
-use payjoin::persist::{InMemoryPersister, SessionPersister};
+use payjoin::persist::{AsyncSessionPersister, InMemoryPersister, SessionPersister};
 
 use crate::error::ForeignError;
-use crate::receive::{JsonReceiverSessionPersister, JsonReceiverSessionPersisterAsync};
-use crate::send::{JsonSenderSessionPersister, JsonSenderSessionPersisterAsync};
+use crate::receive::ReceiverSessionEvent;
+use crate::send::SenderSessionEvent;
+
+/// Session persister that should save and load events as JSON strings.
+#[uniffi::export(with_foreign)]
+pub trait JsonReceiverSessionPersister: Send + Sync {
+    fn save(&self, event: String) -> Result<(), ForeignError>;
+    fn load(&self) -> Result<Vec<String>, ForeignError>;
+    fn close(&self) -> Result<(), ForeignError>;
+}
+
+/// Async session persister that should save and load events as JSON strings.
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait JsonReceiverSessionPersisterAsync: Send + Sync {
+    async fn save(&self, event: String) -> Result<(), ForeignError>;
+    async fn load(&self) -> Result<Vec<String>, ForeignError>;
+    async fn close(&self) -> Result<(), ForeignError>;
+}
+
+/// Session persister that should save and load events as JSON strings.
+#[uniffi::export(with_foreign)]
+pub trait JsonSenderSessionPersister: Send + Sync {
+    fn save(&self, event: String) -> Result<(), ForeignError>;
+    fn load(&self) -> Result<Vec<String>, ForeignError>;
+    fn close(&self) -> Result<(), ForeignError>;
+}
+
+/// Async session persister that should save and load events as JSON strings.
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait JsonSenderSessionPersisterAsync: Send + Sync {
+    async fn save(&self, event: String) -> Result<(), ForeignError>;
+    async fn load(&self) -> Result<Vec<String>, ForeignError>;
+    async fn close(&self) -> Result<(), ForeignError>;
+}
 
 /// In-memory [`JsonReceiverSessionPersister`] backed by
 /// [`payjoin::persist::InMemoryPersister`].
@@ -151,5 +185,201 @@ impl JsonSenderSessionPersisterAsync for InMemorySenderPersisterAsync {
     async fn close(&self) -> Result<(), ForeignError> {
         self.0.close().expect("InMemoryPersister close is infallible");
         Ok(())
+    }
+}
+
+/// Adapter for the [`JsonReceiverSessionPersister`] trait to use the save and load callbacks.
+pub(crate) struct ReceiverCallbackPersisterAdapter {
+    callback_persister: Arc<dyn JsonReceiverSessionPersister>,
+}
+
+impl ReceiverCallbackPersisterAdapter {
+    pub fn new(callback_persister: Arc<dyn JsonReceiverSessionPersister>) -> Self {
+        Self { callback_persister }
+    }
+}
+
+impl SessionPersister for ReceiverCallbackPersisterAdapter {
+    type SessionEvent = payjoin::receive::v2::SessionEvent;
+    type InternalStorageError = ForeignError;
+
+    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
+        let uni_event: ReceiverSessionEvent = event.into();
+        self.callback_persister
+            .save(uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?)
+    }
+
+    fn load(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
+        let res = self.callback_persister.load()?;
+        let events = res
+            .into_iter()
+            .map(|event| {
+                ReceiverSessionEvent::from_json(event)
+                    .map_err(|e| ForeignError::InternalError(e.to_string()))
+                    .map(|e| e.into())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Box::new(events.into_iter()))
+    }
+
+    fn close(&self) -> Result<(), Self::InternalStorageError> { self.callback_persister.close() }
+}
+
+/// Adapter for the [`JsonReceiverSessionPersisterAsync`] trait to use the save and load callbacks.
+pub(crate) struct AsyncReceiverCallbackPersisterAdapter {
+    callback_persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
+}
+
+impl AsyncReceiverCallbackPersisterAdapter {
+    pub fn new(callback_persister: Arc<dyn JsonReceiverSessionPersisterAsync>) -> Self {
+        Self { callback_persister }
+    }
+}
+
+impl AsyncSessionPersister for AsyncReceiverCallbackPersisterAdapter {
+    type SessionEvent = payjoin::receive::v2::SessionEvent;
+    type InternalStorageError = ForeignError;
+
+    fn save_event(
+        &self,
+        event: Self::SessionEvent,
+    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
+        let uni_event: ReceiverSessionEvent = event.into();
+        let persister = self.callback_persister.clone();
+        async move {
+            let json =
+                uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?;
+            persister.save(json).await
+        }
+    }
+
+    fn load(
+        &self,
+    ) -> impl std::future::Future<
+        Output = Result<
+            Box<dyn Iterator<Item = Self::SessionEvent> + Send>,
+            Self::InternalStorageError,
+        >,
+    > + Send {
+        let persister = self.callback_persister.clone();
+        async move {
+            let res = persister.load().await?;
+            let events: Vec<_> = res
+                .into_iter()
+                .map(|event| {
+                    ReceiverSessionEvent::from_json(event)
+                        .map_err(|e| ForeignError::InternalError(e.to_string()))
+                        .map(Into::into)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Box::new(events.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+        }
+    }
+
+    fn close(
+        &self,
+    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
+        let persister = self.callback_persister.clone();
+        async move { persister.close().await }
+    }
+}
+
+/// Adapter for the [`JsonSenderSessionPersister`] trait to use the save and load callbacks.
+pub(crate) struct SenderCallbackPersisterAdapter {
+    callback_persister: Arc<dyn JsonSenderSessionPersister>,
+}
+
+impl SenderCallbackPersisterAdapter {
+    pub fn new(callback_persister: Arc<dyn JsonSenderSessionPersister>) -> Self {
+        Self { callback_persister }
+    }
+}
+
+impl SessionPersister for SenderCallbackPersisterAdapter {
+    type SessionEvent = payjoin::send::v2::SessionEvent;
+    type InternalStorageError = ForeignError;
+
+    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
+        let event: SenderSessionEvent = event.into();
+        self.callback_persister
+            .save(event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?)
+    }
+
+    fn load(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
+        let res = self.callback_persister.load()?;
+        let events = res
+            .into_iter()
+            .map(|event| {
+                SenderSessionEvent::from_json(event)
+                    .map_err(|e| ForeignError::InternalError(e.to_string()))
+                    .map(|e| e.into())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Box::new(events.into_iter()))
+    }
+
+    fn close(&self) -> Result<(), Self::InternalStorageError> { self.callback_persister.close() }
+}
+
+/// Adapter for the [`JsonSenderSessionPersisterAsync`] trait to use the save and load callbacks.
+pub(crate) struct AsyncSenderCallbackPersisterAdapter {
+    callback_persister: Arc<dyn JsonSenderSessionPersisterAsync>,
+}
+
+impl AsyncSenderCallbackPersisterAdapter {
+    pub fn new(callback_persister: Arc<dyn JsonSenderSessionPersisterAsync>) -> Self {
+        Self { callback_persister }
+    }
+}
+
+impl AsyncSessionPersister for AsyncSenderCallbackPersisterAdapter {
+    type SessionEvent = payjoin::send::v2::SessionEvent;
+    type InternalStorageError = ForeignError;
+
+    fn save_event(
+        &self,
+        event: Self::SessionEvent,
+    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
+        let uni_event: SenderSessionEvent = event.into();
+        let persister = self.callback_persister.clone();
+        async move {
+            let json =
+                uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?;
+            persister.save(json).await
+        }
+    }
+
+    fn load(
+        &self,
+    ) -> impl std::future::Future<
+        Output = Result<
+            Box<dyn Iterator<Item = Self::SessionEvent> + Send>,
+            Self::InternalStorageError,
+        >,
+    > + Send {
+        let persister = self.callback_persister.clone();
+        async move {
+            let res = persister.load().await?;
+            let events: Vec<_> = res
+                .into_iter()
+                .map(|event| {
+                    SenderSessionEvent::from_json(event)
+                        .map_err(|e| ForeignError::InternalError(e.to_string()))
+                        .map(Into::into)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Box::new(events.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+        }
+    }
+
+    fn close(
+        &self,
+    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
+        let persister = self.callback_persister.clone();
+        async move { persister.close().await }
     }
 }

--- a/payjoin-ffi/src/persist.rs
+++ b/payjoin-ffi/src/persist.rs
@@ -1,0 +1,155 @@
+//! In-memory implementations of the JSON session persister traits exposed by
+//! [`crate::receive`] and [`crate::send`].
+//!
+//! These wrap [`payjoin::persist::InMemoryPersister`] so that bindings can use a
+//! ready-made persister for tests, examples, and prototyping without having to
+//! re-implement the same event log in every language.
+//!
+//! Each wrapper exposes an `as_persister` method that returns the corresponding
+//! `Arc<dyn Trait>`. uniffi 0.31 generates separate types for `uniffi::Object`
+//! classes and `with_foreign` callback interfaces, and statically-typed bindings
+//! (Dart, C#) will not accept the class where the interface is expected. The
+//! conversion method is the upstream-recommended workaround tracked in
+//! <https://github.com/mozilla/uniffi-rs/issues/2542>.
+
+use std::sync::Arc;
+
+use payjoin::persist::{InMemoryPersister, SessionPersister};
+
+use crate::error::ForeignError;
+use crate::receive::{JsonReceiverSessionPersister, JsonReceiverSessionPersisterAsync};
+use crate::send::{JsonSenderSessionPersister, JsonSenderSessionPersisterAsync};
+
+/// In-memory [`JsonReceiverSessionPersister`] backed by
+/// [`payjoin::persist::InMemoryPersister`].
+#[derive(uniffi::Object, Default)]
+pub struct InMemoryReceiverPersister(InMemoryPersister<String>);
+
+#[uniffi::export]
+impl InMemoryReceiverPersister {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> { Arc::new(Self::default()) }
+
+    /// Returns this persister as a [`JsonReceiverSessionPersister`] trait object so it can
+    /// be passed to APIs that take a callback persister.
+    pub fn as_persister(self: Arc<Self>) -> Arc<dyn JsonReceiverSessionPersister> { self }
+}
+
+impl JsonReceiverSessionPersister for InMemoryReceiverPersister {
+    fn save(&self, event: String) -> Result<(), ForeignError> {
+        self.0.save_event(event).expect("InMemoryPersister save_event is infallible");
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Vec<String>, ForeignError> {
+        Ok(self.0.load().expect("InMemoryPersister load is infallible").collect())
+    }
+
+    fn close(&self) -> Result<(), ForeignError> {
+        self.0.close().expect("InMemoryPersister close is infallible");
+        Ok(())
+    }
+}
+
+/// Async in-memory [`JsonReceiverSessionPersisterAsync`] backed by
+/// [`payjoin::persist::InMemoryPersister`].
+///
+/// The trait methods are `async`-shaped but the storage layer is synchronous: they exist
+/// so binding tests can exercise the async save/load/close FFI dispatch path, not to
+/// model real I/O.
+#[derive(uniffi::Object, Default)]
+pub struct InMemoryReceiverPersisterAsync(InMemoryPersister<String>);
+
+#[uniffi::export]
+impl InMemoryReceiverPersisterAsync {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> { Arc::new(Self::default()) }
+
+    /// Returns this persister as a [`JsonReceiverSessionPersisterAsync`] trait object so it
+    /// can be passed to APIs that take a callback persister.
+    pub fn as_persister(self: Arc<Self>) -> Arc<dyn JsonReceiverSessionPersisterAsync> { self }
+}
+
+#[async_trait::async_trait]
+impl JsonReceiverSessionPersisterAsync for InMemoryReceiverPersisterAsync {
+    async fn save(&self, event: String) -> Result<(), ForeignError> {
+        self.0.save_event(event).expect("InMemoryPersister save_event is infallible");
+        Ok(())
+    }
+
+    async fn load(&self) -> Result<Vec<String>, ForeignError> {
+        Ok(self.0.load().expect("InMemoryPersister load is infallible").collect())
+    }
+
+    async fn close(&self) -> Result<(), ForeignError> {
+        self.0.close().expect("InMemoryPersister close is infallible");
+        Ok(())
+    }
+}
+
+/// In-memory [`JsonSenderSessionPersister`] backed by
+/// [`payjoin::persist::InMemoryPersister`].
+#[derive(uniffi::Object, Default)]
+pub struct InMemorySenderPersister(InMemoryPersister<String>);
+
+#[uniffi::export]
+impl InMemorySenderPersister {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> { Arc::new(Self::default()) }
+
+    /// Returns this persister as a [`JsonSenderSessionPersister`] trait object so it can be
+    /// passed to APIs that take a callback persister.
+    pub fn as_persister(self: Arc<Self>) -> Arc<dyn JsonSenderSessionPersister> { self }
+}
+
+impl JsonSenderSessionPersister for InMemorySenderPersister {
+    fn save(&self, event: String) -> Result<(), ForeignError> {
+        self.0.save_event(event).expect("InMemoryPersister save_event is infallible");
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Vec<String>, ForeignError> {
+        Ok(self.0.load().expect("InMemoryPersister load is infallible").collect())
+    }
+
+    fn close(&self) -> Result<(), ForeignError> {
+        self.0.close().expect("InMemoryPersister close is infallible");
+        Ok(())
+    }
+}
+
+/// Async in-memory [`JsonSenderSessionPersisterAsync`] backed by
+/// [`payjoin::persist::InMemoryPersister`].
+///
+/// The trait methods are `async`-shaped but the storage layer is synchronous: they exist
+/// so binding tests can exercise the async save/load/close FFI dispatch path, not to
+/// model real I/O.
+#[derive(uniffi::Object, Default)]
+pub struct InMemorySenderPersisterAsync(InMemoryPersister<String>);
+
+#[uniffi::export]
+impl InMemorySenderPersisterAsync {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> { Arc::new(Self::default()) }
+
+    /// Returns this persister as a [`JsonSenderSessionPersisterAsync`] trait object so it
+    /// can be passed to APIs that take a callback persister.
+    pub fn as_persister(self: Arc<Self>) -> Arc<dyn JsonSenderSessionPersisterAsync> { self }
+}
+
+#[async_trait::async_trait]
+impl JsonSenderSessionPersisterAsync for InMemorySenderPersisterAsync {
+    async fn save(&self, event: String) -> Result<(), ForeignError> {
+        self.0.save_event(event).expect("InMemoryPersister save_event is infallible");
+        Ok(())
+    }
+
+    async fn load(&self) -> Result<Vec<String>, ForeignError> {
+        Ok(self.0.load().expect("InMemoryPersister load is infallible").collect())
+    }
+
+    async fn close(&self) -> Result<(), ForeignError> {
+        self.0.close().expect("InMemoryPersister close is infallible");
+        Ok(())
+    }
+}

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -14,6 +14,10 @@ use payjoin::persist::{MaybeFatalTransition, NextStateTransition};
 use crate::error::ForeignError;
 pub use crate::error::{FfiValidationError, ImplementationError, SerdeJsonError};
 use crate::ohttp::OhttpKeys;
+use crate::persist::{
+    AsyncReceiverCallbackPersisterAdapter, JsonReceiverSessionPersister,
+    JsonReceiverSessionPersisterAsync, ReceiverCallbackPersisterAdapter,
+};
 use crate::receive::error::{ReceiverPersistedError, ReceiverReplayError};
 use crate::uri::error::FeeRateError;
 use crate::validation::{
@@ -33,7 +37,7 @@ macro_rules! impl_save_for_transition {
                 &self,
                 persister: Arc<dyn JsonReceiverSessionPersister>,
             ) -> Result<$next_state, ReceiverPersistedError> {
-                let adapter = CallbackPersisterAdapter::new(persister);
+                let adapter = ReceiverCallbackPersisterAdapter::new(persister);
                 let mut inner = self.0.write().expect("Lock should not be poisoned");
 
                 let value = inner.take().expect("Already saved or moved");
@@ -48,7 +52,7 @@ macro_rules! impl_save_for_transition {
                 &self,
                 persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
             ) -> Result<$next_state, ReceiverPersistedError> {
-                let adapter = AsyncCallbackPersisterAdapter::new(persister);
+                let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
                 // Extract value while holding the lock, then drop the guard before await
                 let value = {
                     let mut inner = self.0.write().expect("Lock should not be poisoned");
@@ -89,7 +93,7 @@ impl CancelTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersister>,
     ) -> Result<Option<Vec<u8>>, ReceiverPersistedError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = ReceiverCallbackPersisterAdapter::new(persister);
         let mut inner = self.transition.write().expect("Lock should not be poisoned");
         let value = inner.take().expect("Already saved or moved");
         let fallback = value
@@ -102,7 +106,7 @@ impl CancelTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
     ) -> Result<Option<Vec<u8>>, ReceiverPersistedError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.transition.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -251,7 +255,7 @@ impl ReplayResult {
 pub fn replay_receiver_event_log(
     persister: Arc<dyn JsonReceiverSessionPersister>,
 ) -> Result<ReplayResult, ReceiverReplayError> {
-    let adapter = CallbackPersisterAdapter::new(persister);
+    let adapter = ReceiverCallbackPersisterAdapter::new(persister);
     let (state, session_history) = payjoin::receive::v2::replay_event_log(&adapter)?;
     Ok(ReplayResult { state: state.into(), session_history: session_history.into() })
 }
@@ -260,7 +264,7 @@ pub fn replay_receiver_event_log(
 pub async fn replay_receiver_event_log_async(
     persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
 ) -> Result<ReplayResult, ReceiverReplayError> {
-    let adapter = AsyncCallbackPersisterAdapter::new(persister);
+    let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
     let (state, session_history) = payjoin::receive::v2::replay_event_log_async(&adapter).await?;
     Ok(ReplayResult { state: state.into(), session_history: session_history.into() })
 }
@@ -320,7 +324,7 @@ impl InitialReceiveTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersister>,
     ) -> Result<Initialized, ForeignError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = ReceiverCallbackPersisterAdapter::new(persister);
         let mut inner = self.0.write().expect("Lock should not be poisoned");
 
         let value = inner.take().expect("Already saved or moved");
@@ -333,7 +337,7 @@ impl InitialReceiveTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
     ) -> Result<Initialized, ForeignError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.0.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -560,7 +564,7 @@ impl InitializedTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersister>,
     ) -> Result<InitializedTransitionOutcome, ReceiverPersistedError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = ReceiverCallbackPersisterAdapter::new(persister);
         let mut inner = self.0.write().expect("Lock should not be poisoned");
 
         let value = inner.take().expect("Already saved or moved");
@@ -573,7 +577,7 @@ impl InitializedTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
     ) -> Result<InitializedTransitionOutcome, ReceiverPersistedError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.0.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -1310,7 +1314,7 @@ impl HasReplyableErrorTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersister>,
     ) -> Result<(), ReceiverPersistedError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = ReceiverCallbackPersisterAdapter::new(persister);
         let mut inner = self.0.write().expect("Lock should not be poisoned");
 
         let value = inner.take().expect("Already saved or moved");
@@ -1323,7 +1327,7 @@ impl HasReplyableErrorTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
     ) -> Result<(), ReceiverPersistedError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.0.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -1383,7 +1387,7 @@ impl MonitorTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersister>,
     ) -> Result<(), ReceiverPersistedError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = ReceiverCallbackPersisterAdapter::new(persister);
         let mut inner = self.0.write().expect("Lock should not be poisoned");
 
         let value = inner.take().expect("Already saved or moved");
@@ -1396,7 +1400,7 @@ impl MonitorTransition {
         &self,
         persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
     ) -> Result<(), ReceiverPersistedError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncReceiverCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.0.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -1432,120 +1436,5 @@ impl Monitor {
                 .and_then(|buf| buf.map(try_deserialize_tx).transpose())
                 .map_err(|e| ImplementationError::new(e).into())
         })))))
-    }
-}
-
-/// Session persister that should save and load events as JSON strings.
-#[uniffi::export(with_foreign)]
-pub trait JsonReceiverSessionPersister: Send + Sync {
-    fn save(&self, event: String) -> Result<(), ForeignError>;
-    fn load(&self) -> Result<Vec<String>, ForeignError>;
-    fn close(&self) -> Result<(), ForeignError>;
-}
-
-/// Adapter for the [JsonReceiverSessionPersister] trait to use the save and load callbacks.
-struct CallbackPersisterAdapter {
-    callback_persister: Arc<dyn JsonReceiverSessionPersister>,
-}
-
-impl CallbackPersisterAdapter {
-    pub fn new(callback_persister: Arc<dyn JsonReceiverSessionPersister>) -> Self {
-        Self { callback_persister }
-    }
-}
-
-impl payjoin::persist::SessionPersister for CallbackPersisterAdapter {
-    type SessionEvent = payjoin::receive::v2::SessionEvent;
-    type InternalStorageError = ForeignError;
-
-    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
-        let uni_event: ReceiverSessionEvent = event.into();
-        self.callback_persister
-            .save(uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?)
-    }
-
-    fn load(
-        &self,
-    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
-        let res = self.callback_persister.load()?;
-        let events = res
-            .into_iter()
-            .map(|event| {
-                ReceiverSessionEvent::from_json(event)
-                    .map_err(|e| ForeignError::InternalError(e.to_string()))
-                    .map(|e| e.into())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Box::new(events.into_iter()))
-    }
-
-    fn close(&self) -> Result<(), Self::InternalStorageError> { self.callback_persister.close() }
-}
-
-/// Async session persister that should save and load events as JSON strings.
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait JsonReceiverSessionPersisterAsync: Send + Sync {
-    async fn save(&self, event: String) -> Result<(), ForeignError>;
-    async fn load(&self) -> Result<Vec<String>, ForeignError>;
-    async fn close(&self) -> Result<(), ForeignError>;
-}
-
-/// Adapter for the [JsonReceiverSessionPersisterAsync] trait to use the save and load callbacks.
-struct AsyncCallbackPersisterAdapter {
-    callback_persister: Arc<dyn JsonReceiverSessionPersisterAsync>,
-}
-
-impl AsyncCallbackPersisterAdapter {
-    pub fn new(callback_persister: Arc<dyn JsonReceiverSessionPersisterAsync>) -> Self {
-        Self { callback_persister }
-    }
-}
-
-impl payjoin::persist::AsyncSessionPersister for AsyncCallbackPersisterAdapter {
-    type SessionEvent = payjoin::receive::v2::SessionEvent;
-    type InternalStorageError = ForeignError;
-
-    fn save_event(
-        &self,
-        event: Self::SessionEvent,
-    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
-        let uni_event: ReceiverSessionEvent = event.into();
-        let persister = self.callback_persister.clone();
-        async move {
-            let json =
-                uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?;
-            persister.save(json).await
-        }
-    }
-
-    fn load(
-        &self,
-    ) -> impl std::future::Future<
-        Output = Result<
-            Box<dyn Iterator<Item = Self::SessionEvent> + Send>,
-            Self::InternalStorageError,
-        >,
-    > + Send {
-        let persister = self.callback_persister.clone();
-        async move {
-            let res = persister.load().await?;
-            let events: Vec<_> = res
-                .into_iter()
-                .map(|event| {
-                    ReceiverSessionEvent::from_json(event)
-                        .map_err(|e| ForeignError::InternalError(e.to_string()))
-                        .map(Into::into)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(Box::new(events.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
-        }
-    }
-
-    fn close(
-        &self,
-    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
-        let persister = self.callback_persister.clone();
-        async move { persister.close().await }
     }
 }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -9,6 +9,10 @@ pub use error::{
 use crate::error::ForeignError;
 pub use crate::error::{ImplementationError, SerdeJsonError};
 use crate::ohttp::ClientResponse;
+use crate::persist::{
+    AsyncSenderCallbackPersisterAdapter, JsonSenderSessionPersister,
+    JsonSenderSessionPersisterAsync, SenderCallbackPersisterAdapter,
+};
 use crate::request::Request;
 use crate::send::error::{SenderPersistedError, SenderReplayError};
 use crate::uri::PjUri;
@@ -24,7 +28,7 @@ macro_rules! impl_save_for_transition {
                 &self,
                 persister: Arc<dyn JsonSenderSessionPersister>,
             ) -> Result<$next_state, SenderPersistedError> {
-                let adapter = CallbackPersisterAdapter::new(persister);
+                let adapter = SenderCallbackPersisterAdapter::new(persister);
                 let mut inner = self.0.write().expect("Lock should not be poisoned");
 
                 let value = inner.take().expect("Already saved or moved");
@@ -37,7 +41,7 @@ macro_rules! impl_save_for_transition {
                 &self,
                 persister: Arc<dyn JsonSenderSessionPersisterAsync>,
             ) -> Result<$next_state, SenderPersistedError> {
-                let adapter = AsyncCallbackPersisterAdapter::new(persister);
+                let adapter = AsyncSenderCallbackPersisterAdapter::new(persister);
                 // Extract value while holding the lock, then drop the guard before await
                 let value = {
                     let mut inner = self.0.write().expect("Lock should not be poisoned");
@@ -75,7 +79,7 @@ impl SenderCancelTransition {
         &self,
         persister: Arc<dyn JsonSenderSessionPersister>,
     ) -> Result<Vec<u8>, SenderPersistedError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = SenderCallbackPersisterAdapter::new(persister);
         let mut inner = self.transition.write().expect("Lock should not be poisoned");
         let value = inner.take().expect("Already saved or moved");
         let fallback = value
@@ -88,7 +92,7 @@ impl SenderCancelTransition {
         &self,
         persister: Arc<dyn JsonSenderSessionPersisterAsync>,
     ) -> Result<Vec<u8>, SenderPersistedError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncSenderCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.transition.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -218,7 +222,7 @@ impl SenderReplayResult {
 pub fn replay_sender_event_log(
     persister: Arc<dyn JsonSenderSessionPersister>,
 ) -> Result<SenderReplayResult, SenderReplayError> {
-    let adapter = CallbackPersisterAdapter::new(persister);
+    let adapter = SenderCallbackPersisterAdapter::new(persister);
     let (state, session_history) = payjoin::send::v2::replay_event_log(&adapter)?;
     Ok(SenderReplayResult { state: state.into(), session_history: session_history.into() })
 }
@@ -227,7 +231,7 @@ pub fn replay_sender_event_log(
 pub async fn replay_sender_event_log_async(
     persister: Arc<dyn JsonSenderSessionPersisterAsync>,
 ) -> Result<SenderReplayResult, SenderReplayError> {
-    let adapter = AsyncCallbackPersisterAdapter::new(persister);
+    let adapter = AsyncSenderCallbackPersisterAdapter::new(persister);
     let (state, session_history) = payjoin::send::v2::replay_event_log_async(&adapter).await?;
     Ok(SenderReplayResult { state: state.into(), session_history: session_history.into() })
 }
@@ -302,7 +306,7 @@ impl InitialSendTransition {
         &self,
         persister: Arc<dyn JsonSenderSessionPersister>,
     ) -> Result<WithReplyKey, ForeignError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = SenderCallbackPersisterAdapter::new(persister);
         let mut inner = self.0.write().expect("Lock should not be poisoned");
 
         let value = inner.take().expect("Already saved or moved");
@@ -315,7 +319,7 @@ impl InitialSendTransition {
         &self,
         persister: Arc<dyn JsonSenderSessionPersisterAsync>,
     ) -> Result<WithReplyKey, ForeignError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncSenderCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.0.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -471,7 +475,7 @@ impl WithReplyKeyTransition {
         &self,
         persister: Arc<dyn JsonSenderSessionPersister>,
     ) -> Result<PollingForProposal, SenderPersistedError> {
-        let adapter = CallbackPersisterAdapter::new(persister);
+        let adapter = SenderCallbackPersisterAdapter::new(persister);
         let mut inner = self.0.write().expect("Lock should not be poisoned");
 
         let value = inner.take().expect("Already saved or moved");
@@ -484,7 +488,7 @@ impl WithReplyKeyTransition {
         &self,
         persister: Arc<dyn JsonSenderSessionPersisterAsync>,
     ) -> Result<PollingForProposal, SenderPersistedError> {
-        let adapter = AsyncCallbackPersisterAdapter::new(persister);
+        let adapter = AsyncSenderCallbackPersisterAdapter::new(persister);
         let value = {
             let mut inner = self.0.write().expect("Lock should not be poisoned");
             inner.take().expect("Already saved or moved")
@@ -642,122 +646,5 @@ impl PollingForProposal {
         PollingForProposalTransition(Arc::new(RwLock::new(Some(
             self.0.clone().process_response(response, ohttp_ctx.into()),
         ))))
-    }
-}
-
-/// Session persister that should save and load events as JSON strings.
-#[uniffi::export(with_foreign)]
-pub trait JsonSenderSessionPersister: Send + Sync {
-    fn save(&self, event: String) -> Result<(), ForeignError>;
-    fn load(&self) -> Result<Vec<String>, ForeignError>;
-    fn close(&self) -> Result<(), ForeignError>;
-}
-
-// The adapter to use the save and load callbacks
-#[derive(Clone)]
-struct CallbackPersisterAdapter {
-    callback_persister: Arc<dyn JsonSenderSessionPersister>,
-}
-
-impl CallbackPersisterAdapter {
-    pub fn new(callback_persister: Arc<dyn JsonSenderSessionPersister>) -> Self {
-        Self { callback_persister }
-    }
-}
-
-// Implement the Persister trait for the adapter
-impl payjoin::persist::SessionPersister for CallbackPersisterAdapter {
-    type SessionEvent = payjoin::send::v2::SessionEvent;
-    type InternalStorageError = ForeignError;
-
-    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
-        let event: SenderSessionEvent = event.into();
-        self.callback_persister
-            .save(event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?)
-    }
-
-    fn load(
-        &self,
-    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
-        let res = self.callback_persister.load()?;
-        let events = res
-            .into_iter()
-            .map(|event| {
-                SenderSessionEvent::from_json(event)
-                    .map_err(|e| ForeignError::InternalError(e.to_string()))
-                    .map(|e| e.into())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Box::new(events.into_iter()))
-    }
-
-    fn close(&self) -> Result<(), Self::InternalStorageError> { self.callback_persister.close() }
-}
-
-/// Async session persister that should save and load events as JSON strings.
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait JsonSenderSessionPersisterAsync: Send + Sync {
-    async fn save(&self, event: String) -> Result<(), ForeignError>;
-    async fn load(&self) -> Result<Vec<String>, ForeignError>;
-    async fn close(&self) -> Result<(), ForeignError>;
-}
-
-/// Adapter for the [JsonSenderSessionPersisterAsync] trait to use the save and load callbacks.
-struct AsyncCallbackPersisterAdapter {
-    callback_persister: Arc<dyn JsonSenderSessionPersisterAsync>,
-}
-
-impl AsyncCallbackPersisterAdapter {
-    pub fn new(callback_persister: Arc<dyn JsonSenderSessionPersisterAsync>) -> Self {
-        Self { callback_persister }
-    }
-}
-
-impl payjoin::persist::AsyncSessionPersister for AsyncCallbackPersisterAdapter {
-    type SessionEvent = payjoin::send::v2::SessionEvent;
-    type InternalStorageError = ForeignError;
-
-    fn save_event(
-        &self,
-        event: Self::SessionEvent,
-    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
-        let uni_event: SenderSessionEvent = event.into();
-        let persister = self.callback_persister.clone();
-        async move {
-            let json =
-                uni_event.to_json().map_err(|e| ForeignError::InternalError(e.to_string()))?;
-            persister.save(json).await
-        }
-    }
-
-    fn load(
-        &self,
-    ) -> impl std::future::Future<
-        Output = Result<
-            Box<dyn Iterator<Item = Self::SessionEvent> + Send>,
-            Self::InternalStorageError,
-        >,
-    > + Send {
-        let persister = self.callback_persister.clone();
-        async move {
-            let res = persister.load().await?;
-            let events: Vec<_> = res
-                .into_iter()
-                .map(|event| {
-                    SenderSessionEvent::from_json(event)
-                        .map_err(|e| ForeignError::InternalError(e.to_string()))
-                        .map(Into::into)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(Box::new(events.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
-        }
-    }
-
-    fn close(
-        &self,
-    ) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
-        let persister = self.callback_persister.clone();
-        async move { persister.close().await }
     }
 }


### PR DESCRIPTION
Implements #1529

One deviation from that spec is that I chose not to feature gate them behind `_test-utils`. That seems like unnecessary complexity which also deviates from the core rust library. Since we expose InMemoryPersister there for "production" I think it makes sense to expose that utility in the FFI surface too.

Implementation by Claude Opus 4.7

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
