### PR TITLE
Correct FFI bindings monitor method name

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1422,7 +1422,10 @@ fn try_deserialize_tx(
 
 #[uniffi::export]
 impl Monitor {
-    pub fn monitor(&self, transaction_exists: Arc<dyn TransactionExists>) -> MonitorTransition {
+    pub fn check_payment(
+        &self,
+        transaction_exists: Arc<dyn TransactionExists>,
+    ) -> MonitorTransition {
         MonitorTransition(Arc::new(RwLock::new(Some(self.0.clone().check_payment(|txid| {
             transaction_exists
                 .callback(txid.to_string())


### PR DESCRIPTION
### Summary
Correct the payjoin FFI bindings `Monitor::monitor` method name to `Monitor::check_payment` as this:
- keeps it consistent with base payjoin package
- accurately reflects the purpose of the method

It was confirmed that this correction is needed [here](https://github.com/payjoin/rust-payjoin/issues/1548#issuecomment-4454880499).

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
