### PR TITLE
FFI dev shell follow-ups

### DIFF
--- a/payjoin-ffi/csharp/README.md
+++ b/payjoin-ffi/csharp/README.md
@@ -6,11 +6,10 @@ Welcome to the C# language bindings for the [Payjoin Dev Kit](https://payjoindev
 
 Follow these steps to clone the repository and run the tests.
 
-With nix, the default development shell provides the Rust toolchain, .NET 10 SDK,
-and .NET 8 runtime:
+With nix, the C# development shell provides the Rust toolchain and .NET 10 SDK:
 
 ```shell
-nix develop -c bash payjoin-ffi/csharp/contrib/test.sh
+nix develop .#csharp -c bash payjoin-ffi/csharp/contrib/test.sh
 ```
 
 ```shell
@@ -55,7 +54,7 @@ dotnet test
 
 ## Requirements
 
-- .NET 8.0 or higher
+- .NET 10.0 or higher
 - Rust toolchain (MSRV: 1.85.0 for this repository)
 - Cargo will fetch the C# generator from `chavic/uniffi-bindgen-cs` at commit `878a3d269eacce64beadcd336ade0b7c8da09824` (pinned in `payjoin-ffi/Cargo.toml`)
 

--- a/payjoin-ffi/javascript/scripts/generate_bindings.sh
+++ b/payjoin-ffi/javascript/scripts/generate_bindings.sh
@@ -19,7 +19,12 @@ cd node_modules/uniffi-bindgen-react-native
 cargo add home@=0.5.11 --package uniffi-bindgen-react-native
 cd ../..
 
-rustup target add wasm32-unknown-unknown
+# rustup target add is a no-op against a nix-provided toolchain
+# (no rustup home, targets baked into the nix derivation instead).
+if command -v rustup >/dev/null 2>&1 &&
+    rustup show active-toolchain >/dev/null 2>&1; then
+    rustup target add wasm32-unknown-unknown
+fi
 
 npm run build
 npm run build:test-utils


### PR DESCRIPTION
This updates the C# README to point users at the dedicated .#csharp Nix dev shell and aligns the documented .NET requirement with the current net10.0 test target.

It also updates the JavaScript binding generation script to guard rustup target add wasm32-unknown-unknown, matching the Python script's behavior so Nix-provided toolchains do not require a host rustup setup.