### PR TITLE
refactor(cli): simplify bip cli args

### DIFF
--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -5,8 +5,8 @@
 `payjoin-cli` is the reference implementation for the payjoin protocol, written using the [Payjoin Dev Kit](https://payjoindevkit.org).
 
 It enables sending and receiving [BIP 78 Payjoin
-(v1)](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and [Draft
-BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
+(v1)](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) and
+[BIP 77 Async Payjoin (v2)](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
 transactions via `bitcoind`. By default it supports Payjoin v2, which is
 backwards compatible with v1. Enable the `v1` feature to disable Payjoin v2 to
 send and receive using only v1.

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -69,12 +69,12 @@ impl Config {
         let mut selected_version = None;
 
         // Check for BIP77 (v2)
-        if cli.flags.bip77.unwrap_or(false) {
+        if cli.flags.bip77 {
             selected_version = Some(Version::Two);
         }
 
         // Check for BIP78 (v1)
-        if cli.flags.bip78.unwrap_or(false) {
+        if cli.flags.bip78 {
             if selected_version.is_some() {
                 return Err(ConfigError::Message(
                     "Multiple version flags specified. Please use only one of: --bip77, --bip78"

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -12,7 +12,6 @@ use payjoin::bitcoin::{
 };
 use payjoin::receive::InputPair;
 
-/// Implementation of PayjoinWallet for bitcoind using async RPC client
 #[derive(Clone)]
 pub struct BitcoindWallet {
     rpc: Arc<AsyncBitcoinRpc>,

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -4,14 +4,13 @@ use clap::{value_parser, Parser, Subcommand};
 use payjoin::bitcoin::amount::ParseAmountError;
 use payjoin::bitcoin::{Amount, FeeRate};
 use payjoin::Url;
-use serde::Deserialize;
 
-#[derive(Debug, Clone, Deserialize, Parser)]
+#[derive(Debug, Parser)]
 pub struct Flags {
-    #[arg(long = "bip77", help = "Use BIP77 (v2) protocol (default)", action = clap::ArgAction::SetTrue)]
-    pub bip77: Option<bool>,
-    #[arg(long = "bip78", help = "Use BIP78 (v1) protocol", action = clap::ArgAction::SetTrue)]
-    pub bip78: Option<bool>,
+    #[arg(long, help = "Use BIP77 (v2) protocol (default)")]
+    pub bip77: bool,
+    #[arg(long, help = "Use BIP78 (v1) protocol")]
+    pub bip78: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     let config = Config::new(&cli)?;
 
     #[allow(clippy::if_same_then_else)]
-    let app: Box<dyn AppTrait> = if cli.flags.bip78.unwrap_or(false) {
+    let app: Box<dyn AppTrait> = if cli.flags.bip78 {
         #[cfg(feature = "v1")]
         {
             Box::new(crate::app::v1::App::new(config).await?)
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
                 "BIP78 (v1) support is not enabled in this build. Recompile with --features v1"
             )
         }
-    } else if cli.flags.bip77.unwrap_or(false) {
+    } else if cli.flags.bip77 {
         #[cfg(feature = "v2")]
         {
             Box::new(crate::app::v2::App::new(config).await?)


### PR DESCRIPTION
Closes #1530

Simplify `--bip77`/`--bip78` args, drop redundant clap attributes.
The cli api didn't change, just internal refactoring.

I used Claude Code for research, but wrote all changes manually.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have disclosed my use of [AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
