### PR TITLE
fix(cli): v1 config rejecting endpoints without explicit port

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -362,3 +362,50 @@ where
             .map(Some),
     }
 }
+
+#[cfg(all(test, feature = "v1"))]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+    use crate::cli::Cli;
+
+    fn cli(port: &str, endpoint: &str) -> Cli {
+        Cli::parse_from([
+            "payjoin-cli",
+            "--bip78",
+            "--port",
+            port,
+            "--pj-endpoint",
+            endpoint,
+            "receive",
+            "50000",
+        ])
+    }
+
+    #[test]
+    fn rejects_random_port_with_explicit_endpoint_port() {
+        let err = Config::new(&cli("0", "https://example.com:443/")).unwrap_err();
+        assert!(err.to_string().contains("port"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn accepts_random_port_with_implicit_endpoint_port() {
+        Config::new(&cli("0", "https://example.com/")).unwrap();
+    }
+
+    #[test]
+    fn accepts_explicit_port_with_implicit_endpoint_port() {
+        Config::new(&cli("3000", "https://example.com/")).unwrap();
+    }
+
+    #[test]
+    fn accepts_explicit_port_with_matching_explicit_endpoint_port() {
+        Config::new(&cli("3000", "https://example.com:3000/")).unwrap();
+    }
+
+    #[test]
+    fn accepts_explicit_port_with_different_explicit_endpoint_port() {
+        Config::new(&cli("3000", "https://example.com:443/")).unwrap();
+    }
+}

--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -156,7 +156,7 @@ impl Config {
                 {
                     match built_config.get::<V1Config>("v1") {
                         Ok(v1) => {
-                            if v1.pj_endpoint.port().is_none() != (v1.port == 0) {
+                            if v1.port == 0 && v1.pj_endpoint.port().is_some() {
                                 return Err(ConfigError::Message(
                                     "If --port is 0, --pj-endpoint may not have a port".to_owned(),
                                 ));


### PR DESCRIPTION
```sh
-> % payjoin-cli --bip78 --port 3000 --pj-endpoint https://example.com/ receive 50000

Error: If --port is 0, --pj-endpoint may not have a port
```

Two problems here:
- `--port` is 3000, not 0. 
- The command should succeed, because this is a valid reverse-proxy setup - nginx terminating TLS on 443 and forwarding to payjoin-cli on 3000.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
