### PR TITLE
chore: add lcov.info to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mutants.out*
 *.ikm
 *payjoin.sqlite
 data
+lcov.info


### PR DESCRIPTION
adds lcov.info to the root `.gitignore ` file to ensure that local test coverage data reports are ignored and not accidentally tracked by Git. #closes #1522
<details>
  <summary>Pull Request Checklist</summary>
I used Gemini to help me double-check the project guidelines and PR template, but I authored the .gitignore fix manually.


Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.

</details>
