### PR TITLE
Force linting scripts to align rust toolchain with latest nix shell and not latest nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,30 +45,30 @@ jobs:
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
-      - name: "Install nightly toolchain"
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+      - name: "Install nix"
+        uses: DeterminateSystems/determinate-nix-action@main
+      - name: "Use nix cache"
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: "Run linting check"
-        run: cd payjoin-ffi && bash contrib/lint.sh
+        run: cd payjoin-ffi && nix develop -c ./contrib/lint.sh
 
   Lint:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
-      - name: "Install nightly toolchain"
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+      - name: "Install nix"
+        uses: DeterminateSystems/determinate-nix-action@main
+      - name: "Use nix cache"
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: "Run code linting"
-        run: bash contrib/lint.sh
+        run: nix develop -c ./contrib/lint.sh
       - name: "Run documentation linting"
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --document-private-items
+        run: nix develop -c -- bash -c 'RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --document-private-items'
 
   Coverage:
     name: Code coverage


### PR DESCRIPTION
Closes #1521

I opted to keep the lint scripts instead of the `nix build .#checks.x86_64-linux.payjoin-workspace-clippy` suggestion in the issue since these scripts catch version isolation bugs better than an `--all-features- lint

~The second commit fixes a regression from #1531. I ACKed without thinking that the CI job did not acutally run an FFI CI job.~

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
