### PR TITLE
Skip taproot coins in payjoin-cli

### DIFF
--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -169,13 +169,20 @@ impl BitcoindWallet {
     }
 
     /// List unspent UTXOs
+    ///
+    /// Filters out P2TR outputs since taproot inputs are not yet supported by payjoin.
     pub fn list_unspent(&self) -> Result<Vec<InputPair>> {
         let unspent = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current()
                 .block_on(async { self.rpc.list_unspent(None, None, None, None, None).await })
         })
         .context("Failed to list unspent")?;
-        Ok(unspent.0.into_iter().map(input_pair_from_corepc).collect())
+        Ok(unspent
+            .0
+            .into_iter()
+            .filter(|utxo| !utxo.script_pubkey.is_p2tr())
+            .map(input_pair_from_corepc)
+            .collect())
     }
 
     /// Check if wallet has any spendable UTXOs


### PR DESCRIPTION
I found this bug when testing payjoins in liana where a taproot coin would be added to my payjoin-cli wallet and then the next time I would try to do a payjoin the latest utxo would be a taproot output and would then cause errors when trying to do a payjoin. 

This PR simply skips taproot outputs as coins to be chosen in the payjoin-cli.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
