### PR TITLE
Dedup utxos locked method

### DIFF
--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -351,6 +351,17 @@ impl PsbtContext {
         let payjoin_proposal = self.prepare_psbt(signed_psbt);
         Ok(payjoin_proposal)
     }
+
+    fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
+        let sender_input_indexes = self.sender_input_indexes();
+        self.payjoin_psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .enumerate()
+            .filter(move |(i, _)| !sender_input_indexes.contains(i))
+            .map(|(_, input)| &input.previous_output)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -292,11 +292,14 @@ impl ProvisionalProposal {
         self,
         wallet_process_psbt: impl Fn(&Psbt) -> Result<Psbt, ImplementationError>,
     ) -> Result<PayjoinProposal, Error> {
+        let original_psbt = self.psbt_context.original_psbt.clone();
         let finalized_psbt = self
             .psbt_context
             .finalize_proposal(wallet_process_psbt)
             .map_err(|e| Error::Implementation(ImplementationError::new(e)))?;
-        Ok(PayjoinProposal { payjoin_psbt: finalized_psbt })
+        Ok(PayjoinProposal {
+            psbt_context: PsbtContext { payjoin_psbt: finalized_psbt, original_psbt },
+        })
     }
 
     /// The Payjoin proposal PSBT that the receiver needs to sign
@@ -311,17 +314,17 @@ impl ProvisionalProposal {
 /// should find acceptable.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PayjoinProposal {
-    payjoin_psbt: Psbt,
+    psbt_context: PsbtContext,
 }
 
 impl PayjoinProposal {
     /// The UTXOs that would be spent by this Payjoin transaction.
     pub fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
-        self.payjoin_psbt.unsigned_tx.input.iter().map(|input| &input.previous_output)
+        self.psbt_context.utxos_to_be_locked()
     }
 
     /// The Payjoin Proposal PSBT.
-    pub fn psbt(&self) -> &Psbt { &self.payjoin_psbt }
+    pub fn psbt(&self) -> &Psbt { &self.psbt_context.payjoin_psbt }
 }
 
 #[cfg(test)]
@@ -548,5 +551,22 @@ mod tests {
         };
         let psbt = provisional_proposal.psbt_to_sign();
         assert_eq!(psbt, PARSED_PAYJOIN_PROPOSAL.clone());
+    }
+
+    #[test]
+    fn test_utxos_to_be_locked() {
+        let provisional_proposal = ProvisionalProposal {
+            psbt_context: PsbtContext {
+                payjoin_psbt: PARSED_PAYJOIN_PROPOSAL.clone(),
+                original_psbt: PARSED_ORIGINAL_PSBT.clone(),
+            },
+        };
+        let finalized_proposal = provisional_proposal
+            .clone()
+            .finalize_proposal(|_| Ok(PARSED_PAYJOIN_PROPOSAL.clone()))
+            .unwrap();
+        let utxos = finalized_proposal.utxos_to_be_locked().collect::<Vec<_>>();
+        assert_eq!(utxos.len(), 1);
+        assert_eq!(*utxos[0], PARSED_PAYJOIN_PROPOSAL.unsigned_tx.input[1].previous_output);
     }
 }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1149,9 +1149,8 @@ pub struct PayjoinProposal {
 impl Receiver<PayjoinProposal> {
     /// The UTXOs that would be spent by this Payjoin transaction.
     pub fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
-        // TODO: de-duplicate this with the v1 implementation
         // It would make more sense if the payjoin proposal was only available after utxos are locked via session persister
-        self.psbt_context.payjoin_psbt.unsigned_tx.input.iter().map(|input| &input.previous_output)
+        self.psbt_context.utxos_to_be_locked()
     }
 
     /// The Payjoin Proposal PSBT.

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1149,7 +1149,7 @@ pub struct PayjoinProposal {
 impl Receiver<PayjoinProposal> {
     /// The UTXOs that would be spent by this Payjoin transaction.
     pub fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
-        // It would make more sense if the payjoin proposal was only available after utxos are locked via session persister
+        // TODO: It would make more sense if the payjoin proposal was only available after utxos are locked via session persister
         self.psbt_context.utxos_to_be_locked()
     }
 


### PR DESCRIPTION
Resolving this todo comment: `TODO: de-duplicate this with the v1 implementation` by moving `utxos_to_be_locked` to `PsbtContext`.
The bigger change is to filter out the sender inputs. If the prupose of this method is to inform the reciever what inputs they have to mark as "locked".

Not a fan of cloning the original PSBT. The only thing we need is sender input indecies.
In general, `PsbtContext` only needs a `vec<usize>` for the sender inputs (for other methods: `psbt_to_sign`).  The only place where we use the original tx is the in the v2 monitor typestate. This is where something like #1197 would be useful. 


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
