### PR TITLE
Fix payjoin-cli receiver premature resolution

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -347,12 +347,32 @@ impl AppTrait for App {
 
         let mut interrupt = self.interrupt.clone();
         tokio::select! {
-            _ = async {
+            all_completed = async {
+                let mut all_completed = true;
                 for task in tasks {
-                    let _ = task.await;
+                    let result = task.await;
+                    match result {
+                        Ok(inner) => {
+                            match inner {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    all_completed = false;
+                                    println!("{e}")
+                                }
+                            }
+                        },
+                        Err(e) => {
+                            all_completed = false;
+                            println!("{e}")
+                        }
+
+                    }
                 }
+                all_completed
             } => {
-                println!("All resumed sessions completed.");
+                if all_completed {
+                    println!("All resumed sessions completed.");
+                }
             }
             _ = interrupt.changed() => {
                 println!("Resumed sessions were interrupted.");
@@ -859,9 +879,18 @@ impl App {
                     .save(persister);
 
                 match check_result {
-                    Ok(_) => {
-                        println!("Payjoin transaction detected in the mempool!");
-                        return Ok(());
+                    Ok(outcome) => {
+                        match outcome {
+                            OptionalTransitionOutcome::Progress(_) => {
+                                println!("Payjoin transaction detected in the mempool!");
+                                return Ok(());
+                            }
+                            OptionalTransitionOutcome::Stasis(_) => {
+                                // keep polling
+
+                                continue;
+                            }
+                        }
                     }
                     Err(_) => {
                         // keep polling

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -313,6 +313,26 @@ mod e2e {
                 .expect("Failed to execute payjoin-cli");
             respond_with_payjoin(cli_receive_resumer).await?;
 
+            // Resume the receiver to ensure it stays active before receiving payment
+            let cli_receive_resumer = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relay)
+                .arg("resume")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli");
+            check_resume_not_completed(cli_receive_resumer).await?;
+
+            // Resume the sender to process and broadcast payjoin
             let cli_send_resumer = Command::new(payjoin_cli)
                 .arg("--root-certificate")
                 .arg(cert_path)
@@ -360,8 +380,8 @@ mod e2e {
                 .stderr(Stdio::inherit())
                 .spawn()
                 .expect("Failed to execute payjoin-cli");
-
             check_resume_completed(cli_receive_resumer).await?;
+
             // Check that neither the sender or the receiver have sessions to resume
             let cli_receive_resumer = Command::new(payjoin_cli)
                 .arg("--root-certificate")
@@ -397,6 +417,7 @@ mod e2e {
                 .spawn()
                 .expect("Failed to execute payjoin-cli");
             check_resume_has_no_sessions(cli_send_resumer).await?;
+
             Ok(())
         }
 
@@ -459,6 +480,24 @@ mod e2e {
 
             terminate(cli_resumer).await.expect("Failed to kill payjoin-cli");
             assert!(res.is_some(), "Expected all resumed sessions completed");
+            Ok(())
+        }
+
+        async fn check_resume_not_completed(mut cli_resumer: Child) -> Result<()> {
+            let mut stdout =
+                cli_resumer.stdout.take().expect("Failed to take stdout of child process");
+            let timeout = tokio::time::Duration::from_secs(10);
+            let res = tokio::time::timeout(
+                timeout,
+                wait_for_stdout_match(&mut stdout, |line| {
+                    line.contains("All resumed sessions completed.")
+                        || line.contains("No sessions to resume.")
+                }),
+            )
+            .await?;
+
+            terminate(cli_resumer).await.expect("Failed to kill payjoin-cli");
+            assert!(res.is_none(), "Expected resumed sessions not yet completed",);
             Ok(())
         }
         Ok(())


### PR DESCRIPTION
### Summary

Resolves #1545 

Currently the payjoin-cli receiver will return an "All resumed sessions completed." message even when the session did not progress to completion. This was due to:
- Not appropriately handling the stasis outcome
- Not appropriately handling the timeout for resumed receiver session

Test has been updated to enforce that receiver should not return completed message when session was not completed.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
