### PR TITLE
Remove reciever wordings from global ffi error type

### DIFF
--- a/payjoin-ffi/src/error.rs
+++ b/payjoin-ffi/src/error.rs
@@ -1,6 +1,6 @@
 use std::error;
 
-/// Error arising due to the specific receiver implementation
+/// Error arising due to the specific application implementation
 ///
 /// e.g. database errors, network failures, wallet errors
 #[derive(Debug, thiserror::Error, uniffi::Object)]


### PR DESCRIPTION
This error type can and is shared by the sender.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
