### PR TITLE
Update cargo-mutants to 27.1.0

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -28,7 +28,4 @@ exclude_re = [
   "replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is
   # payjoin/src/core/send/mod.rs
   "replace match guard proposed_txout.script_pubkey == original_output.script_pubkey with true in PsbtContext::check_outputs", # This non-deterministic mutation has a possible test to catch it
-  # These will be removed following #1123
-  # payjoin/src/core/send/v2/session.rs
-  "SessionHistory::terminal_error",
 ]

--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants@25.2.2
+          tool: cargo-mutants@27.1.0
       - run: cargo mutants --in-place --no-shuffle
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,7 @@ jobs:
           git diff origin/${{ github.base_ref }}.. -- '*.rs' | tee git.diff
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants@25.2.2
+          tool: cargo-mutants@27.1.0
       - name: "Install toolchain"
         uses: dtolnay/rust-toolchain@stable
       - name: "Use cache"


### PR DESCRIPTION
cargo mutants has mostly stabilized and I want to update to the latest version in hopes of continuing to update our mutation coverage approaching 1.0.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
