### PR TITLE
 Rename EncapsulationError to DecapsulationError

### DIFF
--- a/payjoin-ffi/src/send/error.rs
+++ b/payjoin-ffi/src/send/error.rs
@@ -60,11 +60,11 @@ impl From<FfiValidationError> for SenderInputError {
 #[error(transparent)]
 pub struct CreateRequestError(#[from] send::v2::CreateRequestError);
 
-/// Error returned for v2-specific payload encapsulation errors.
+/// Error returned for v2-specific payload decapsulation errors.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[uniffi::export(Debug, Display)]
 #[error(transparent)]
-pub struct EncapsulationError(#[from] send::v2::EncapsulationError);
+pub struct DecapsulationError(#[from] send::v2::DecapsulationError);
 
 /// Error that may occur when the response from receiver is malformed.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
@@ -126,9 +126,9 @@ pub struct SenderReplayError(
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[error(transparent)]
 pub enum SenderPersistedError {
-    /// rust-payjoin sender Encapsulation error
+    /// rust-payjoin sender Decapsulation error
     #[error(transparent)]
-    EncapsulationError(Arc<EncapsulationError>),
+    DecapsulationError(Arc<DecapsulationError>),
     /// rust-payjoin sender response error
     #[error(transparent)]
     ResponseError(ResponseError),
@@ -147,12 +147,12 @@ impl From<ImplementationError> for SenderPersistedError {
     fn from(value: ImplementationError) -> Self { SenderPersistedError::Storage(Arc::new(value)) }
 }
 
-impl<S> From<payjoin::persist::PersistedError<send::v2::EncapsulationError, S>>
+impl<S> From<payjoin::persist::PersistedError<send::v2::DecapsulationError, S>>
     for SenderPersistedError
 where
     S: std::error::Error + Send + Sync + 'static,
 {
-    fn from(err: payjoin::persist::PersistedError<send::v2::EncapsulationError, S>) -> Self {
+    fn from(err: payjoin::persist::PersistedError<send::v2::DecapsulationError, S>) -> Self {
         if err.storage_error_ref().is_some() {
             if let Some(storage_err) = err.storage_error() {
                 return SenderPersistedError::from(ImplementationError::new(storage_err));
@@ -160,7 +160,7 @@ where
             return SenderPersistedError::Unexpected;
         }
         if let Some(api_err) = err.api_error() {
-            return SenderPersistedError::EncapsulationError(Arc::new(api_err.into()));
+            return SenderPersistedError::DecapsulationError(Arc::new(api_err.into()));
         }
         SenderPersistedError::Unexpected
     }

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 pub use error::{
-    BuildSenderError, CreateRequestError, EncapsulationError, PsbtParseError, ResponseError,
+    BuildSenderError, CreateRequestError, DecapsulationError, PsbtParseError, ResponseError,
     SenderInputError,
 };
 
@@ -456,7 +456,7 @@ pub struct WithReplyKeyTransition(
                 payjoin::persist::MaybeFatalTransition<
                     payjoin::send::v2::SessionEvent,
                     payjoin::send::v2::Sender<payjoin::send::v2::PollingForProposal>,
-                    payjoin::send::v2::EncapsulationError,
+                    payjoin::send::v2::DecapsulationError,
                 >,
             >,
         >,

--- a/payjoin/src/core/send/error.rs
+++ b/payjoin/src/core/send/error.rs
@@ -98,7 +98,7 @@ pub(crate) enum InternalValidationError {
     ContentTooLarge,
     Proposal(InternalProposalError),
     #[cfg(feature = "v2")]
-    V2Encapsulation(crate::send::v2::EncapsulationError),
+    V2Decapsulation(crate::send::v2::DecapsulationError),
 }
 
 impl From<InternalValidationError> for ValidationError {
@@ -126,7 +126,7 @@ impl fmt::Display for ValidationError {
             }
             Proposal(e) => write!(f, "proposal PSBT error: {e}"),
             #[cfg(feature = "v2")]
-            V2Encapsulation(e) => write!(f, "v2 encapsulation error: {e}"),
+            V2Decapsulation(e) => write!(f, "v2 encapsulation error: {e}"),
         }
     }
 }
@@ -141,7 +141,7 @@ impl std::error::Error for ValidationError {
             ContentTooLarge => None,
             Proposal(e) => Some(e),
             #[cfg(feature = "v2")]
-            V2Encapsulation(e) => Some(e),
+            V2Decapsulation(e) => Some(e),
         }
     }
 }

--- a/payjoin/src/core/send/v2/error.rs
+++ b/payjoin/src/core/send/v2/error.rs
@@ -55,21 +55,21 @@ impl From<crate::into_url::Error> for CreateRequestError {
     }
 }
 
-/// Error returned for v2-specific payload encapsulation errors.
+/// Error returned for v2-specific payload decapsulation errors.
 #[derive(Debug)]
-pub struct EncapsulationError(InternalEncapsulationError);
+pub struct DecapsulationError(InternalDecapsulationError);
 
 #[derive(Debug)]
-pub(crate) enum InternalEncapsulationError {
+pub(crate) enum InternalDecapsulationError {
     /// The HPKE failed.
     Hpke(crate::hpke::HpkeError),
     /// The directory returned a bad response
     DirectoryResponse(DirectoryResponseError),
 }
 
-impl fmt::Display for EncapsulationError {
+impl fmt::Display for DecapsulationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use InternalEncapsulationError::*;
+        use InternalDecapsulationError::*;
 
         match &self.0 {
             Hpke(error) => write!(f, "HPKE error: {error}"),
@@ -78,9 +78,9 @@ impl fmt::Display for EncapsulationError {
     }
 }
 
-impl std::error::Error for EncapsulationError {
+impl std::error::Error for DecapsulationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use InternalEncapsulationError::*;
+        use InternalDecapsulationError::*;
 
         match &self.0 {
             Hpke(error) => Some(error),
@@ -89,12 +89,12 @@ impl std::error::Error for EncapsulationError {
     }
 }
 
-impl From<InternalEncapsulationError> for EncapsulationError {
-    fn from(value: InternalEncapsulationError) -> Self { EncapsulationError(value) }
+impl From<InternalDecapsulationError> for DecapsulationError {
+    fn from(value: InternalDecapsulationError) -> Self { DecapsulationError(value) }
 }
 
-impl From<InternalEncapsulationError> for super::ResponseError {
-    fn from(value: InternalEncapsulationError) -> Self {
-        super::InternalValidationError::V2Encapsulation(value.into()).into()
+impl From<InternalDecapsulationError> for super::ResponseError {
+    fn from(value: InternalDecapsulationError) -> Self {
+        super::InternalValidationError::V2Decapsulation(value.into()).into()
     }
 }

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -30,8 +30,8 @@
 
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::Address;
-pub use error::{CreateRequestError, EncapsulationError};
-use error::{InternalCreateRequestError, InternalEncapsulationError};
+pub use error::{CreateRequestError, DecapsulationError};
+use error::{InternalCreateRequestError, InternalDecapsulationError};
 use ohttp::ClientResponse;
 use serde::{Deserialize, Serialize};
 pub use session::{
@@ -392,18 +392,18 @@ impl Sender<WithReplyKey> {
         self,
         response: &[u8],
         post_ctx: ClientResponse,
-    ) -> MaybeFatalTransition<SessionEvent, Sender<PollingForProposal>, EncapsulationError> {
+    ) -> MaybeFatalTransition<SessionEvent, Sender<PollingForProposal>, DecapsulationError> {
         match process_post_res(response, post_ctx) {
             Ok(()) => {}
             Err(e) =>
                 if e.is_fatal() {
                     return MaybeFatalTransition::fatal(
                         SessionEvent::Closed(SessionOutcome::Failure),
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 } else {
                     return MaybeFatalTransition::transient(
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 },
         }
@@ -533,11 +533,11 @@ impl Sender<PollingForProposal> {
                 if e.is_fatal() {
                     return MaybeSuccessTransitionWithNoResults::fatal(
                         SessionEvent::Closed(SessionOutcome::Failure),
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 } else {
                     return MaybeSuccessTransitionWithNoResults::transient(
-                        InternalEncapsulationError::DirectoryResponse(e).into(),
+                        InternalDecapsulationError::DirectoryResponse(e).into(),
                     );
                 },
         };
@@ -551,7 +551,7 @@ impl Sender<PollingForProposal> {
             Err(e) =>
                 return MaybeSuccessTransitionWithNoResults::fatal(
                     SessionEvent::Closed(SessionOutcome::Failure),
-                    InternalEncapsulationError::Hpke(e).into(),
+                    InternalDecapsulationError::Hpke(e).into(),
                 ),
         };
 


### PR DESCRIPTION
The send-v2 EncapsulationError is a misnomer: it's only raised while decapsulating directory responses in
process_response, never during request encapsulation (that's CreateRequestError). Renames the public struct,
InternalEncapsulationError, InternalValidationError::V2Encapsulation, and the payjoin-ffi sender surface → Decapsulation*. Pure rename, no behavior change; doc-prose aligned. OhttpEncapsulationError left untouched. The user-facing "v2 encapsulation error" 
Display string intentionally unchanged.

Why — Fix naming before the 1.0 error-type lock in & addresses the misnomer in #749; related to #403.

Reviewer note #403 fix PR is stacked on this so merge this first.

Disclosure: co-authored by Claude Code


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
