### PR TITLE
Test utils feature unification

### DIFF
--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -8,22 +8,40 @@ repository = "https://github.com/payjoin/rust-payjoin"
 rust-version = "1.85"
 license = "MIT"
 
+[features]
+default = ["v2"]
+v2 = [
+  "payjoin/io",
+  "payjoin/_manual-tls",
+  "dep:axum-server",
+  "dep:ohttp",
+  "dep:rcgen",
+  "dep:rustls",
+  "dep:reqwest",
+  "dep:http",
+  "dep:tempfile",
+]
+
 [dependencies]
-axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.8", features = [
+  "tls-rustls-no-provider",
+], optional = true }
 bitcoin = { version = "0.32.7", features = ["base64"] }
 corepc-node = { version = "0.10.0", features = ["download", "29_0"] }
-http = "1.3.1"
-ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
+http = { version = "1.3.1", optional = true }
+ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "0.25.0", features = ["io", "_manual-tls"] }
+payjoin = { version = "0.25.0", default-features = false }
 payjoin-mailroom = { path = "../payjoin-mailroom", features = ["_manual-tls"] }
 # Pin to 0.14.7 (last version to support our MSRV 1.85)
-rcgen = "=0.14.7"
+rcgen = { version = "=0.14.7", optional = true }
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls",
-] }
-rustls = { version = "0.23.31", default-features = false, features = ["ring"] }
-tempfile = "3.20.0"
+], optional = true }
+rustls = { version = "0.23.31", default-features = false, features = [
+  "ring",
+], optional = true }
+tempfile = { version = "3.20.0", optional = true }
 # Pin to 0.3.45 (last version to support our MSRV 1.85)
 time = "=0.3.45"
 tokio = { version = "1.47.1", features = ["full"] }

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -1,31 +1,20 @@
 use std::result::Result;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
 
-use axum_server::tls_rustls::RustlsConfig;
 use bitcoin::{Amount, Psbt};
 pub use corepc_node; // re-export for convenience
 use corepc_node::AddressType;
-use http::StatusCode;
-use ohttp::hpke::{Aead, Kdf, Kem};
-use ohttp::{KeyId, SymmetricSuite};
 use once_cell::sync::{Lazy, OnceCell};
-use payjoin::io::{fetch_ohttp_keys_with_cert, Error as IOError};
-use payjoin::OhttpKeys;
-use rcgen::Certificate;
-use reqwest::{Client, ClientBuilder};
-use rustls::pki_types::CertificateDer;
-use rustls::RootCertStore;
-use tempfile::tempdir;
-use tokio::task::JoinHandle;
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
+#[cfg(feature = "v2")]
+pub mod v2;
+#[cfg(feature = "v2")]
+pub use v2::*;
+
 pub type BoxError = Box<dyn std::error::Error + 'static>;
 pub type BoxSendSyncError = Box<dyn std::error::Error + Send + Sync>;
-
-pub use payjoin::persist::{InMemoryPersister, SessionPersister};
 
 static INIT_TRACING: OnceCell<()> = OnceCell::new();
 
@@ -39,137 +28,6 @@ pub fn init_tracing() {
         tracing::subscriber::set_global_default(subscriber)
             .expect("failed to set global default subscriber");
     });
-}
-
-pub struct TestServices {
-    cert: Certificate,
-    directory: (u16, Option<JoinHandle<Result<(), BoxSendSyncError>>>),
-    ohttp_relay: (u16, Option<JoinHandle<Result<(), BoxSendSyncError>>>),
-    http_agent: Arc<Client>,
-}
-
-impl TestServices {
-    pub async fn initialize() -> Result<Self, BoxSendSyncError> {
-        // TODO add a UUID, and cleanup guard to delete after on successful run
-        let cert = local_cert_key();
-        let cert_der = cert.cert.der().to_vec();
-        let key_der = cert.signing_key.serialize_der();
-        let cert_key = (cert_der.clone(), key_der);
-
-        let mut root_store = RootCertStore::empty();
-        root_store.add(CertificateDer::from(cert.cert.der().to_vec())).unwrap();
-
-        let directory = init_directory(cert_key, root_store.clone()).await?;
-        let ohttp_relay = init_ohttp_relay(root_store, None).await?;
-
-        let http_agent: Arc<Client> = Arc::new(http_agent(cert_der)?);
-
-        Ok(Self {
-            cert: cert.cert,
-            directory: (directory.0, Some(directory.1)),
-            ohttp_relay: (ohttp_relay.0, Some(ohttp_relay.1)),
-            http_agent,
-        })
-    }
-
-    pub fn cert(&self) -> Vec<u8> { self.cert.der().to_vec() }
-
-    pub fn directory_url(&self) -> String { format!("https://localhost:{}", self.directory.0) }
-
-    pub fn take_directory_handle(&mut self) -> JoinHandle<Result<(), BoxSendSyncError>> {
-        self.directory.1.take().expect("directory handle not found")
-    }
-
-    pub fn ohttp_relay_url(&self) -> String { format!("http://localhost:{}", self.ohttp_relay.0) }
-
-    pub fn ohttp_gateway_url(&self) -> String {
-        format!("{}/.well-known/ohttp-gateway", self.directory_url())
-    }
-
-    pub fn take_ohttp_relay_handle(&mut self) -> JoinHandle<Result<(), BoxSendSyncError>> {
-        self.ohttp_relay.1.take().expect("ohttp relay handle not found")
-    }
-
-    pub fn http_agent(&self) -> Arc<Client> { self.http_agent.clone() }
-
-    pub async fn wait_for_services_ready(&self) -> Result<(), &'static str> {
-        wait_for_service_ready(&self.ohttp_relay_url(), self.http_agent()).await?;
-        wait_for_service_ready(&self.directory_url(), self.http_agent()).await?;
-        Ok(())
-    }
-
-    pub async fn fetch_ohttp_keys(&self) -> Result<OhttpKeys, IOError> {
-        fetch_ohttp_keys_with_cert(
-            self.ohttp_relay_url().as_str(),
-            self.directory_url().as_str(),
-            &self.cert(),
-        )
-        .await
-    }
-}
-
-pub async fn init_directory(
-    local_cert_key: (Vec<u8>, Vec<u8>),
-    root_store: RootCertStore,
-) -> std::result::Result<
-    (u16, tokio::task::JoinHandle<std::result::Result<(), BoxSendSyncError>>),
-    BoxSendSyncError,
-> {
-    let tempdir = tempdir()?;
-    let config = payjoin_mailroom::config::Config::new(
-        "[::]:0".parse().expect("valid listener address"),
-        tempdir.path().to_path_buf(),
-        Duration::from_secs(2),
-        Some(payjoin_mailroom::config::V1Config::default()),
-    );
-
-    let tls_config = RustlsConfig::from_der(vec![local_cert_key.0], local_cert_key.1).await?;
-
-    let (port, handle) =
-        payjoin_mailroom::serve_manual_tls(config, Some(tls_config), root_store, None)
-            .await
-            .map_err(|e| e.to_string())?;
-
-    let handle = tokio::spawn(async move {
-        let _tempdir = tempdir; // keep the tempdir until the directory shuts down
-        handle.await.map_err(|e| e.to_string())?.map_err(|e| e.to_string().into())
-    });
-
-    Ok((port, handle))
-}
-
-pub async fn init_ohttp_relay(
-    root_store: RootCertStore,
-    default_gateway: Option<payjoin_mailroom::ohttp_relay::GatewayUri>,
-) -> std::result::Result<
-    (u16, tokio::task::JoinHandle<std::result::Result<(), BoxSendSyncError>>),
-    BoxSendSyncError,
-> {
-    let tempdir = tempdir()?;
-    let config = payjoin_mailroom::config::Config::new(
-        "[::]:0".parse().expect("valid listener address"),
-        tempdir.path().to_path_buf(),
-        Duration::from_secs(2),
-        None,
-    );
-
-    let (port, handle) =
-        payjoin_mailroom::serve_manual_tls(config, None, root_store, default_gateway)
-            .await
-            .map_err(|e| e.to_string())?;
-
-    let handle = tokio::spawn(async move {
-        let _tempdir = tempdir; // keep the tempdir until the relay shuts down
-        handle.await.map_err(|e| e.to_string())?.map_err(|e| e.to_string().into())
-    });
-
-    Ok((port, handle))
-}
-
-/// generate or get a DER encoded localhost cert and key.
-pub fn local_cert_key() -> rcgen::CertifiedKey<rcgen::KeyPair> {
-    rcgen::generate_simple_self_signed(vec!["0.0.0.0".to_string(), "localhost".to_string()])
-        .expect("Failed to generate cert")
 }
 
 pub fn init_bitcoind() -> Result<corepc_node::Node, BoxError> {
@@ -226,10 +84,6 @@ fn create_and_fund_wallets<W: AsRef<str>>(
     Ok(funded_wallets)
 }
 
-pub fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxSendSyncError> {
-    Ok(http_agent_builder(cert_der).build()?)
-}
-
 pub fn init_bitcoind_multi_sender_single_reciever(
     number_of_senders: usize,
 ) -> Result<(corepc_node::Node, Vec<corepc_node::Client>, corepc_node::Client), BoxError> {
@@ -243,42 +97,7 @@ pub fn init_bitcoind_multi_sender_single_reciever(
     Ok((bitcoind, senders, receiver))
 }
 
-fn http_agent_builder(cert_der: Vec<u8>) -> ClientBuilder {
-    ClientBuilder::new().http1_only().use_rustls_tls().add_root_certificate(
-        reqwest::tls::Certificate::from_der(cert_der.as_slice())
-            .expect("cert_der should be a valid DER-encoded certificate"),
-    )
-}
-
-const TESTS_TIMEOUT: Duration = Duration::from_secs(20);
-const WAIT_SERVICE_INTERVAL: Duration = Duration::from_secs(3);
-
-pub async fn wait_for_service_ready(
-    service_url: &str,
-    agent: Arc<Client>,
-) -> Result<(), &'static str> {
-    let health_url = format!("{}/health", service_url.trim_end_matches("/"));
-    let start = std::time::Instant::now();
-
-    while start.elapsed() < TESTS_TIMEOUT {
-        let request_result =
-            agent.get(health_url.clone()).send().await.map_err(|_| "Bad request")?;
-        match request_result.status() {
-            StatusCode::OK => return Ok(()),
-            StatusCode::NOT_FOUND => return Err("Endpoint not found"),
-            _ => std::thread::sleep(WAIT_SERVICE_INTERVAL),
-        }
-    }
-
-    Err("Timeout waiting for service to be ready")
-}
-
 pub static EXAMPLE_URL: &str = "https://example.com";
-
-pub const KEY_ID: KeyId = 1;
-pub const KEM: Kem = Kem::K256Sha256;
-pub const SYMMETRIC: &[SymmetricSuite] =
-    &[ohttp::SymmetricSuite::new(Kdf::HkdfSha256, Aead::ChaCha20Poly1305)];
 
 // https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#user-content-span_idtestvectorsspanTest_vectors
 // | InputScriptType | Original PSBT Fee rate | maxadditionalfeecontribution | additionalfeeoutputindex|

--- a/payjoin-test-utils/src/v2.rs
+++ b/payjoin-test-utils/src/v2.rs
@@ -1,0 +1,189 @@
+use std::result::Result;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum_server::tls_rustls::RustlsConfig;
+use http::StatusCode;
+use ohttp::hpke::{Aead, Kdf, Kem};
+use ohttp::{KeyId, SymmetricSuite};
+use payjoin::io::{fetch_ohttp_keys_with_cert, Error as IOError};
+pub use payjoin::persist::{InMemoryPersister, SessionPersister};
+use payjoin::OhttpKeys;
+use rcgen::Certificate;
+use reqwest::{Client, ClientBuilder};
+use rustls::pki_types::CertificateDer;
+use rustls::RootCertStore;
+use tempfile::tempdir;
+use tokio::task::JoinHandle;
+
+use crate::BoxSendSyncError;
+
+pub struct TestServices {
+    cert: Certificate,
+    directory: (u16, Option<JoinHandle<Result<(), BoxSendSyncError>>>),
+    ohttp_relay: (u16, Option<JoinHandle<Result<(), BoxSendSyncError>>>),
+    http_agent: Arc<Client>,
+}
+
+impl TestServices {
+    pub async fn initialize() -> Result<Self, BoxSendSyncError> {
+        // TODO add a UUID, and cleanup guard to delete after on successful run
+        let cert = local_cert_key();
+        let cert_der = cert.cert.der().to_vec();
+        let key_der = cert.signing_key.serialize_der();
+        let cert_key = (cert_der.clone(), key_der);
+
+        let mut root_store = RootCertStore::empty();
+        root_store.add(CertificateDer::from(cert.cert.der().to_vec())).unwrap();
+
+        let directory = init_directory(cert_key, root_store.clone()).await?;
+        let ohttp_relay = init_ohttp_relay(root_store, None).await?;
+
+        let http_agent: Arc<Client> = Arc::new(http_agent(cert_der)?);
+
+        Ok(Self {
+            cert: cert.cert,
+            directory: (directory.0, Some(directory.1)),
+            ohttp_relay: (ohttp_relay.0, Some(ohttp_relay.1)),
+            http_agent,
+        })
+    }
+
+    pub fn cert(&self) -> Vec<u8> { self.cert.der().to_vec() }
+
+    pub fn directory_url(&self) -> String { format!("https://localhost:{}", self.directory.0) }
+
+    pub fn take_directory_handle(&mut self) -> JoinHandle<Result<(), BoxSendSyncError>> {
+        self.directory.1.take().expect("directory handle not found")
+    }
+
+    pub fn ohttp_relay_url(&self) -> String { format!("http://localhost:{}", self.ohttp_relay.0) }
+
+    pub fn ohttp_gateway_url(&self) -> String {
+        format!("{}/.well-known/ohttp-gateway", self.directory_url())
+    }
+
+    pub fn take_ohttp_relay_handle(&mut self) -> JoinHandle<Result<(), BoxSendSyncError>> {
+        self.ohttp_relay.1.take().expect("ohttp relay handle not found")
+    }
+
+    pub fn http_agent(&self) -> Arc<Client> { self.http_agent.clone() }
+
+    pub async fn wait_for_services_ready(&self) -> Result<(), &'static str> {
+        wait_for_service_ready(&self.ohttp_relay_url(), self.http_agent()).await?;
+        wait_for_service_ready(&self.directory_url(), self.http_agent()).await?;
+        Ok(())
+    }
+
+    pub async fn fetch_ohttp_keys(&self) -> Result<OhttpKeys, IOError> {
+        fetch_ohttp_keys_with_cert(
+            self.ohttp_relay_url().as_str(),
+            self.directory_url().as_str(),
+            &self.cert(),
+        )
+        .await
+    }
+}
+
+pub async fn init_directory(
+    local_cert_key: (Vec<u8>, Vec<u8>),
+    root_store: RootCertStore,
+) -> std::result::Result<
+    (u16, tokio::task::JoinHandle<std::result::Result<(), BoxSendSyncError>>),
+    BoxSendSyncError,
+> {
+    let tempdir = tempdir()?;
+    let config = payjoin_mailroom::config::Config::new(
+        "[::]:0".parse().expect("valid listener address"),
+        tempdir.path().to_path_buf(),
+        Duration::from_secs(2),
+        Some(payjoin_mailroom::config::V1Config::default()),
+    );
+
+    let tls_config = RustlsConfig::from_der(vec![local_cert_key.0], local_cert_key.1).await?;
+
+    let (port, handle) =
+        payjoin_mailroom::serve_manual_tls(config, Some(tls_config), root_store, None)
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let handle = tokio::spawn(async move {
+        let _tempdir = tempdir; // keep the tempdir until the directory shuts down
+        handle.await.map_err(|e| e.to_string())?.map_err(|e| e.to_string().into())
+    });
+
+    Ok((port, handle))
+}
+
+pub async fn init_ohttp_relay(
+    root_store: RootCertStore,
+    default_gateway: Option<payjoin_mailroom::ohttp_relay::GatewayUri>,
+) -> std::result::Result<
+    (u16, tokio::task::JoinHandle<std::result::Result<(), BoxSendSyncError>>),
+    BoxSendSyncError,
+> {
+    let tempdir = tempdir()?;
+    let config = payjoin_mailroom::config::Config::new(
+        "[::]:0".parse().expect("valid listener address"),
+        tempdir.path().to_path_buf(),
+        Duration::from_secs(2),
+        None,
+    );
+
+    let (port, handle) =
+        payjoin_mailroom::serve_manual_tls(config, None, root_store, default_gateway)
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let handle = tokio::spawn(async move {
+        let _tempdir = tempdir; // keep the tempdir until the relay shuts down
+        handle.await.map_err(|e| e.to_string())?.map_err(|e| e.to_string().into())
+    });
+
+    Ok((port, handle))
+}
+
+/// generate or get a DER encoded localhost cert and key.
+pub fn local_cert_key() -> rcgen::CertifiedKey<rcgen::KeyPair> {
+    rcgen::generate_simple_self_signed(vec!["0.0.0.0".to_string(), "localhost".to_string()])
+        .expect("Failed to generate cert")
+}
+
+pub fn http_agent(cert_der: Vec<u8>) -> Result<Client, BoxSendSyncError> {
+    Ok(http_agent_builder(cert_der).build()?)
+}
+
+fn http_agent_builder(cert_der: Vec<u8>) -> ClientBuilder {
+    ClientBuilder::new().http1_only().use_rustls_tls().add_root_certificate(
+        reqwest::tls::Certificate::from_der(cert_der.as_slice())
+            .expect("cert_der should be a valid DER-encoded certificate"),
+    )
+}
+
+const TESTS_TIMEOUT: Duration = Duration::from_secs(20);
+const WAIT_SERVICE_INTERVAL: Duration = Duration::from_secs(3);
+
+pub async fn wait_for_service_ready(
+    service_url: &str,
+    agent: Arc<Client>,
+) -> Result<(), &'static str> {
+    let health_url = format!("{}/health", service_url.trim_end_matches("/"));
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < TESTS_TIMEOUT {
+        let request_result =
+            agent.get(health_url.clone()).send().await.map_err(|_| "Bad request")?;
+        match request_result.status() {
+            StatusCode::OK => return Ok(()),
+            StatusCode::NOT_FOUND => return Err("Endpoint not found"),
+            _ => std::thread::sleep(WAIT_SERVICE_INTERVAL),
+        }
+    }
+
+    Err("Timeout waiting for service to be ready")
+}
+
+pub const KEY_ID: KeyId = 1;
+pub const KEM: Kem = Kem::K256Sha256;
+pub const SYMMETRIC: &[SymmetricSuite] =
+    &[ohttp::SymmetricSuite::new(Kdf::HkdfSha256, Aead::ChaCha20Poly1305)];

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -33,7 +33,7 @@ _core = [
 ]
 directory = []
 v1 = ["_core"]
-v2 = ["_core", "hpke", "bhttp", "ohttp", "directory"]
+v2 = ["_core", "hpke", "bhttp", "ohttp", "directory", "payjoin-test-utils/v2"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
 _manual-tls = ["rustls"]
@@ -63,7 +63,7 @@ ignored = ["bitcoin-units"]
 
 [dev-dependencies]
 once_cell = "1.21.3"
-payjoin-test-utils = { version = "0.0.1" }
+payjoin-test-utils = { version = "0.0.1", default-features = false }
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 

--- a/payjoin/src/directory.rs
+++ b/payjoin/src/directory.rs
@@ -74,7 +74,7 @@ impl std::str::FromStr for ShortId {
 
 #[cfg(test)]
 mod tests {
-    use crate::uri::ShortId;
+    use super::ShortId;
 
     #[test]
     fn short_id_conversion() {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -2,7 +2,9 @@ mod integration {
     use std::collections::HashMap;
     use std::str::FromStr;
 
+    #[cfg(feature = "v2")]
     use bitcoin::bech32::primitives::decode::CheckedHrpstring;
+    #[cfg(feature = "v2")]
     use bitcoin::bech32::NoChecksum;
     use bitcoin::policy::DEFAULT_MIN_RELAY_TX_FEE;
     use bitcoin::psbt::{Input as PsbtInput, Psbt};


### PR DESCRIPTION
Closes #1598

This allows the payjoin crate to only test the `v1` feature gated tests on their own without also pulling in `v2` as payjoin-test-utils now no longer automatically pulls in the `v2` feature.

Claude caught the `directory.rs` issue which was occuring because of the` v2` only re-export of `ShortId`.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
