### PR TITLE
Nixify ffi CI

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -8,45 +8,54 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
-env:
-  RUSTUP_TOOLCHAIN: 1.85
 
 jobs:
-  build-csharp-and-test:
+  build-csharp-and-test-unix:
     name: "Build and test csharp"
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: payjoin-ffi/csharp
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+      - name: "Install nix"
+        uses: DeterminateSystems/determinate-nix-action@main
+      - name: "Use nix cache"
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: "Build and test"
+        run: nix develop .#csharp -c ./payjoin-ffi/csharp/contrib/test.sh
 
+  build-csharp-and-test-windows:
+    name: "Build and test csharp (windows)"
+    runs-on: windows-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.85
+    defaults:
+      run:
+        working-directory: payjoin-ffi/csharp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Rust 1.85.0
         uses: dtolnay/rust-toolchain@1.85.0
 
       - name: Use cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install .NET 8 SDK
+      - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Verify .NET SDK
         run: |
           dotnet --version
           dotnet --list-sdks
 
-      - name: Generate bindings and binaries (unix)
-        if: matrix.os != 'windows-latest'
-        run: bash ./scripts/generate_bindings.sh
-
-      - name: Generate bindings and binaries (windows)
-        if: matrix.os == 'windows-latest'
+      - name: Generate bindings and binaries
         shell: pwsh
         run: ./scripts/generate_bindings.ps1
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,27 +8,22 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
-env:
-  # Override the value from the rust-toolchain file
-  # This is necessary because even though the correct toolchain
-  # is explicitly specified for the rust-toolchain action,
-  # rustup honors the rust-toolchain file over the default
-  RUSTUP_TOOLCHAIN: 1.85
 
 jobs:
   build-dart-and-test:
     name: "Build and test dart"
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: payjoin-ffi/dart
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Build and test
-        run: nix develop --command bash ./contrib/test.sh
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+      - name: "Install nix"
+        uses: DeterminateSystems/determinate-nix-action@main
+      - name: "Use nix cache"
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: "Build and test"
+        run: nix develop .#dart -c bash ./payjoin-ffi/dart/contrib/test.sh

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -13,24 +13,17 @@ jobs:
   build-js-and-test:
     name: "Build and test javascript"
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: payjoin-ffi/javascript
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
-
       - name: "Install nix"
         uses: DeterminateSystems/determinate-nix-action@main
-
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: "Build and test"
-        run: nix develop .#msrv -c ./contrib/test.sh
+        run: nix develop .#javascript -c ./payjoin-ffi/javascript/contrib/test.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,12 +8,6 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
-env:
-  # Override the value from the rust-toolchain file
-  # This is necessary because even though the correct toolchain
-  # is explicitly specified for the rust-toolchain action,
-  # rustup honors the rust-toolchain file over the default
-  RUSTUP_TOOLCHAIN: 1.85
 
 jobs:
   build-python-and-test:
@@ -25,7 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Build and test
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+      - name: "Install nix"
+        uses: DeterminateSystems/determinate-nix-action@main
+      - name: "Use nix cache"
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: "Build and test"
         run: nix develop .#python --command bash ./payjoin-ffi/python/contrib/test.sh

--- a/flake.nix
+++ b/flake.nix
@@ -89,19 +89,6 @@
                   "rustfmt"
                   "llvm-tools-preview"
                 ];
-                # Targets needed by payjoin-ffi/{python,javascript}/scripts/generate_bindings.sh
-                # so cargo can build per-arch artifacts under nix (rustup target add
-                # is a no-op against a nix-provided toolchain).
-                targets = [
-                  "wasm32-unknown-unknown"
-                ]
-                ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-                  "aarch64-apple-darwin"
-                  "x86_64-apple-darwin"
-                ]
-                ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                  "x86_64-unknown-linux-gnu"
-                ];
               }
             )
             {
@@ -272,10 +259,7 @@
             "payjoin-mailroom-image" = mkContainerImage "payjoin-mailroom" packages.payjoin-mailroom tag;
           };
 
-        dotnetSdk = pkgs.dotnetCorePackages.combinePackages [
-          pkgs.dotnetCorePackages.sdk_10_0
-          pkgs.dotnetCorePackages.runtime_8_0
-        ];
+        dotnetSdk = pkgs.dotnetCorePackages.sdk_10_0;
 
         devShells = builtins.mapAttrs (
           _name: craneLib:
@@ -287,29 +271,15 @@
                 cargo-nextest
                 cargo-watch
                 rust-analyzer
-                dart
-                dotnetSdk
                 cargo-fuzz
                 bzip2 # needed for some machines to have access to libzip at runtime
                 codespell
-                # secp256k1-sys build.rs invokes cc-rs for the wasm32-unknown-unknown
-                # target; cc-rs defaults to clang for wasm and needs llvm-ar.
-                llvmPackages.clang-unwrapped
-                llvmPackages.bintools-unwrapped
-                lld
-                # Version must match the wasm-bindgen crate locked in
-                # payjoin-ffi/javascript/rust_modules/wasm/Cargo.lock.
-                wasm-bindgen-cli_0_2_108
               ]
               ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
                 cargo-llvm-cov
               ];
             BITCOIND_EXE = pkgs.lib.getExe' pkgs.bitcoind "bitcoind";
             BITCOIND_SKIP_DOWNLOAD = 1;
-            DOTNET_ROOT = "${dotnetSdk}/share/dotnet";
-            DOTNET_CLI_TELEMETRY_OPTOUT = "1";
-            CC_wasm32_unknown_unknown = "${pkgs.llvmPackages.clang-unwrapped}/bin/clang";
-            AR_wasm32_unknown_unknown = "${pkgs.llvmPackages.bintools-unwrapped}/bin/llvm-ar";
           }
         ) craneLibVersions;
 
@@ -338,6 +308,96 @@
           builtins.removeAttrs pythonWorkspace.deps.all [ "payjoin" ]
         );
 
+        # Rust toolchain for the javascript dev shell: msrv pinned to match
+        # payjoin-ffi/javascript build requirements, with wasm32 target added
+        # so cargo can build per-arch artifacts under nix (rustup target add
+        # is a no-op against a nix-provided toolchain).
+        jsRustToolchain = pkgs.rust-bin.stable.${msrv-version}.default.override {
+          extensions = [
+            "rust-src"
+            "rustfmt"
+            "llvm-tools-preview"
+          ];
+          targets = [ "wasm32-unknown-unknown" ];
+        };
+
+        javascriptDevShell = pkgs.mkShell {
+          name = "javascript-dev";
+          packages = with pkgs; [
+            jsRustToolchain
+            nodejs
+            # Version must match the wasm-bindgen crate locked in
+            # payjoin-ffi/javascript/rust_modules/wasm/Cargo.lock.
+            wasm-bindgen-cli_0_2_108
+            # secp256k1-sys build.rs invokes cc-rs for the wasm32-unknown-unknown
+            # target; cc-rs defaults to clang for wasm and needs llvm-ar.
+            llvmPackages.clang-unwrapped
+            llvmPackages.bintools-unwrapped
+            lld
+            bzip2 # needed for some machines to have access to libzip at runtime
+          ];
+          CC_wasm32_unknown_unknown = "${pkgs.llvmPackages.clang-unwrapped}/bin/clang";
+          AR_wasm32_unknown_unknown = "${pkgs.llvmPackages.bintools-unwrapped}/bin/llvm-ar";
+        };
+
+        dartDevShell = pkgs.mkShell {
+          name = "dart-dev";
+          packages =
+            with pkgs;
+            [
+              rustVersions.msrv
+              dart
+              bzip2
+            ]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkg-config
+              openssl
+              clang
+            ];
+          BITCOIND_EXE = pkgs.lib.getExe' pkgs.bitcoind "bitcoind";
+          BITCOIND_SKIP_DOWNLOAD = 1;
+        };
+
+        csharpDevShell = pkgs.mkShell {
+          name = "csharp-dev";
+          packages =
+            with pkgs;
+            [
+              rustVersions.msrv
+              dotnetSdk
+              bzip2
+            ]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkg-config
+              openssl
+              clang
+            ];
+          DOTNET_ROOT = "${dotnetSdk}/share/dotnet";
+          DOTNET_CLI_TELEMETRY_OPTOUT = "1";
+          BITCOIND_EXE = pkgs.lib.getExe' pkgs.bitcoind "bitcoind";
+          BITCOIND_SKIP_DOWNLOAD = 1;
+        };
+
+        # Rust toolchain for the python dev shell: msrv pinned to match
+        # payjoin-ffi/python build requirements, with per-arch targets added
+        # so cargo can build artifacts under nix for payjoin-ffi/python/scripts/generate_bindings.sh
+        # (rustup target add is a no-op against a nix-provided toolchain).
+        pythonRustToolchain = pkgs.rust-bin.stable.${msrv-version}.default.override {
+          extensions = [
+            "rust-src"
+            "rustfmt"
+            "llvm-tools-preview"
+          ];
+          targets =
+            pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              "aarch64-apple-darwin"
+              "x86_64-apple-darwin"
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+              "x86_64-unknown-linux-gnu"
+            ];
+        };
+
         pythonDevShell = pkgs.mkShell {
           name = "python-dev";
           packages =
@@ -345,7 +405,7 @@
             [
               pythonVenv
               uv
-              rustVersions.msrv
+              pythonRustToolchain
               bzip2 # needed for some machines to have access to libzip at runtime
             ]
             ++ lib.optionals pkgs.stdenv.isLinux [
@@ -398,6 +458,9 @@
         devShells = devShells // {
           default = devShells.nightly;
           python = pythonDevShell;
+          javascript = javascriptDevShell;
+          csharp = csharpDevShell;
+          dart = dartDevShell;
         };
         formatter = treefmtEval.config.build.wrapper;
         checks =

--- a/payjoin-ffi/csharp/Payjoin.Tests.csproj
+++ b/payjoin-ffi/csharp/Payjoin.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Required by UniFFI-generated interop code (pointer usage in payjoin.cs); disabling /unsafe fails with CS0227. -->


### PR DESCRIPTION
I realized adding the specific needs for the JS bindings into the global dev shell was mostly a time waster so I opted to refactor the recent additions from #1572 and instead use a javascript specific dev shell, the same applies for the addition of csharp and dart here

Unfortunately a windows build is not really feasibly nixify-able at this time.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
