### PR TITLE
WIP - sender fallback method

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -56,6 +56,7 @@ impl StatusText for SendSession {
                 SenderSessionOutcome::Failure => "Session failure",
                 SenderSessionOutcome::Success(_) => "Session success",
                 SenderSessionOutcome::Cancel => "Session cancelled",
+                SenderSessionOutcome::FallbackBroadcasted => "Fallback broadcasted",
             },
         }
     }
@@ -486,26 +487,32 @@ impl AppTrait for App {
 
     async fn fallback_sender(&self, session_id: SessionId) -> Result<()> {
         let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
-        let (session, history) = replay_sender_event_log(&persister)?;
+        let (session, _) = replay_sender_event_log(&persister)?;
+        let broadcast = |tx: &payjoin::bitcoin::Transaction| {
+            let txid = tx.compute_txid();
+            println!("Broadcasted fallback transaction txid: {txid}");
+            self.wallet().broadcast_tx(tx).unwrap();
+        };
 
-        if let SendSession::Closed(SenderSessionOutcome::Success(proposal)) = session {
-            let txid = proposal.clone().extract_tx_unchecked_fee_rate().compute_txid();
-            println!(
-                "Session {session_id} already produced payjoin transaction {txid}. \
+        match session {
+            SendSession::WithReplyKey(sender) => {
+                sender.fallback(broadcast).save(&persister)?;
+            }
+            SendSession::PollingForProposal(sender) => {
+                sender.fallback(broadcast).save(&persister)?;
+            }
+            SendSession::Closed(SenderSessionOutcome::Success(proposal)) => {
+                let txid = proposal.clone().extract_tx_unchecked_fee_rate().compute_txid();
+                println!(
+                    "Session {session_id} already produced payjoin transaction {txid}. \
                  Broadcasting the original now would double-spend against it. \
                  If the payjoin tx needs re-broadcast, run \
                  `bitcoin-cli gettransaction {txid}` to fetch the hex, then \
                  `bitcoin-cli sendrawtransaction <hex>`."
-            );
-            return Ok(());
-        }
-
-        let fallback_tx = history.fallback_tx();
-        self.wallet().broadcast_tx(&fallback_tx)?;
-        println!("Broadcasted fallback transaction txid: {}", fallback_tx.compute_txid());
-
-        if let Err(e) = SessionPersister::close(&persister) {
-            tracing::warn!("Failed to close session {session_id} after fallback: {e}");
+                );
+                return Ok(());
+            }
+            _ => return Err(anyhow!("TODO")),
         }
         Ok(())
     }
@@ -543,6 +550,11 @@ impl App {
                 println!(
                     "Session {id} ended without payjoin. Run `payjoin-cli fallback {id}` to broadcast the original transaction."
                 );
+                return Ok(());
+            }
+            SendSession::Closed(SenderSessionOutcome::FallbackBroadcasted) => {
+                let id = persister.session_id();
+                println!("Session {id} ended with fallback broadcasted.");
                 return Ok(());
             }
         }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -352,6 +352,16 @@ impl<S: State> Receiver<S> {
         let fallback = self.state.fallback_tx();
         TerminalTransition::new(SessionEvent::Closed(SessionOutcome::Cancel), fallback)
     }
+
+    pub fn fallback(
+        self,
+        broadcast: impl Fn(&bitcoin::Transaction) -> (),
+    ) -> TerminalTransition<SessionEvent, bitcoin::Txid> {
+        let fallback_tx = self.state.fallback_tx().unwrap();
+        broadcast(&fallback_tx);
+        let txid = fallback_tx.compute_txid();
+        TerminalTransition::new(SessionEvent::Closed(SessionOutcome::FallbackBroadcasted), txid)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -258,6 +258,17 @@ impl<S: State> Sender<S> {
             self.session_context.psbt_ctx.original_psbt.clone().extract_tx_unchecked_fee_rate();
         TerminalTransition::new(SessionEvent::Closed(SessionOutcome::Cancel), fallback)
     }
+
+    pub fn fallback(
+        self,
+        broadcast: impl Fn(&bitcoin::Transaction) -> (),
+    ) -> TerminalTransition<SessionEvent, bitcoin::Txid> {
+        let fallback_tx =
+            self.session_context.psbt_ctx.original_psbt.clone().extract_tx_unchecked_fee_rate();
+        let txid = fallback_tx.compute_txid();
+        broadcast(&fallback_tx);
+        TerminalTransition::new(SessionEvent::Closed(SessionOutcome::FallbackBroadcasted), txid)
+    }
 }
 
 /// Represents the various states of a Payjoin send session during the protocol flow.

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -131,6 +131,7 @@ impl SessionHistory {
             Some(SessionEvent::Closed(outcome)) => match outcome {
                 SessionOutcome::Success(_) => SessionStatus::Completed,
                 SessionOutcome::Failure | SessionOutcome::Cancel => SessionStatus::Failed,
+                SessionOutcome::FallbackBroadcasted => SessionStatus::FallbackBroadcasted,
             },
             _ => SessionStatus::Active,
         }
@@ -145,6 +146,7 @@ pub enum SessionStatus {
     Active,
     Failed,
     Completed,
+    FallbackBroadcasted,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -166,6 +168,8 @@ pub enum SessionOutcome {
     Failure,
     /// Payjoin was cancelled by the user
     Cancel,
+    /// Fallback transaction was broadcasted
+    FallbackBroadcasted,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
POC an alternative to manually pushing fallback related events to the persistence layer. spawned from a dicsussion on https://github.com/payjoin/rust-payjoin/pull/1542#discussion_r3208776020.

I hate the giant match statement. For the recv it will be even more boilerplate. And if we go this route we will probably need an async version `fallback()` 


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
