### PR TITLE
Remove sender sigs from receiver psbt_to_sign

### DIFF
--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -312,6 +312,23 @@ impl PsbtContext {
         sender_input_indexes
     }
 
+    /// Returns payjoin proposal PSBT to be signed
+    ///
+    /// Removes all sender signatures which are received with the original PSBT
+    /// as these signatures are now invalid
+    fn psbt_to_sign(&self) -> Psbt {
+        let mut psbt = self.payjoin_psbt.clone();
+        // Remove now-invalid sender signatures before applying the receiver signatures
+        for i in self.sender_input_indexes() {
+            tracing::trace!("Clearing sender input {i}");
+            psbt.inputs[i].final_script_sig = None;
+            psbt.inputs[i].final_script_witness = None;
+            psbt.inputs[i].tap_key_sig = None;
+        }
+
+        psbt
+    }
+
     /// Finalizes the Payjoin proposal into a PSBT which the sender will find acceptable before
     /// they sign the transaction and broadcast it to the network.
     ///
@@ -322,23 +339,16 @@ impl PsbtContext {
         self,
         wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, ImplementationError>,
     ) -> Result<Psbt, ImplementationError> {
-        let mut psbt = self.payjoin_psbt.clone();
-        // Remove now-invalid sender signatures before applying the receiver signatures
-        for i in self.sender_input_indexes() {
-            tracing::trace!("Clearing sender input {i}");
-            psbt.inputs[i].final_script_sig = None;
-            psbt.inputs[i].final_script_witness = None;
-            psbt.inputs[i].tap_key_sig = None;
-        }
-        let finalized_psbt = wallet_process_psbt(&psbt)?;
+        let psbt = self.psbt_to_sign();
+        let signed_psbt = wallet_process_psbt(&psbt)?;
         let expected_ntxid = self.payjoin_psbt.unsigned_tx.compute_ntxid();
-        let actual_ntxid = finalized_psbt.unsigned_tx.compute_ntxid();
+        let actual_ntxid = signed_psbt.unsigned_tx.compute_ntxid();
         if expected_ntxid != actual_ntxid {
             return Err(ImplementationError::from(
                 format!("Ntxid mismatch: expected {expected_ntxid}, got {actual_ntxid}").as_str(),
             ));
         }
-        let payjoin_proposal = self.prepare_psbt(finalized_psbt);
+        let payjoin_proposal = self.prepare_psbt(signed_psbt);
         Ok(payjoin_proposal)
     }
 }

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -304,7 +304,7 @@ impl ProvisionalProposal {
     /// In some applications the entity that progresses the typestate
     /// is different from the entity that has access to the private keys,
     /// so the PSBT to sign must be accessible to such implementers.
-    pub fn psbt_to_sign(&self) -> Psbt { self.psbt_context.payjoin_psbt.clone() }
+    pub fn psbt_to_sign(&self) -> Psbt { self.psbt_context.psbt_to_sign() }
 }
 
 /// A finalized Payjoin proposal, complete with fees and receiver signatures, that the sender

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1124,7 +1124,7 @@ impl Receiver<ProvisionalProposal> {
     /// In some applications the entity that progresses the typestate
     /// is different from the entity that has access to the private keys,
     /// so the PSBT to sign must be accessible to such implementers.
-    pub fn psbt_to_sign(&self) -> Psbt { self.state.psbt_context.payjoin_psbt.clone() }
+    pub fn psbt_to_sign(&self) -> Psbt { self.state.psbt_context.psbt_to_sign() }
 
     pub(crate) fn apply_payjoin_proposal(self, payjoin_psbt: Psbt) -> ReceiveSession {
         let psbt_context = PsbtContext {


### PR DESCRIPTION
### Summary
Currently the `psbt_to_sign` helper function in the `ProvisionalProposal` typestate in v1 and v2 returns the provisional proposal without removing the outdated sender signature elements. Since the purpose of this helper function is to allow the caller to extract the PSBT for the payjoin proposal tx so that it can be signed outside of the state machine flow it makes sense to return a PSBT that has already stripped the outdated sender signature(s) rather than forcing the caller to do this themselves.

### Misc
This was suggested to be a separate PR that could probably get merged faster [here](https://github.com/payjoin/rust-payjoin/pull/1546#pullrequestreview-4293696224).

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
