### PR TITLE
Mailroom EMFILE resilience

### DIFF
--- a/nix/modules/payjoin-mailroom.nix
+++ b/nix/modules/payjoin-mailroom.nix
@@ -83,6 +83,14 @@ in
         Restart = "on-failure";
         RestartSec = 5;
 
+        # A public directory + OHTTP relay holds many concurrent file
+        # descriptors: inbound connections, long-poll waits, and OHTTP
+        # bootstrap tunnels (2 fds each). The systemd default soft limit
+        # (1024) is exhausted under load, making accept() fail with EMFILE
+        # ("Too many open files"). soft:hard — 65536 enforced guardrail; the
+        # 524288 hard ceiling stays available to raise live without a redeploy.
+        LimitNOFILE = "65536:524288";
+
         # Allow binding to privileged ports (e.g. 443 for ACME)
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];

--- a/payjoin-mailroom/docker-compose.yml
+++ b/payjoin-mailroom/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - ./data:/data
     ports:
       - "443:443"
+    # A public directory + OHTTP relay holds many concurrent file descriptors
+    # (inbound connections, long-poll waits, OHTTP bootstrap tunnels). The
+    # default soft limit (often 1024) is exhausted under load, making accept()
+    # fail with EMFILE ("Too many open files"). soft:hard — 65536 enforced
+    # guardrail; 524288 hard ceiling stays available to raise live.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
     logging:
       driver: "json-file"
       options:

--- a/payjoin-mailroom/payjoin-mailroom.example.service
+++ b/payjoin-mailroom/payjoin-mailroom.example.service
@@ -11,5 +11,13 @@ ExecStart=/root/.cargo/bin/payjoin-mailroom --config /root/rust-payjoin/payjoin-
 Restart=on-failure
 RestartSec=5
 
+# A public directory + OHTTP relay holds many concurrent file descriptors:
+# inbound connections, long-poll waits, and OHTTP bootstrap tunnels (2 fds
+# each). The systemd default soft limit (1024) is exhausted under load, making
+# accept() fail with EMFILE ("Too many open files"). soft:hard form — 65536 is
+# the enforced guardrail (well above peak); the 524288 hard ceiling stays
+# available to raise live (prlimit) without a redeploy.
+LimitNOFILE=65536:524288
+
 [Install]
 WantedBy=multi-user.target

--- a/payjoin-mailroom/src/lib.rs
+++ b/payjoin-mailroom/src/lib.rs
@@ -62,9 +62,16 @@ pub async fn serve(config: Config, meter_provider: Option<SdkMeterProvider>) -> 
     #[cfg(feature = "access-control")]
     let app = app.into_make_service_with_connect_info::<middleware::MaybePeerIp>();
 
+    // EMFILE/ENFILE (file-descriptor exhaustion) is transient. Without
+    // sleep_on_errors, tokio_listener treats it as fatal and the axum08
+    // accept loop hangs forever (std::future::pending), so a momentary FD
+    // spike permanently downs the service until it is manually restarted.
+    // Backing off 1s and retrying lets the listener self-heal once
+    // descriptors free up (long-polls time out, tunnels close).
+    let mut system_options = SystemOptions::default();
+    system_options.sleep_on_errors = true;
     let listener =
-        Listener::bind(&config.listener, &SystemOptions::default(), &UserOptions::default())
-            .await?;
+        Listener::bind(&config.listener, &system_options, &UserOptions::default()).await?;
     info!("Payjoin service listening on {:?}", listener.local_addr());
     axum::serve(listener, app).await?;
 


### PR DESCRIPTION
## Symptoms

mailroom has been intermittently stopped serving requests and logging `errno 24 (EMFILE, "Too many open files").` on one host the accept loop hung `accept4() failed (24: Too many open files)`. on payjo.in the directory's mailbox reads started 500ing because the process has been hitting the file descriptor limit. This PR is a necessary but insufficient change raising that limit, so when there's a blowup it doesn't crash so quickly.

## Bug

The actual bug seems to be that payjoin-mailroom accepts connections through `tokio_listener` behind `axum::serve`

  1. tokio_listener's accept loop sorts errors into two buckets. Per-connection errors (a client reset mid-handshake — ECONNRESET/ECONNABORTED/ECONNREFUSED) → retry immediately, the next connection is probably fine. Everything else, including EMFILE/ENFILE, is returned as fatal — unless its sleep_on_errors option is on, in which case it sleeps 1s and retries (the pause gives fds time to free). The default is sleep_on_errors = false, so EMFILE escaped as fatal.
  2. axum 0.8's listener adapter handles a fatal accept error by logging it and then calling std::future::pending() — a future that never resolves. That parks the accept loop forever. The process stays alive but won't serve any new requests because they can't open fds.. And because it's hung, not crashed, systemd Restart=on-failure never fires (there's no exit to detect). Only a human restart brings it back.

  The one-line fix: `set sleep_on_errors = true` Now EMFILE → sleep 1s → retry accept(). Once connections drain and fds free, accept() succeeds and the server self-heals — no restart. It briefly degrades (new connections wait/refuse during the saturated second) instead
  of dying permanently.

This does two things: raise the fd limit and survive hitting it. This does NOT yet address the underlying problem. But this is the fire extinguisher we use first so that we have some time to address the core issues.

## Underlying Issue

`axum::serve` enforces no keep-alive/idle timeout and no connection cap, so idle inbound connections pile up until they exhaust the limit ~1k idle ESTABLISHED inbound sockets, accept queue overflowing. We ship this PR first but the real fix is long-poll-safe timeout +  connection caps in a follow-up PR. Multiplexing with h2/h3 between relay<->director hops is how this scales beyond that.

 Disclosure: co-authored by Claude; reviewed by Codex

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
