### PR TITLE
Document BIP77 v1 fallback behavior in create_post_request

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1239,7 +1239,20 @@ impl PayjoinProposal {
         .to_string()
     }
 
-    /// Construct an OHTTP Encapsulated HTTP POST request for the Proposal PSBT
+    /// Construct an OHTTP-encapsulated HTTP request carrying the Proposal PSBT.
+    ///
+    /// The inner HTTP method, body encoding, and target mailbox depend on
+    /// whether the original sender used Payjoin v2 (BIP 77) or Payjoin v1
+    /// (BIP 78), as recorded in the session context:
+    ///
+    /// - v2 sender (reply key present): POST an HPKE-encrypted `PjV2MsgB`
+    ///   payload to the sender's reply mailbox.
+    /// - v1 sender (no reply key): PUT the base64-encoded PSBT as cleartext
+    ///   UTF-8 bytes to the receiver's own mailbox, per the
+    ///   [BIP 77](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
+    ///   Backwards compatibility section.
+    ///
+    /// Both paths are then OHTTP-encapsulated to the directory's OHTTP Gateway.
     pub fn create_post_request(
         &self,
         ohttp_relay: String,

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1137,7 +1137,20 @@ impl Receiver<PayjoinProposal> {
     /// The Payjoin Proposal PSBT.
     pub fn psbt(&self) -> &Psbt { &self.psbt_context.payjoin_psbt }
 
-    /// Construct an OHTTP Encapsulated HTTP POST request for the Proposal PSBT
+    /// Construct an OHTTP-encapsulated HTTP request carrying the Proposal PSBT.
+    ///
+    /// The inner HTTP method, body encoding, and target mailbox depend on
+    /// whether the original sender used Payjoin v2 (BIP 77) or Payjoin v1
+    /// (BIP 78), as recorded in the session context:
+    ///
+    /// - v2 sender (reply key present): POST an HPKE-encrypted `PjV2MsgB`
+    ///   payload to the sender's reply mailbox.
+    /// - v1 sender (no reply key): PUT the base64-encoded PSBT as cleartext
+    ///   UTF-8 bytes to the receiver's own mailbox, per the
+    ///   [BIP 77](https://github.com/bitcoin/bips/blob/master/bip-0077.md)
+    ///   Backwards compatibility section.
+    ///
+    /// Both paths are then OHTTP-encapsulated to the directory's OHTTP Gateway.
     pub fn create_post_request(
         &self,
         ohttp_relay: impl IntoUrl,


### PR DESCRIPTION
Re: #1487 along with bitcoin/bips/pull/2186

Documents v2-receiving-v1-fallback behavior in both core lib and ffi.

Asked claude to draft and manually reviewed each line based on bip change.

<details>
  <summary>Pull Request Checklist</summary>


Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
