### PR TITLE
Cleanup python devshell CI testing environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,17 @@
                   "rustfmt"
                   "llvm-tools-preview"
                 ];
+                # Targets needed by payjoin-ffi/python/scripts/generate_bindings.sh
+                # so cargo can build per-arch artifacts under nix (rustup target add
+                # is a no-op against a nix-provided toolchain).
+                targets =
+                  pkgs.lib.optionals pkgs.stdenv.isDarwin [
+                    "aarch64-apple-darwin"
+                    "x86_64-apple-darwin"
+                  ]
+                  ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+                    "x86_64-unknown-linux-gnu"
+                  ];
               }
             )
             {
@@ -309,22 +320,27 @@
 
         pythonDevShell = pkgs.mkShell {
           name = "python-dev";
-          packages = [
-            pythonVenv
-            pkgs.uv
-            rustVersions.msrv
-          ]
-          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-            pkgs.pkg-config
-            pkgs.openssl
-            pkgs.clang
-          ];
+          packages =
+            with pkgs;
+            [
+              pythonVenv
+              uv
+              rustVersions.msrv
+              bzip2 # needed for some machines to have access to libzip at runtime
+            ]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkg-config
+              openssl
+              clang
+            ];
 
           env = {
             # Prevent uv from downloading Python or managing the venv itself, nix provides both;
             UV_NO_SYNC = "1";
             UV_PYTHON_DOWNLOADS = "never";
           };
+          BITCOIND_EXE = pkgs.lib.getExe' pkgs.bitcoind "bitcoind";
+          BITCOIND_SKIP_DOWNLOAD = 1;
 
           shellHook = ''
             # to avoid host/global Python path leaking into the Nix env

--- a/payjoin-ffi/python/scripts/generate_bindings.sh
+++ b/payjoin-ffi/python/scripts/generate_bindings.sh
@@ -17,6 +17,15 @@ fi
 
 uv run python --version
 
+# rustup target add is a no-op against a nix-provided toolchain
+# (no rustup home, targets baked into the nix derivation instead).
+ensure_target() {
+    if command -v rustup >/dev/null 2>&1 &&
+        rustup show active-toolchain >/dev/null 2>&1; then
+        rustup target add "$@"
+    fi
+}
+
 cd ../
 # This is a test script the actual release should not include the test utils feature
 cargo build --features _test-utils --profile dev
@@ -24,7 +33,7 @@ cargo run --features _test-utils --profile dev --bin uniffi-bindgen generate --l
 
 if [[ $OS == "Darwin" ]]; then
     echo "Generating native binaries..."
-    rustup target add aarch64-apple-darwin x86_64-apple-darwin
+    ensure_target aarch64-apple-darwin x86_64-apple-darwin
     # This is a test script the actual release should not include the test utils feature
     cargo build --profile dev --target aarch64-apple-darwin --features _test-utils &
     cargo build --profile dev --target x86_64-apple-darwin --features _test-utils &
@@ -37,7 +46,7 @@ if [[ $OS == "Darwin" ]]; then
 
 else
     echo "Generating native binaries..."
-    rustup target add x86_64-unknown-linux-gnu
+    ensure_target x86_64-unknown-linux-gnu
     # This is a test script the actual release should not include the test utils feature
     cargo build --profile dev --target x86_64-unknown-linux-gnu --features _test-utils
 


### PR DESCRIPTION
Supersedes #1538 

There were some regressions following
42859654a8905d374fd0621e3eef2a4b38128c80 that broke the python tests. We need to do a few things to fix it.
- Ensure that the runner has access to bzip2 at runtime
- Ensure that the bitcoind download is skipped and the nix version is used instead
- use the rustup target available in the nix flake at the job level and to skip rustup target add when inside of the dev shell

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
