### PR TITLE
Nixify Javascript FFi tests

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -8,12 +8,6 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
-env:
-  # Override the value from the rust-toolchain file
-  # This is necessary because even though the correct toolchain
-  # is explicitly specified for the rust-toolchain action,
-  # rustup honors the rust-toolchain file over the default
-  RUSTUP_TOOLCHAIN: 1.85
 
 jobs:
   build-js-and-test:
@@ -29,22 +23,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.85.0
-        uses: dtolnay/rust-toolchain@1.85.0
-
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
 
-      - name: Install Node
-        uses: actions/setup-node@v6
+      - name: "Install nix"
+        uses: DeterminateSystems/determinate-nix-action@main
 
-      - name: Install llvm
-        if: matrix.os == 'macos-latest'
-        run: brew install llvm
-
-      # 0.2.109+ requires rustc 1.88 (via time crate).
-      - name: Install wasm-bindgen
-        run: cargo install --locked wasm-bindgen-cli --version 0.2.108
+      - name: "Use nix cache"
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: "Build and test"
-        run: bash ./contrib/test.sh
+        run: nix develop .#msrv -c ./contrib/test.sh

--- a/flake.nix
+++ b/flake.nix
@@ -89,17 +89,19 @@
                   "rustfmt"
                   "llvm-tools-preview"
                 ];
-                # Targets needed by payjoin-ffi/python/scripts/generate_bindings.sh
+                # Targets needed by payjoin-ffi/{python,javascript}/scripts/generate_bindings.sh
                 # so cargo can build per-arch artifacts under nix (rustup target add
                 # is a no-op against a nix-provided toolchain).
-                targets =
-                  pkgs.lib.optionals pkgs.stdenv.isDarwin [
-                    "aarch64-apple-darwin"
-                    "x86_64-apple-darwin"
-                  ]
-                  ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                    "x86_64-unknown-linux-gnu"
-                  ];
+                targets = [
+                  "wasm32-unknown-unknown"
+                ]
+                ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+                  "aarch64-apple-darwin"
+                  "x86_64-apple-darwin"
+                ]
+                ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+                  "x86_64-unknown-linux-gnu"
+                ];
               }
             )
             {
@@ -290,6 +292,14 @@
                 cargo-fuzz
                 bzip2 # needed for some machines to have access to libzip at runtime
                 codespell
+                # secp256k1-sys build.rs invokes cc-rs for the wasm32-unknown-unknown
+                # target; cc-rs defaults to clang for wasm and needs llvm-ar.
+                llvmPackages.clang-unwrapped
+                llvmPackages.bintools-unwrapped
+                lld
+                # Version must match the wasm-bindgen crate locked in
+                # payjoin-ffi/javascript/rust_modules/wasm/Cargo.lock.
+                wasm-bindgen-cli_0_2_108
               ]
               ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
                 cargo-llvm-cov
@@ -298,6 +308,8 @@
             BITCOIND_SKIP_DOWNLOAD = 1;
             DOTNET_ROOT = "${dotnetSdk}/share/dotnet";
             DOTNET_CLI_TELEMETRY_OPTOUT = "1";
+            CC_wasm32_unknown_unknown = "${pkgs.llvmPackages.clang-unwrapped}/bin/clang";
+            AR_wasm32_unknown_unknown = "${pkgs.llvmPackages.bintools-unwrapped}/bin/llvm-ar";
           }
         ) craneLibVersions;
 

--- a/payjoin-ffi/javascript/scripts/generate_bindings.sh
+++ b/payjoin-ffi/javascript/scripts/generate_bindings.sh
@@ -6,7 +6,7 @@ echo "Running on $OS"
 
 npm --version
 
-if [[ $OS == "Darwin" ]]; then
+if [[ $OS == "Darwin" && -z ${IN_NIX_SHELL:-} ]]; then
     # TODO: check if brew & llvm are installed
     LLVM_PREFIX=$(brew --prefix llvm)
     export AR="$LLVM_PREFIX/bin/llvm-ar"


### PR DESCRIPTION
`./payjoin-ffi/javascript/contrib/test.sh` was failing within the `nix develop .#msrv` dev shell.

The first commit fixes the failure itself and the second commit is a way for the workflow to ensure that it always runs and a step further in nixifying the CI.  Currently this still selects our current msrv to be locked at 1.85.0 but perhaps this is too strict and not really necessary for the users of the ffi bindings and maybe we should choose a higher fixed stable "ssrv"

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
