### PR TITLE
Revert "Add nixpkgs-unstable overlay and migrate CI workflows to nix flake"

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -28,7 +28,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Build and test
-        run: nix develop --command bash ./contrib/test.sh
+
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+
+      - name: "Build and test"
+        run: bash ./contrib/test.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,13 +19,32 @@ jobs:
   build-python-and-test:
     name: "Build and test python"
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: payjoin-ffi/python
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Build and test
-        run: nix develop .#python --command bash ./payjoin-ffi/python/contrib/test.sh
+
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install a specific version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.2"
+          enable-cache: true
+
+      - name: "Build and test"
+        run: bash ./contrib/test.sh

--- a/flake.lock
+++ b/flake.lock
@@ -66,22 +66,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1777425547,
-        "narHash": "sha256-d57AbflkNfZNoFaZDzssEq1RfPoM9dLtOGI2O+N/68Q=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ebc08544afa77957cc348ba72dc490ec73b87f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1778003029,
@@ -150,7 +134,6 @@
         "flake-utils": "flake-utils",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
         "rust-overlay": "rust-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -38,7 +37,6 @@
     {
       self,
       nixpkgs,
-      nixpkgs-unstable,
       flake-utils,
       rust-overlay,
       crane,
@@ -59,7 +57,6 @@
           overlays = [
             rust-overlay.overlays.default
             (final: prev: {
-              dart = nixpkgs-unstable.legacyPackages.${system}.dart;
               rustToolchains = {
                 msrv = prev.rust-bin.stable.${msrv-version}.default;
                 stable = prev.rust-bin.stable.latest.default;


### PR DESCRIPTION
Reverts payjoin/rust-payjoin#1531 as it introduced CI failures in the python checks which are blocking other unrelated PRs.