### PR TITLE
Add v2 receiver fallback subcommand

### DIFF
--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -32,6 +32,13 @@ pub trait App: Send + Sync {
     async fn history(&self) -> Result<()>;
     #[cfg(feature = "v2")]
     async fn fallback_sender(&self, session_id: SessionId) -> Result<()>;
+    #[cfg(feature = "v2")]
+    async fn fallback_receiver(&self, session_id: SessionId) -> Result<()>;
+    /// Look up `session_id` in the sender then the receiver table and dispatch
+    /// to [`Self::fallback_sender`] or [`Self::fallback_receiver`] accordingly.
+    /// Errors if the id is not present in either table.
+    #[cfg(feature = "v2")]
+    async fn fallback(&self, session_id: SessionId) -> Result<()>;
 
     fn create_original_psbt(
         &self,

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -11,6 +11,8 @@ pub mod wallet;
 use crate::app::config::Config;
 use crate::app::wallet::BitcoindWallet;
 #[cfg(feature = "v2")]
+use crate::cli::SessionRef;
+#[cfg(feature = "v2")]
 use crate::db::v2::SessionId;
 
 #[cfg(feature = "v1")]
@@ -34,11 +36,12 @@ pub trait App: Send + Sync {
     async fn fallback_sender(&self, session_id: SessionId) -> Result<()>;
     #[cfg(feature = "v2")]
     async fn fallback_receiver(&self, session_id: SessionId) -> Result<()>;
-    /// Look up `session_id` in the sender then the receiver table and dispatch
-    /// to [`Self::fallback_sender`] or [`Self::fallback_receiver`] accordingly.
-    /// Errors if the id is not present in either table.
+    /// Dispatch `session_ref` to [`Self::fallback_sender`] or
+    /// [`Self::fallback_receiver`] based on the prefix the operator
+    /// supplied. The prefix is authoritative; we do not consult either
+    /// table to guess sides.
     #[cfg(feature = "v2")]
-    async fn fallback(&self, session_id: SessionId) -> Result<()>;
+    async fn fallback(&self, session_ref: SessionRef) -> Result<()>;
 
     fn create_original_psbt(
         &self,

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -132,6 +132,16 @@ impl AppTrait for App {
     async fn fallback_sender(&self, _session_id: crate::db::v2::SessionId) -> Result<()> {
         anyhow::bail!("fallback is only supported for v2 (BIP77) sessions")
     }
+
+    #[cfg(feature = "v2")]
+    async fn fallback_receiver(&self, _session_id: crate::db::v2::SessionId) -> Result<()> {
+        anyhow::bail!("fallback is only supported for v2 (BIP77) sessions")
+    }
+
+    #[cfg(feature = "v2")]
+    async fn fallback(&self, _session_id: crate::db::v2::SessionId) -> Result<()> {
+        anyhow::bail!("fallback is only supported for v2 (BIP77) sessions")
+    }
 }
 
 impl App {

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -139,7 +139,7 @@ impl AppTrait for App {
     }
 
     #[cfg(feature = "v2")]
-    async fn fallback(&self, _session_id: crate::db::v2::SessionId) -> Result<()> {
+    async fn fallback(&self, _session_ref: crate::cli::SessionRef) -> Result<()> {
         anyhow::bail!("fallback is only supported for v2 (BIP77) sessions")
     }
 }

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -9,8 +9,8 @@ use payjoin::receive::v2::{
     replay_event_log as replay_receiver_event_log, HasReplyableError, Initialized,
     MaybeInputsOwned, MaybeInputsSeen, Monitor, OutputsUnknown, PayjoinProposal,
     ProvisionalProposal, ReceiveSession, Receiver, ReceiverBuilder,
-    SessionOutcome as ReceiverSessionOutcome, UncheckedOriginalPayload, WantsFeeRange, WantsInputs,
-    WantsOutputs,
+    SessionEvent as ReceiverSessionEvent, SessionOutcome as ReceiverSessionOutcome,
+    UncheckedOriginalPayload, WantsFeeRange, WantsInputs, WantsOutputs,
 };
 use payjoin::send::v2::{
     replay_event_log as replay_sender_event_log, PollingForProposal, SendSession, Sender,
@@ -508,6 +508,63 @@ impl AppTrait for App {
             tracing::warn!("Failed to close session {session_id} after fallback: {e}");
         }
         Ok(())
+    }
+
+    async fn fallback_receiver(&self, session_id: SessionId) -> Result<()> {
+        let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
+        let (session, history) = replay_receiver_event_log(&persister)?;
+
+        if let ReceiveSession::Closed(outcome) = &session {
+            match outcome {
+                ReceiverSessionOutcome::Success(_)
+                | ReceiverSessionOutcome::PayjoinProposalSent => {
+                    println!(
+                        "Session {session_id} already produced a payjoin proposal. \
+                         Broadcasting the original now would double-spend against it."
+                    );
+                    return Ok(());
+                }
+                ReceiverSessionOutcome::FallbackBroadcasted => {
+                    println!("Session {session_id} already broadcast the fallback transaction.");
+                    return Ok(());
+                }
+                ReceiverSessionOutcome::Failure | ReceiverSessionOutcome::Cancel => {
+                    // Continue to broadcast if a fallback tx is recorded.
+                }
+            }
+        }
+
+        let fallback_tx = history.fallback_tx().ok_or_else(|| {
+            anyhow!(
+                "Session {session_id} has no fallback transaction recorded. \
+                 The sender has not yet posted an Original PSBT to broadcast."
+            )
+        })?;
+        self.wallet().broadcast_tx(&fallback_tx)?;
+        println!("Broadcasted fallback transaction txid: {}", fallback_tx.compute_txid());
+
+        if let Err(e) = persister
+            .save_event(ReceiverSessionEvent::Closed(ReceiverSessionOutcome::FallbackBroadcasted))
+        {
+            tracing::warn!("Failed to record fallback broadcast for session {session_id}: {e}");
+        }
+        if let Err(e) = SessionPersister::close(&persister) {
+            tracing::warn!("Failed to close session {session_id} after fallback: {e}");
+        }
+        Ok(())
+    }
+
+    async fn fallback(&self, session_id: SessionId) -> Result<()> {
+        if self.db.has_send_session(&session_id)? {
+            return self.fallback_sender(session_id).await;
+        }
+        if self.db.has_recv_session(&session_id)? {
+            return self.fallback_receiver(session_id).await;
+        }
+        anyhow::bail!(
+            "No payjoin session with id {session_id} found. Run \
+             `payjoin-cli history` to list known session ids."
+        )
     }
 }
 

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -24,6 +24,7 @@ use super::wallet::BitcoindWallet;
 use super::App as AppTrait;
 use crate::app::v2::ohttp::{unwrap_ohttp_keys_or_else_fetch, RelayManager};
 use crate::app::{handle_interrupt, http_agent};
+use crate::cli::SessionRef;
 use crate::db::v2::{ReceiverPersister, SenderPersister, SessionId};
 use crate::db::Database;
 
@@ -119,10 +120,14 @@ struct SessionHistoryRow<Status> {
 
 impl<Status: StatusText> fmt::Display for SessionHistoryRow<Status> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let session_ref = match self.role {
+            Role::Sender => SessionRef::Send(self.session_id.clone()),
+            Role::Receiver => SessionRef::Recv(self.session_id.clone()),
+        };
         write!(
             f,
             "{:<W_ID$} {:<W_ROLE$} {:<W_DONE$} {:<W_STATUS$}",
-            self.session_id.to_string(),
+            session_ref.to_string(),
             self.role.as_str(),
             match self.completed_at {
                 None => "Not Completed".to_string(),
@@ -255,14 +260,14 @@ impl AppTrait for App {
                         match res {
                             Ok(()) => return Ok(()),
                             Err(err) => {
-                                let id = persister.session_id();
+                                let id = SessionRef::Send(persister.session_id());
                                 println!("Session {id} failed. Run `payjoin-cli fallback {id}` to broadcast the original transaction.");
                                 return Err(err);
                             }
                         }
                     },
                     _ = interrupt.changed() => {
-                        let id = persister.session_id();
+                        let id = SessionRef::Send(persister.session_id());
                         println!(
                             "Session {id} interrupted. Call `send` again to resume, `resume` to resume all sessions, or `payjoin-cli fallback {id}` to broadcast the original transaction."
                         );
@@ -322,7 +327,10 @@ impl AppTrait for App {
                 }
                 Err(e) => {
                     tracing::error!("An error {:?} occurred while replaying receiver session", e);
-                    Self::close_failed_session(&recv_persister, &session_id, "receiver");
+                    Self::close_failed_session(
+                        &recv_persister,
+                        &SessionRef::Recv(session_id.clone()),
+                    );
                 }
             }
         }
@@ -339,7 +347,10 @@ impl AppTrait for App {
                 }
                 Err(e) => {
                     tracing::error!("An error {:?} occurred while replaying Sender session", e);
-                    Self::close_failed_session(&sender_persister, &session_id, "sender");
+                    Self::close_failed_session(
+                        &sender_persister,
+                        &SessionRef::Send(session_id.clone()),
+                    );
                 }
             }
         }
@@ -487,11 +498,12 @@ impl AppTrait for App {
     async fn fallback_sender(&self, session_id: SessionId) -> Result<()> {
         let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
         let (session, history) = replay_sender_event_log(&persister)?;
+        let session_ref = SessionRef::Send(session_id);
 
         if let SendSession::Closed(SenderSessionOutcome::Success(proposal)) = session {
             let txid = proposal.clone().extract_tx_unchecked_fee_rate().compute_txid();
             println!(
-                "Session {session_id} already produced payjoin transaction {txid}. \
+                "Session {session_ref} already produced payjoin transaction {txid}. \
                  Broadcasting the original now would double-spend against it. \
                  If the payjoin tx needs re-broadcast, run \
                  `bitcoin-cli gettransaction {txid}` to fetch the hex, then \
@@ -505,7 +517,7 @@ impl AppTrait for App {
         println!("Broadcasted fallback transaction txid: {}", fallback_tx.compute_txid());
 
         if let Err(e) = SessionPersister::close(&persister) {
-            tracing::warn!("Failed to close session {session_id} after fallback: {e}");
+            tracing::warn!("Failed to close session {session_ref} after fallback: {e}");
         }
         Ok(())
     }
@@ -513,19 +525,20 @@ impl AppTrait for App {
     async fn fallback_receiver(&self, session_id: SessionId) -> Result<()> {
         let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
         let (session, history) = replay_receiver_event_log(&persister)?;
+        let session_ref = SessionRef::Recv(session_id);
 
         if let ReceiveSession::Closed(outcome) = &session {
             match outcome {
                 ReceiverSessionOutcome::Success(_)
                 | ReceiverSessionOutcome::PayjoinProposalSent => {
                     println!(
-                        "Session {session_id} already produced a payjoin proposal. \
+                        "Session {session_ref} already produced a payjoin proposal. \
                          Broadcasting the original now would double-spend against it."
                     );
                     return Ok(());
                 }
                 ReceiverSessionOutcome::FallbackBroadcasted => {
-                    println!("Session {session_id} already broadcast the fallback transaction.");
+                    println!("Session {session_ref} already broadcast the fallback transaction.");
                     return Ok(());
                 }
                 ReceiverSessionOutcome::Failure | ReceiverSessionOutcome::Cancel => {
@@ -536,7 +549,7 @@ impl AppTrait for App {
 
         let fallback_tx = history.fallback_tx().ok_or_else(|| {
             anyhow!(
-                "Session {session_id} has no fallback transaction recorded. \
+                "Session {session_ref} has no fallback transaction recorded. \
                  The sender has not yet posted an Original PSBT to broadcast."
             )
         })?;
@@ -546,37 +559,31 @@ impl AppTrait for App {
         if let Err(e) = persister
             .save_event(ReceiverSessionEvent::Closed(ReceiverSessionOutcome::FallbackBroadcasted))
         {
-            tracing::warn!("Failed to record fallback broadcast for session {session_id}: {e}");
+            tracing::warn!("Failed to record fallback broadcast for session {session_ref}: {e}");
         }
         if let Err(e) = SessionPersister::close(&persister) {
-            tracing::warn!("Failed to close session {session_id} after fallback: {e}");
+            tracing::warn!("Failed to close session {session_ref} after fallback: {e}");
         }
         Ok(())
     }
 
-    async fn fallback(&self, session_id: SessionId) -> Result<()> {
-        if self.db.has_send_session(&session_id)? {
-            return self.fallback_sender(session_id).await;
+    async fn fallback(&self, session_ref: SessionRef) -> Result<()> {
+        match session_ref {
+            SessionRef::Send(id) => self.fallback_sender(id).await,
+            SessionRef::Recv(id) => self.fallback_receiver(id).await,
         }
-        if self.db.has_recv_session(&session_id)? {
-            return self.fallback_receiver(session_id).await;
-        }
-        anyhow::bail!(
-            "No payjoin session with id {session_id} found. Run \
-             `payjoin-cli history` to list known session ids."
-        )
     }
 }
 
 impl App {
-    fn close_failed_session<P>(persister: &P, session_id: &SessionId, role: &str)
+    fn close_failed_session<P>(persister: &P, session_ref: &SessionRef)
     where
         P: SessionPersister,
     {
         if let Err(close_err) = SessionPersister::close(persister) {
-            tracing::error!("Failed to close {} session {}: {:?}", role, session_id, close_err);
+            tracing::error!("Failed to close session {session_ref}: {close_err:?}");
         } else {
-            tracing::error!("Closed failed {} session: {}", role, session_id);
+            tracing::error!("Closed failed session {session_ref}");
         }
     }
 
@@ -596,7 +603,7 @@ impl App {
             }
             SendSession::Closed(SenderSessionOutcome::Failure)
             | SendSession::Closed(SenderSessionOutcome::Cancel) => {
-                let id = persister.session_id();
+                let id = SessionRef::Send(persister.session_id());
                 println!(
                     "Session {id} ended without payjoin. Run `payjoin-cli fallback {id}` to broadcast the original transaction."
                 );

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -6,6 +6,11 @@ use payjoin::bitcoin::{Amount, FeeRate};
 use payjoin::Url;
 use serde::Deserialize;
 
+#[cfg(feature = "v2")]
+pub(crate) mod session_ref;
+#[cfg(feature = "v2")]
+pub(crate) use session_ref::{parse_session_ref, SessionRef};
+
 #[derive(Debug, Clone, Deserialize, Parser)]
 pub struct Flags {
     #[arg(long = "bip77", help = "Use BIP77 (v2) protocol (default)", action = clap::ArgAction::SetTrue)]
@@ -136,9 +141,12 @@ pub enum Commands {
     #[cfg(feature = "v2")]
     /// Broadcast the original transaction for a sender or receiver session (BIP77/v2 only)
     Fallback {
-        /// The session ID to broadcast the fallback transaction for
-        #[arg(required = true)]
-        session_id: i64,
+        /// The session ref to broadcast the fallback transaction for, prefixed
+        /// with `s` for a sender session or `r` for a receiver session
+        /// (e.g. `s1`, `r2`). Sender and receiver session ids auto-increment
+        /// independently, so the prefix is required to disambiguate them.
+        #[arg(required = true, value_parser = parse_session_ref)]
+        session_ref: SessionRef,
     },
 }
 

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -134,7 +134,7 @@ pub enum Commands {
     /// Show payjoin session history
     History,
     #[cfg(feature = "v2")]
-    /// Broadcast the original transaction for a sender session (BIP77/v2 only)
+    /// Broadcast the original transaction for a sender or receiver session (BIP77/v2 only)
     Fallback {
         /// The session ID to broadcast the fallback transaction for
         #[arg(required = true)]

--- a/payjoin-cli/src/cli/session_ref.rs
+++ b/payjoin-cli/src/cli/session_ref.rs
@@ -1,0 +1,175 @@
+use std::fmt;
+use std::str::FromStr;
+
+use crate::db::v2::SessionId;
+
+/// A side-prefixed reference to a v2 session, as accepted by the
+/// `payjoin-cli fallback` subcommand.
+///
+/// Sender and receiver session ids are auto-incremented per table, so a
+/// bare numeric id can collide between the two tables. The `s` / `r`
+/// prefix tells the dispatcher which side the operator means without a
+/// table-existence guess.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionRef {
+    Send(SessionId),
+    Recv(SessionId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionRefParseError {
+    Empty,
+    MissingSide,
+    UnknownSide(char),
+    MissingNumber,
+    InvalidNumber(String),
+}
+
+impl fmt::Display for SessionRefParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty =>
+                write!(f, "session ref must not be empty (expected `s<n>` or `r<n>`, e.g. `s1`, `r2`)"),
+            Self::MissingSide =>
+                write!(f, "session ref must start with `s` (sender) or `r` (receiver), e.g. `s1`, `r2`"),
+            Self::UnknownSide(c) => write!(
+                f,
+                "unknown session-ref prefix `{c}` (expected `s` for sender or `r` for receiver, e.g. `s1`, `r2`)"
+            ),
+            Self::MissingNumber =>
+                write!(f, "session ref `{{s|r}}` must be followed by a non-negative integer, e.g. `s1`, `r2`"),
+            Self::InvalidNumber(n) => write!(
+                f,
+                "invalid session number `{n}` (expected a non-negative integer, e.g. `s1`, `r2`)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SessionRefParseError {}
+
+impl FromStr for SessionRef {
+    type Err = SessionRefParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut chars = s.chars();
+        let prefix = chars.next().ok_or(SessionRefParseError::Empty)?;
+        let rest = chars.as_str();
+        match prefix {
+            's' => parse_id(rest).map(SessionRef::Send),
+            'r' => parse_id(rest).map(SessionRef::Recv),
+            '0'..='9' => Err(SessionRefParseError::MissingSide),
+            _ => Err(SessionRefParseError::UnknownSide(prefix)),
+        }
+    }
+}
+
+fn parse_id(rest: &str) -> Result<SessionId, SessionRefParseError> {
+    if rest.is_empty() {
+        return Err(SessionRefParseError::MissingNumber);
+    }
+    // Parse via u64 to reject negative numbers, leading whitespace, and
+    // a leading `+` -- the auto-increment storage produces only
+    // non-negative ids, so anything else is a typo.
+    let id: u64 =
+        rest.parse().map_err(|_| SessionRefParseError::InvalidNumber(rest.to_string()))?;
+    let id: i64 =
+        id.try_into().map_err(|_| SessionRefParseError::InvalidNumber(rest.to_string()))?;
+    Ok(SessionId(id))
+}
+
+impl fmt::Display for SessionRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SessionRef::Send(id) => write!(f, "s{id}"),
+            SessionRef::Recv(id) => write!(f, "r{id}"),
+        }
+    }
+}
+
+/// clap-friendly wrapper around [`SessionRef::from_str`] that surfaces
+/// the parse error as a `String` for the CLI value parser.
+pub(crate) fn parse_session_ref(s: &str) -> Result<SessionRef, String> {
+    s.parse::<SessionRef>().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_send_prefix() {
+        assert_eq!(SessionRef::from_str("s1").unwrap(), SessionRef::Send(SessionId(1)));
+        assert_eq!(SessionRef::from_str("s0").unwrap(), SessionRef::Send(SessionId(0)));
+        assert_eq!(
+            SessionRef::from_str("s9223372036854775807").unwrap(),
+            SessionRef::Send(SessionId(i64::MAX))
+        );
+    }
+
+    #[test]
+    fn parses_recv_prefix() {
+        assert_eq!(SessionRef::from_str("r42").unwrap(), SessionRef::Recv(SessionId(42)));
+        assert_eq!(SessionRef::from_str("r0").unwrap(), SessionRef::Recv(SessionId(0)));
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert_eq!(SessionRef::from_str(""), Err(SessionRefParseError::Empty));
+    }
+
+    #[test]
+    fn rejects_bare_numeric() {
+        assert_eq!(SessionRef::from_str("1"), Err(SessionRefParseError::MissingSide));
+        assert_eq!(SessionRef::from_str("42"), Err(SessionRefParseError::MissingSide));
+    }
+
+    #[test]
+    fn rejects_prefix_only() {
+        assert_eq!(SessionRef::from_str("s"), Err(SessionRefParseError::MissingNumber));
+        assert_eq!(SessionRef::from_str("r"), Err(SessionRefParseError::MissingNumber));
+    }
+
+    #[test]
+    fn rejects_unknown_prefix() {
+        assert_eq!(SessionRef::from_str("x1"), Err(SessionRefParseError::UnknownSide('x')));
+        assert_eq!(SessionRef::from_str("S1"), Err(SessionRefParseError::UnknownSide('S')));
+        assert_eq!(SessionRef::from_str("R1"), Err(SessionRefParseError::UnknownSide('R')));
+    }
+
+    #[test]
+    fn rejects_negative_number() {
+        assert_eq!(
+            SessionRef::from_str("s-1"),
+            Err(SessionRefParseError::InvalidNumber("-1".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_internal_whitespace() {
+        assert_eq!(
+            SessionRef::from_str("s 1"),
+            Err(SessionRefParseError::InvalidNumber(" 1".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_overflow() {
+        // i64::MAX + 1 expressed as a u64 fits in u64 but not i64.
+        assert_eq!(
+            SessionRef::from_str("s9223372036854775808"),
+            Err(SessionRefParseError::InvalidNumber("9223372036854775808".to_string()))
+        );
+    }
+
+    #[test]
+    fn display_round_trips() {
+        let send = SessionRef::Send(SessionId(7));
+        assert_eq!(send.to_string(), "s7");
+        assert_eq!(SessionRef::from_str(&send.to_string()).unwrap(), send);
+
+        let recv = SessionRef::Recv(SessionId(99));
+        assert_eq!(recv.to_string(), "r99");
+        assert_eq!(SessionRef::from_str(&recv.to_string()).unwrap(), recv);
+    }
+}

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -288,6 +288,26 @@ impl Database {
         }
         Ok(session_ids)
     }
+
+    pub(crate) fn has_send_session(&self, session_id: &SessionId) -> Result<bool> {
+        let conn = self.get_connection()?;
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM send_sessions WHERE session_id = ?1)",
+            params![session_id.0],
+            |row| row.get(0),
+        )?;
+        Ok(exists)
+    }
+
+    pub(crate) fn has_recv_session(&self, session_id: &SessionId) -> Result<bool> {
+        let conn = self.get_connection()?;
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM receive_sessions WHERE session_id = ?1)",
+            params![session_id.0],
+            |row| row.get(0),
+        )?;
+        Ok(exists)
+    }
 }
 
 #[cfg(all(test, feature = "v2"))]

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -8,7 +8,7 @@ use rusqlite::params;
 
 use super::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SessionId(pub(crate) i64);
 
 impl core::ops::Deref for SessionId {
@@ -287,26 +287,6 @@ impl Database {
             session_ids.push((session_id, completed_at));
         }
         Ok(session_ids)
-    }
-
-    pub(crate) fn has_send_session(&self, session_id: &SessionId) -> Result<bool> {
-        let conn = self.get_connection()?;
-        let exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM send_sessions WHERE session_id = ?1)",
-            params![session_id.0],
-            |row| row.get(0),
-        )?;
-        Ok(exists)
-    }
-
-    pub(crate) fn has_recv_session(&self, session_id: &SessionId) -> Result<bool> {
-        let conn = self.get_connection()?;
-        let exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM receive_sessions WHERE session_id = ?1)",
-            params![session_id.0],
-            |row| row.get(0),
-        )?;
-        Ok(exists)
     }
 }
 

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         }
         #[cfg(feature = "v2")]
         Commands::Fallback { session_id } => {
-            app.fallback_sender(SessionId(*session_id)).await?;
+            app.fallback(SessionId(*session_id)).await?;
         }
     };
 

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -6,9 +6,6 @@ use cli::{Cli, Commands};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
-#[cfg(feature = "v2")]
-use crate::db::v2::SessionId;
-
 mod app;
 mod cli;
 mod db;
@@ -79,8 +76,8 @@ async fn main() -> Result<()> {
             app.history().await?;
         }
         #[cfg(feature = "v2")]
-        Commands::Fallback { session_id } => {
-            app.fallback(SessionId(*session_id)).await?;
+        Commands::Fallback { session_ref } => {
+            app.fallback(session_ref.clone()).await?;
         }
     };
 

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -714,14 +714,15 @@ mod e2e {
 
             send_until_request_timeout(cli_sender).await?;
 
-            // There is only one sender session in progress.
-            let session_id = 1i64;
+            // There is only one sender session in progress; pass the
+            // sender-prefixed ref `s1` rather than a bare numeric id.
+            let session_ref = "s1";
             // Ensure the fallback was not broadcast yet
             let mempool_size =
                 sender.get_mempool_info().expect("should be able to get mempool").unbroadcast_count;
             assert_eq!(mempool_size, 0, "fallback should not be in mempool");
 
-            // Run `payjoin-cli fallback <session-id>` and assert broadcast
+            // Run `payjoin-cli fallback <session-ref>` and assert broadcast
             let mut cli_fallback = Command::new(payjoin_cli)
                 .arg("--root-certificate")
                 .arg(cert_path)
@@ -734,7 +735,7 @@ mod e2e {
                 .arg("--ohttp-relays")
                 .arg(ohttp_relay)
                 .arg("fallback")
-                .arg(session_id.to_string())
+                .arg(session_ref)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()
@@ -900,8 +901,9 @@ mod e2e {
                 .unbroadcast_count;
             assert_eq!(mempool_size, 0, "fallback should not be in mempool yet");
 
-            // The receiver session is the only one in the receiver DB.
-            let session_id = 1i64;
+            // The receiver session is the only one in the receiver DB; pass
+            // the receiver-prefixed ref `r1` rather than a bare numeric id.
+            let session_ref = "r1";
 
             let mut cli_fallback = Command::new(payjoin_cli)
                 .arg("--root-certificate")
@@ -915,7 +917,7 @@ mod e2e {
                 .arg("--ohttp-relays")
                 .arg(ohttp_relay)
                 .arg("fallback")
-                .arg(session_id.to_string())
+                .arg(session_ref)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -18,6 +18,13 @@ mod e2e {
         child.wait().await
     }
 
+    #[allow(dead_code)]
+    async fn force_kill(mut child: tokio::process::Child) -> tokio::io::Result<ExitStatus> {
+        let pid = child.id().expect("Failed to get child PID");
+        kill(Pid::from_raw(pid as i32), Signal::SIGKILL)?;
+        child.wait().await
+    }
+
     const RECEIVE_SATS: &str = "54321";
 
     /// Helper function to extract BIP21 URI from receiver stdout
@@ -751,6 +758,186 @@ mod e2e {
 
             assert!(
                 sender.get_raw_transaction(fallback_txid).is_ok(),
+                "fallback tx should be in the mempool"
+            );
+
+            Ok(())
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "v2")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn receiver_fallback_v2() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use payjoin_test_utils::{init_tracing, TestServices};
+        use tempfile::TempDir;
+
+        type Result<T> = std::result::Result<T, BoxError>;
+
+        init_tracing();
+        let mut services = TestServices::initialize().await?;
+        let temp_dir = tempdir()?;
+
+        let result = tokio::select! {
+            res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {res:?}").into()),
+            res = services.take_directory_handle() => Err(format!("Directory server is long running: {res:?}").into()),
+            res = receiver_fallback_cli_async(&services, &temp_dir) => res,
+        };
+
+        assert!(result.is_ok(), "receiver_fallback_v2 failed: {:#?}", result.unwrap_err());
+
+        async fn receiver_fallback_cli_async(
+            services: &TestServices,
+            temp_dir: &TempDir,
+        ) -> Result<()> {
+            let sender_db_path = temp_dir.path().join("sender_db");
+            let receiver_db_path = temp_dir.path().join("receiver_db");
+            let (bitcoind, _sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
+            let cert_path = &temp_dir.path().join("localhost.der");
+            tokio::fs::write(cert_path, services.cert()).await?;
+            services.wait_for_services_ready().await?;
+            let ohttp_keys = services.fetch_ohttp_keys().await?;
+            let ohttp_keys_path = temp_dir.path().join("ohttp_keys");
+            tokio::fs::write(&ohttp_keys_path, ohttp_keys.encode()?).await?;
+
+            let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
+            let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
+            let cookie_file = &bitcoind.params.cookie_file;
+            let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
+            let directory = &services.directory_url();
+            let ohttp_relay = &services.ohttp_relay_url();
+
+            // Start receiver to obtain a BIP21, then kill it; the session is in
+            // Initialized state with no original received yet.
+            let cli_receiver = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("receive")
+                .arg(RECEIVE_SATS)
+                .arg("--pj-directory")
+                .arg(directory)
+                .arg("--ohttp-keys")
+                .arg(&ohttp_keys_path)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli receiver");
+            let bip21 = get_bip21_from_receiver(cli_receiver).await;
+
+            // Start the sender so the Original PSBT lands in the directory mailbox,
+            // then interrupt; the sender session stays in PollingForProposal.
+            let cli_sender = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&sender_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&sender_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("send")
+                .arg(&bip21)
+                .arg("--fee-rate")
+                .arg("1")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli sender");
+            send_until_request_timeout(cli_sender).await?;
+
+            // Resume the receiver. It retrieves the Original PSBT, runs the
+            // broadcast-suitability check (which persists CheckedBroadcastSuitability
+            // and prints "Fallback transaction received."), then continues into the
+            // rest of the flow. We SIGKILL right after that line so the rest of the
+            // events stop persisting; the session retains a fallback tx accessible
+            // via SessionHistory::fallback_tx().
+            let mut cli_receive_resumer = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("resume")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli receiver resume");
+            let mut resume_stdout = cli_receive_resumer
+                .stdout
+                .take()
+                .expect("failed to take stdout of receiver resume");
+            let timeout = tokio::time::Duration::from_secs(20);
+            let received = tokio::time::timeout(
+                timeout,
+                wait_for_stdout_match(&mut resume_stdout, |l| {
+                    l.contains("Fallback transaction received")
+                }),
+            )
+            .await?;
+            assert!(received.is_some(), "receiver should retrieve the original PSBT");
+            force_kill(cli_receive_resumer).await.expect("Failed to SIGKILL receiver resume");
+
+            // Pre-broadcast sanity check: the original is not in the mempool yet.
+            let mempool_size = receiver
+                .get_mempool_info()
+                .expect("should be able to get mempool")
+                .unbroadcast_count;
+            assert_eq!(mempool_size, 0, "fallback should not be in mempool yet");
+
+            // The receiver session is the only one in the receiver DB.
+            let session_id = 1i64;
+
+            let mut cli_fallback = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("fallback")
+                .arg(session_id.to_string())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli fallback");
+
+            let mut fallback_stdout =
+                cli_fallback.stdout.take().expect("failed to take stdout of fallback");
+            let timeout = tokio::time::Duration::from_secs(10);
+            let broadcast_line = tokio::time::timeout(
+                timeout,
+                wait_for_stdout_match(&mut fallback_stdout, |l| {
+                    l.contains("Broadcasted fallback transaction txid")
+                }),
+            )
+            .await?;
+            terminate(cli_fallback).await.expect("Failed to kill payjoin-cli fallback");
+            let subcommand_output = broadcast_line.expect("fallback should broadcast");
+            let fallback_txid = subcommand_output.split_whitespace().nth(4).unwrap_or("");
+            let fallback_txid = Txid::from_str(fallback_txid).expect("valid txid");
+
+            assert!(
+                receiver.get_raw_transaction(fallback_txid).is_ok(),
                 "fallback tx should be in the mempool"
             );
 

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -352,6 +352,22 @@ impl<S: State> Receiver<S> {
         let fallback = self.state.fallback_tx();
         TerminalTransition::new(SessionEvent::Closed(SessionOutcome::Cancel), fallback)
     }
+
+    /// Close the Payjoin session and record that the fallback transaction was broadcast.
+    ///
+    /// Returns a [`TerminalTransition`] that, once persisted, yields the fallback
+    /// transaction when one is available for the current state. Callers are
+    /// responsible for actually broadcasting the returned transaction; this method
+    /// only updates the persisted session log so the outcome reflects that the
+    /// receiver has fallen back to broadcasting the sender's original transaction.
+    ///
+    /// This is a terminal transition — the session cannot be used after this call.
+    pub fn broadcast_fallback(
+        self,
+    ) -> TerminalTransition<SessionEvent, Option<bitcoin::Transaction>> {
+        let fallback = self.state.fallback_tx();
+        TerminalTransition::new(SessionEvent::Closed(SessionOutcome::FallbackBroadcasted), fallback)
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Mirrors the sender-side fallback that shipped in PR #1510. The existing `Fallback`
subcommand now dispatches to either sender or receiver flow. Session ids on the CLI
take an explicit side prefix (`s<n>` for send, `r<n>` for receive) — bare numeric
input is rejected to prevent silent mis-routing when both tables hold the same
auto-incremented id.

The library gains `Receiver<S: State>::broadcast_fallback()`, a terminal transition
that mirrors `Receiver::cancel()` but records `SessionOutcome::FallbackBroadcasted`
instead of `Cancel`, returning the fallback transaction so the caller can broadcast
it.

The `App` trait gains `fallback(SessionRef)` as the unified entry point that parses
the prefix and routes; `fallback_sender` and `fallback_receiver` stay as direct entry
points.

Receivers want a way to recover funds when a v2 payjoin session gets stuck after the
sender has posted but before the receiver can finalize and post a proposal. Without
this command, operators have no programmatic path from a stuck session to a broadcast
original.

## Notes for reviewers
- Receiver-side `SessionId` typing follows when `fallback-sender-session-id` merges
(this branch ships with `i64` to match current master).
- The new e2e `receiver_fallback_v2` was structurally checked but unverified at
runtime in the agent sandbox: existing baseline tests `sender_fallback_v2` and
`send_receive_payjoin_v2` fail identically on master in that environment due to
in-process OHTTP relay 403s. CI should confirm.
- Auto-broadcast on session expiry was prototyped and dropped — receiver fallback is
manual-only, consistent with v2's interactive spirit.
Disclosure: co-authored by Claude Opus 4.7