### PR TITLE
Patch payjoin git URL in JS wasm manifest

### DIFF
--- a/payjoin-ffi/javascript/wasm-manifest-patch.toml
+++ b/payjoin-ffi/javascript/wasm-manifest-patch.toml
@@ -20,3 +20,6 @@ features = ["wasm-unstable-single-threaded"]
 payjoin = { path = "../../../../payjoin" }
 payjoin-mailroom = { path = "../../../../payjoin-mailroom" }
 payjoin-test-utils = { path = "../../../../payjoin-test-utils" }
+
+[patch."https://github.com/payjoin/rust-payjoin.git"]
+payjoin = { path = "../../../../payjoin" }


### PR DESCRIPTION
Fix to pickup local changes in JS bindings.