### PR TITLE
Mailroom fd hygiene

### DIFF
--- a/payjoin-mailroom/src/lib.rs
+++ b/payjoin-mailroom/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn serve(config: Config, meter_provider: Option<SdkMeterProvider>) -> 
 
     let services = Services {
         directory,
-        relay: crate::ohttp_relay::Service::new(sentinel_tag).await,
+        relay: crate::ohttp_relay::Service::new(sentinel_tag, metrics.clone()).await,
         metrics,
         #[cfg(feature = "access-control")]
         geoip,
@@ -109,6 +109,7 @@ pub async fn serve_manual_tls(
             sentinel_tag,
             root_store,
             default_gateway,
+            metrics.clone(),
         )
         .await,
         metrics,
@@ -175,7 +176,7 @@ pub async fn serve_acme(
 
     let services = Services {
         directory,
-        relay: crate::ohttp_relay::Service::new(sentinel_tag).await,
+        relay: crate::ohttp_relay::Service::new(sentinel_tag, metrics.clone()).await,
         metrics,
         #[cfg(feature = "access-control")]
         geoip,
@@ -565,7 +566,7 @@ mod tests {
         let metrics = MetricsService::new(Some(provider.clone()));
         let services = Services {
             directory: init_directory(&config, sentinel_tag, &metrics).await.unwrap(),
-            relay: crate::ohttp_relay::Service::new(sentinel_tag).await,
+            relay: crate::ohttp_relay::Service::new(sentinel_tag, metrics.clone()).await,
             metrics,
             #[cfg(feature = "access-control")]
             geoip: None,
@@ -614,7 +615,7 @@ mod tests {
         let metrics = MetricsService::new(Some(provider.clone()));
         let services = Services {
             directory: init_directory(&config, sentinel_tag, &metrics).await.unwrap(),
-            relay: crate::ohttp_relay::Service::new(sentinel_tag).await,
+            relay: crate::ohttp_relay::Service::new(sentinel_tag, metrics.clone()).await,
             metrics,
             #[cfg(feature = "access-control")]
             geoip: None,

--- a/payjoin-mailroom/src/metrics.rs
+++ b/payjoin-mailroom/src/metrics.rs
@@ -12,6 +12,8 @@ use payjoin::directory::ShortId;
 
 pub(crate) const TOTAL_CONNECTIONS: &str = "total_connections";
 pub(crate) const ACTIVE_CONNECTIONS: &str = "active_connections";
+pub(crate) const ACTIVE_TUNNELS: &str = "bootstrap_active_tunnels";
+pub(crate) const TUNNEL_SHEDS: &str = "bootstrap_tunnel_shed_total";
 pub(crate) const HTTP_REQUESTS: &str = "http_request_total";
 pub(crate) const DB_ENTRIES: &str = "db_entries_total";
 pub(crate) const UNIQUE_SHORT_IDS: &str = "unique_short_ids";
@@ -159,10 +161,20 @@ pub struct MetricsService {
     total_connections: Counter<u64>,
     /// Number of active connections right now
     active_connections: UpDownCounter<i64>,
+    /// Number of OHTTP bootstrap tunnels open right now
+    active_tunnels: UpDownCounter<i64>,
+    /// Total OHTTP bootstrap tunnels shed at the concurrency cap
+    tunnel_sheds_total: Counter<u64>,
     /// Total v1/v2 mailbox entries written, labelled by `version`
     db_entries_total: Counter<u64>,
     tracker: UniqueShortIdTracker,
     _unique_ids_gauge: Option<Arc<ObservableGauge<u64>>>,
+}
+
+impl fmt::Debug for MetricsService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetricsService").finish_non_exhaustive()
+    }
 }
 
 #[repr(u8)]
@@ -197,6 +209,16 @@ impl MetricsService {
         let active_connections = meter
             .i64_up_down_counter(ACTIVE_CONNECTIONS)
             .with_description("Number of active connections")
+            .build();
+
+        let active_tunnels = meter
+            .i64_up_down_counter(ACTIVE_TUNNELS)
+            .with_description("Number of OHTTP bootstrap tunnels open right now")
+            .build();
+
+        let tunnel_sheds_total = meter
+            .u64_counter(TUNNEL_SHEDS)
+            .with_description("Total OHTTP bootstrap tunnels shed at the concurrency cap")
             .build();
 
         let db_entries_total = meter
@@ -240,6 +262,8 @@ impl MetricsService {
             http_requests_total,
             total_connections,
             active_connections,
+            active_tunnels,
+            tunnel_sheds_total,
             db_entries_total,
             tracker,
             _unique_ids_gauge: unique_ids_gauge,
@@ -263,6 +287,12 @@ impl MetricsService {
     }
 
     pub fn record_connection_close(&self) { self.active_connections.add(-1, &[]); }
+
+    pub fn record_tunnel_open(&self) { self.active_tunnels.add(1, &[]); }
+
+    pub fn record_tunnel_close(&self) { self.active_tunnels.add(-1, &[]); }
+
+    pub fn record_tunnel_shed(&self) { self.tunnel_sheds_total.add(1, &[]); }
 
     pub fn record_db_entry(&self, version: PayjoinVersion) {
         self.db_entries_total.add(1, &[KeyValue::new("version", version.to_string())]);

--- a/payjoin-mailroom/src/ohttp_relay/bootstrap/connect.rs
+++ b/payjoin-mailroom/src/ohttp_relay/bootstrap/connect.rs
@@ -10,17 +10,19 @@ use tokio::net::TcpStream;
 use tokio::sync::OwnedSemaphorePermit;
 use tracing::{debug, error, instrument};
 
-use crate::ohttp_relay::bootstrap::{run_tunnel_within, TunnelLimits};
+use crate::metrics::MetricsService;
+use crate::ohttp_relay::bootstrap::{run_tunnel_within, TunnelGuard, TunnelLimits};
 use crate::ohttp_relay::error::Error;
 use crate::ohttp_relay::{empty, GatewayUri};
 
 pub(crate) fn is_connect_request<B>(req: &Request<B>) -> bool { Method::CONNECT == req.method() }
 
-#[instrument(skip(limits))]
+#[instrument(skip(limits, metrics))]
 pub(crate) async fn try_upgrade<B>(
     req: Request<B>,
     gateway_origin: GatewayUri,
     limits: &TunnelLimits,
+    metrics: &MetricsService,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error>
 where
     B: Send + Debug + 'static,
@@ -30,11 +32,16 @@ where
     // unbounded number of file descriptors.
     let permit = match limits.semaphore.clone().try_acquire_owned() {
         Ok(permit) => permit,
-        Err(_) => return Err(Error::Unavailable(limits.timeout)),
+        Err(_) => {
+            metrics.record_tunnel_shed();
+            return Err(Error::Unavailable(limits.timeout));
+        }
     };
 
     let timeout = limits.timeout;
+    let guard = TunnelGuard::open(metrics.clone());
     tokio::task::spawn(async move {
+        let _guard = guard;
         match run_tunnel_within(timeout, tunnel_after_upgrade(req, gateway_origin, permit)).await {
             Some(Ok(())) => {}
             Some(Err(e)) => error!("server io error: {}", e),
@@ -82,6 +89,7 @@ mod tests {
     use tokio::sync::Semaphore;
 
     use super::try_upgrade;
+    use crate::metrics::MetricsService;
     use crate::ohttp_relay::bootstrap::TunnelLimits;
     use crate::ohttp_relay::error::Error;
     use crate::ohttp_relay::GatewayUri;
@@ -94,6 +102,7 @@ mod tests {
             semaphore: Arc::new(Semaphore::new(0)),
             timeout: Duration::from_secs(60),
         };
+        let metrics = MetricsService::new(None);
         let req = Request::builder()
             .method(Method::CONNECT)
             .uri("example.com:443")
@@ -101,7 +110,8 @@ mod tests {
             .expect("valid request");
         let gateway = GatewayUri::from_str("https://example.com").expect("valid gateway");
 
-        let err = try_upgrade(req, gateway, &limits).await.expect_err("should be rejected");
+        let err =
+            try_upgrade(req, gateway, &limits, &metrics).await.expect_err("should be rejected");
 
         assert!(matches!(err, Error::Unavailable(_)));
     }

--- a/payjoin-mailroom/src/ohttp_relay/bootstrap/connect.rs
+++ b/payjoin-mailroom/src/ohttp_relay/bootstrap/connect.rs
@@ -7,39 +7,60 @@ use hyper::upgrade::Upgraded;
 use hyper::{Method, Request, Response};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
-use tracing::{error, instrument};
+use tokio::sync::OwnedSemaphorePermit;
+use tracing::{debug, error, instrument};
 
+use crate::ohttp_relay::bootstrap::{run_tunnel_within, TunnelLimits};
 use crate::ohttp_relay::error::Error;
 use crate::ohttp_relay::{empty, GatewayUri};
 
 pub(crate) fn is_connect_request<B>(req: &Request<B>) -> bool { Method::CONNECT == req.method() }
 
-#[instrument]
+#[instrument(skip(limits))]
 pub(crate) async fn try_upgrade<B>(
     req: Request<B>,
     gateway_origin: GatewayUri,
+    limits: &TunnelLimits,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error>
 where
     B: Send + Debug + 'static,
 {
-    let addr = gateway_origin
-        .to_socket_addr()
-        .await
-        .map_err(|e| Error::InternalServerError(Box::new(e)))?
-        .ok_or_else(|| Error::NotFound)?;
+    // Reject before doing any work (including DNS resolution) when the tunnel
+    // budget is exhausted, so a flood of bootstrap requests cannot pin an
+    // unbounded number of file descriptors.
+    let permit = match limits.semaphore.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => return Err(Error::Unavailable(limits.timeout)),
+    };
 
+    let timeout = limits.timeout;
     tokio::task::spawn(async move {
-        match hyper::upgrade::on(req).await {
-            Ok(upgraded) => {
-                if let Err(e) = tunnel(upgraded, addr).await {
-                    error!("server io error: {}", e);
-                };
-            }
-            Err(e) => error!("upgrade error: {}", e),
+        match run_tunnel_within(timeout, tunnel_after_upgrade(req, gateway_origin, permit)).await {
+            Some(Ok(())) => {}
+            Some(Err(e)) => error!("server io error: {}", e),
+            None => debug!("tunnel exceeded {timeout:?}, closing"),
         }
     });
 
     Ok(Response::new(empty()))
+}
+
+async fn tunnel_after_upgrade<B>(
+    req: Request<B>,
+    gateway_origin: GatewayUri,
+    permit: OwnedSemaphorePermit,
+) -> std::io::Result<()>
+where
+    B: Send + Debug + 'static,
+{
+    // Hold the permit for the entire tunnel lifecycle: DNS, HTTP upgrade,
+    // outbound connect, and byte proxying.
+    let _permit = permit;
+    let addr = gateway_origin.to_socket_addr().await?.ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "gateway resolved to no addresses")
+    })?;
+    let upgraded = hyper::upgrade::on(req).await.map_err(std::io::Error::other)?;
+    tunnel(upgraded, addr).await
 }
 
 /// Create a TCP connection to host:port, build a tunnel between the connection and
@@ -48,6 +69,40 @@ where
 async fn tunnel(upgraded: Upgraded, addr: SocketAddr) -> std::io::Result<()> {
     let mut server = TcpStream::connect(addr).await?;
     let mut upgraded = TokioIo::new(upgraded);
-    let (_, _) = tokio::io::copy_bidirectional(&mut upgraded, &mut server).await?;
-    Ok(())
+    tokio::io::copy_bidirectional(&mut upgraded, &mut server).await.map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use hyper::{Method, Request};
+    use tokio::sync::Semaphore;
+
+    use super::try_upgrade;
+    use crate::ohttp_relay::bootstrap::TunnelLimits;
+    use crate::ohttp_relay::error::Error;
+    use crate::ohttp_relay::GatewayUri;
+
+    #[tokio::test]
+    async fn rejects_when_tunnel_budget_exhausted() {
+        // No permits available: the next bootstrap request must be rejected
+        // before any upgrade or gateway connection is attempted.
+        let limits = TunnelLimits {
+            semaphore: Arc::new(Semaphore::new(0)),
+            timeout: Duration::from_secs(60),
+        };
+        let req = Request::builder()
+            .method(Method::CONNECT)
+            .uri("example.com:443")
+            .body(())
+            .expect("valid request");
+        let gateway = GatewayUri::from_str("https://example.com").expect("valid gateway");
+
+        let err = try_upgrade(req, gateway, &limits).await.expect_err("should be rejected");
+
+        assert!(matches!(err, Error::Unavailable(_)));
+    }
 }

--- a/payjoin-mailroom/src/ohttp_relay/bootstrap/mod.rs
+++ b/payjoin-mailroom/src/ohttp_relay/bootstrap/mod.rs
@@ -1,8 +1,11 @@
 use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::{Request, Response};
+use tokio::sync::Semaphore;
 use tracing::instrument;
 
 use crate::ohttp_relay::error::Error;
@@ -14,23 +17,94 @@ pub mod connect;
 #[cfg(feature = "ws-bootstrap")]
 pub mod ws;
 
-#[instrument]
+/// Maximum number of concurrent OHTTP bootstrap tunnels. Each tunnel pins two
+/// file descriptors (the inbound upgraded socket and the outbound TCP stream),
+/// so an unbounded number of them can exhaust the process descriptor limit.
+pub(crate) const MAX_CONCURRENT_TUNNELS: usize = 1024;
+
+/// Maximum lifetime of a single bootstrap tunnel. OHTTP key bootstrap is a
+/// short request/response exchange, so a tunnel still open after this is
+/// assumed stalled and is torn down to release its descriptors.
+pub(crate) const TUNNEL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Resource bounds shared by the CONNECT and WebSocket bootstrap tunnels.
+///
+/// Bootstrap tunnels are the only relay path that holds descriptors open for an
+/// unbounded time without these limits: a stalled or malicious client can pin
+/// two descriptors per tunnel indefinitely. The semaphore caps concurrency and
+/// the timeout caps lifetime, so total descriptor use stays bounded.
+#[derive(Debug, Clone)]
+pub(crate) struct TunnelLimits {
+    /// Caps the number of concurrent tunnels.
+    pub(crate) semaphore: Arc<Semaphore>,
+    /// Caps the lifetime of each tunnel.
+    pub(crate) timeout: Duration,
+}
+
+impl Default for TunnelLimits {
+    fn default() -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_TUNNELS)),
+            timeout: TUNNEL_TIMEOUT,
+        }
+    }
+}
+
+/// Drive a bootstrap tunnel to completion, tearing it down if it stays open
+/// longer than `timeout`. The deadline covers the whole tunnel lifecycle (DNS,
+/// HTTP upgrade, outbound connect, and byte proxying), so a stalled client
+/// cannot pin its descriptors past the deadline. Returns `Some(output)` when
+/// the tunnel finished on its own and `None` when the deadline tore it down.
+pub(crate) async fn run_tunnel_within<F: std::future::Future>(
+    timeout: Duration,
+    tunnel: F,
+) -> Option<F::Output> {
+    tokio::time::timeout(timeout, tunnel).await.ok()
+}
+
+#[instrument(skip(limits))]
 pub(crate) async fn handle_ohttp_keys<B>(
     req: Request<B>,
     gateway_origin: GatewayUri,
+    limits: &TunnelLimits,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error>
 where
     B: Send + Debug + 'static,
 {
     #[cfg(feature = "connect-bootstrap")]
     if connect::is_connect_request(&req) {
-        return connect::try_upgrade(req, gateway_origin).await;
+        return connect::try_upgrade(req, gateway_origin, limits).await;
     }
 
     #[cfg(feature = "ws-bootstrap")]
     if ws::is_websocket_request(&req) {
-        return ws::try_upgrade(req, gateway_origin).await;
+        return ws::try_upgrade(req, gateway_origin, limits).await;
     }
 
     Err(Error::BadRequest("Not a supported proxy upgrade request".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::run_tunnel_within;
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_tunnel_is_torn_down_at_deadline() {
+        // A tunnel future that never makes progress must be torn down once the
+        // timeout elapses, so its descriptors are released rather than pinned.
+        let never = std::future::pending::<std::io::Result<()>>();
+        let outcome = run_tunnel_within(Duration::from_secs(30), never).await;
+        assert!(outcome.is_none(), "stalled tunnel must time out");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn completed_tunnel_returns_its_result() {
+        // A tunnel that finishes before the deadline returns its own result
+        // untouched.
+        let done = std::future::ready(Ok::<(), std::io::Error>(()));
+        let outcome = run_tunnel_within(Duration::from_secs(30), done).await;
+        assert!(matches!(outcome, Some(Ok(()))), "completed tunnel returns its result");
+    }
 }

--- a/payjoin-mailroom/src/ohttp_relay/bootstrap/mod.rs
+++ b/payjoin-mailroom/src/ohttp_relay/bootstrap/mod.rs
@@ -8,6 +8,7 @@ use hyper::{Request, Response};
 use tokio::sync::Semaphore;
 use tracing::instrument;
 
+use crate::metrics::MetricsService;
 use crate::ohttp_relay::error::Error;
 use crate::ohttp_relay::GatewayUri;
 
@@ -50,6 +51,25 @@ impl Default for TunnelLimits {
     }
 }
 
+/// Records a bootstrap tunnel as open for as long as it is held, and records it
+/// closed on drop. Holding the guard inside the tunnel task means the close is
+/// recorded however the tunnel ends -- normal close, I/O error, timeout
+/// teardown, or panic -- so the active-tunnel gauge cannot drift.
+pub(crate) struct TunnelGuard {
+    metrics: MetricsService,
+}
+
+impl TunnelGuard {
+    pub(crate) fn open(metrics: MetricsService) -> Self {
+        metrics.record_tunnel_open();
+        Self { metrics }
+    }
+}
+
+impl Drop for TunnelGuard {
+    fn drop(&mut self) { self.metrics.record_tunnel_close(); }
+}
+
 /// Drive a bootstrap tunnel to completion, tearing it down if it stays open
 /// longer than `timeout`. The deadline covers the whole tunnel lifecycle (DNS,
 /// HTTP upgrade, outbound connect, and byte proxying), so a stalled client
@@ -62,23 +82,24 @@ pub(crate) async fn run_tunnel_within<F: std::future::Future>(
     tokio::time::timeout(timeout, tunnel).await.ok()
 }
 
-#[instrument(skip(limits))]
+#[instrument(skip(limits, metrics))]
 pub(crate) async fn handle_ohttp_keys<B>(
     req: Request<B>,
     gateway_origin: GatewayUri,
     limits: &TunnelLimits,
+    metrics: &MetricsService,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error>
 where
     B: Send + Debug + 'static,
 {
     #[cfg(feature = "connect-bootstrap")]
     if connect::is_connect_request(&req) {
-        return connect::try_upgrade(req, gateway_origin, limits).await;
+        return connect::try_upgrade(req, gateway_origin, limits, metrics).await;
     }
 
     #[cfg(feature = "ws-bootstrap")]
     if ws::is_websocket_request(&req) {
-        return ws::try_upgrade(req, gateway_origin, limits).await;
+        return ws::try_upgrade(req, gateway_origin, limits, metrics).await;
     }
 
     Err(Error::BadRequest("Not a supported proxy upgrade request".to_string()))

--- a/payjoin-mailroom/src/ohttp_relay/bootstrap/ws.rs
+++ b/payjoin-mailroom/src/ohttp_relay/bootstrap/ws.rs
@@ -11,11 +11,13 @@ use hyper::header::{CONNECTION, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, UPGRADE
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::OwnedSemaphorePermit;
 use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
-use tracing::{error, instrument};
+use tracing::{debug, error, instrument};
 
+use crate::ohttp_relay::bootstrap::{run_tunnel_within, TunnelLimits};
 use crate::ohttp_relay::empty;
 use crate::ohttp_relay::error::Error;
 use crate::ohttp_relay::gateway_uri::GatewayUri;
@@ -48,19 +50,22 @@ pub(crate) fn is_websocket_request<B>(req: &Request<B>) -> bool {
 /// This performs the WebSocket handshake to support generic body types.
 /// When bootstrapping moves to axum, this can be replaced with
 /// `axum::extract::ws::WebSocketUpgrade`.
-#[instrument]
+#[instrument(skip(limits))]
 pub(crate) async fn try_upgrade<B>(
     req: Request<B>,
     gateway_origin: GatewayUri,
+    limits: &TunnelLimits,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error>
 where
     B: Send + Debug + 'static,
 {
-    let gateway_addr = gateway_origin
-        .to_socket_addr()
-        .await
-        .map_err(|e| Error::InternalServerError(Box::new(e)))?
-        .ok_or_else(|| Error::NotFound)?;
+    // Reject before doing any work when the tunnel budget is exhausted, so a
+    // flood of bootstrap requests cannot pin an unbounded number of file
+    // descriptors.
+    let permit = match limits.semaphore.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => return Err(Error::Unavailable(limits.timeout)),
+    };
 
     let key = req
         .headers()
@@ -72,20 +77,12 @@ where
 
     let accept_key = derive_accept_key(key.as_bytes());
 
+    let timeout = limits.timeout;
     tokio::spawn(async move {
-        match hyper::upgrade::on(req).await {
-            Ok(upgraded) => {
-                let ws_stream = WebSocketStream::from_raw_socket(
-                    TokioIo::new(upgraded),
-                    tungstenite::protocol::Role::Server,
-                    None,
-                )
-                .await;
-                if let Err(e) = serve_websocket(ws_stream, gateway_addr).await {
-                    error!("Error in websocket connection: {e}");
-                }
-            }
-            Err(e) => error!("WebSocket upgrade error: {}", e),
+        match run_tunnel_within(timeout, serve_after_upgrade(req, gateway_origin, permit)).await {
+            Some(Ok(())) => {}
+            Some(Err(e)) => error!("Error in websocket connection: {e}"),
+            None => debug!("websocket tunnel exceeded {timeout:?}, closing"),
         }
     });
 
@@ -100,6 +97,30 @@ where
     Ok(res)
 }
 
+async fn serve_after_upgrade<B>(
+    req: Request<B>,
+    gateway_origin: GatewayUri,
+    permit: OwnedSemaphorePermit,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+where
+    B: Send + Debug + 'static,
+{
+    // Hold the permit for the entire tunnel lifecycle: DNS, HTTP upgrade,
+    // outbound connect, and byte proxying.
+    let _permit = permit;
+    let gateway_addr = gateway_origin.to_socket_addr().await?.ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "gateway resolved to no addresses")
+    })?;
+    let upgraded = hyper::upgrade::on(req).await?;
+    let ws_stream = WebSocketStream::from_raw_socket(
+        TokioIo::new(upgraded),
+        tungstenite::protocol::Role::Server,
+        None,
+    )
+    .await;
+    serve_websocket(ws_stream, gateway_addr).await
+}
+
 /// Stream WebSocket frames from the client to the gateway server's TCP socket and vice versa.
 #[instrument(skip(ws_stream))]
 async fn serve_websocket<S>(
@@ -111,7 +132,7 @@ where
 {
     let mut tcp_stream = tokio::net::TcpStream::connect(gateway_addr).await?;
     let mut ws_io = WsIo::new(ws_stream);
-    let (_, _) = tokio::io::copy_bidirectional(&mut ws_io, &mut tcp_stream).await?;
+    tokio::io::copy_bidirectional(&mut ws_io, &mut tcp_stream).await?;
     Ok(())
 }
 

--- a/payjoin-mailroom/src/ohttp_relay/bootstrap/ws.rs
+++ b/payjoin-mailroom/src/ohttp_relay/bootstrap/ws.rs
@@ -17,7 +17,8 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
 use tracing::{debug, error, instrument};
 
-use crate::ohttp_relay::bootstrap::{run_tunnel_within, TunnelLimits};
+use crate::metrics::MetricsService;
+use crate::ohttp_relay::bootstrap::{run_tunnel_within, TunnelGuard, TunnelLimits};
 use crate::ohttp_relay::empty;
 use crate::ohttp_relay::error::Error;
 use crate::ohttp_relay::gateway_uri::GatewayUri;
@@ -50,11 +51,12 @@ pub(crate) fn is_websocket_request<B>(req: &Request<B>) -> bool {
 /// This performs the WebSocket handshake to support generic body types.
 /// When bootstrapping moves to axum, this can be replaced with
 /// `axum::extract::ws::WebSocketUpgrade`.
-#[instrument(skip(limits))]
+#[instrument(skip(limits, metrics))]
 pub(crate) async fn try_upgrade<B>(
     req: Request<B>,
     gateway_origin: GatewayUri,
     limits: &TunnelLimits,
+    metrics: &MetricsService,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error>
 where
     B: Send + Debug + 'static,
@@ -64,7 +66,10 @@ where
     // descriptors.
     let permit = match limits.semaphore.clone().try_acquire_owned() {
         Ok(permit) => permit,
-        Err(_) => return Err(Error::Unavailable(limits.timeout)),
+        Err(_) => {
+            metrics.record_tunnel_shed();
+            return Err(Error::Unavailable(limits.timeout));
+        }
     };
 
     let key = req
@@ -78,7 +83,9 @@ where
     let accept_key = derive_accept_key(key.as_bytes());
 
     let timeout = limits.timeout;
+    let guard = TunnelGuard::open(metrics.clone());
     tokio::spawn(async move {
+        let _guard = guard;
         match run_tunnel_within(timeout, serve_after_upgrade(req, gateway_origin, permit)).await {
             Some(Ok(())) => {}
             Some(Err(e)) => error!("Error in websocket connection: {e}"),

--- a/payjoin-mailroom/src/ohttp_relay/mod.rs
+++ b/payjoin-mailroom/src/ohttp_relay/mod.rs
@@ -29,6 +29,7 @@ pub mod sentinel;
 pub use sentinel::SentinelTag;
 
 use self::error::{BoxError, Error};
+use crate::metrics::MetricsService;
 
 #[cfg(any(feature = "connect-bootstrap", feature = "ws-bootstrap"))]
 pub mod bootstrap;
@@ -42,19 +43,25 @@ struct RelayConfig {
     client: HttpClient,
     prober: Prober,
     sentinel_tag: SentinelTag,
+    metrics: MetricsService,
     #[cfg(any(feature = "connect-bootstrap", feature = "ws-bootstrap"))]
     tunnel_limits: bootstrap::TunnelLimits,
 }
 
 impl RelayConfig {
-    fn new_with_default_client(default_gateway: GatewayUri, sentinel_tag: SentinelTag) -> Self {
-        Self::new(default_gateway, HttpClient::default(), sentinel_tag)
+    fn new_with_default_client(
+        default_gateway: GatewayUri,
+        sentinel_tag: SentinelTag,
+        metrics: MetricsService,
+    ) -> Self {
+        Self::new(default_gateway, HttpClient::default(), sentinel_tag, metrics)
     }
 
     fn new(
         default_gateway: GatewayUri,
         into_client: impl Into<HttpClient>,
         sentinel_tag: SentinelTag,
+        metrics: MetricsService,
     ) -> Self {
         let client = into_client.into();
         let prober = Prober::new_with_client(client.clone());
@@ -63,6 +70,7 @@ impl RelayConfig {
             client,
             prober,
             sentinel_tag,
+            metrics,
             #[cfg(any(feature = "connect-bootstrap", feature = "ws-bootstrap"))]
             tunnel_limits: bootstrap::TunnelLimits::default(),
         }
@@ -75,13 +83,13 @@ pub struct Service {
 }
 
 impl Service {
-    pub async fn new(sentinel_tag: SentinelTag) -> Self {
+    pub async fn new(sentinel_tag: SentinelTag, metrics: MetricsService) -> Self {
         // The default gateway is hardcoded because it is obsolete and required only for backwards
         // compatibility.
         // The new mechanism for specifying a custom gateway is via RFC 9540 using
         // `/.well-known/ohttp-gateway` request paths.
         let gateway_origin = GatewayUri::from_str(DEFAULT_GATEWAY).expect("valid gateway uri");
-        let config = RelayConfig::new_with_default_client(gateway_origin, sentinel_tag);
+        let config = RelayConfig::new_with_default_client(gateway_origin, sentinel_tag, metrics);
         config.prober.assert_opt_in(&config.default_gateway).await;
         Self { config: Arc::new(config) }
     }
@@ -91,10 +99,11 @@ impl Service {
         sentinel_tag: SentinelTag,
         root_store: rustls::RootCertStore,
         default_gateway: Option<GatewayUri>,
+        metrics: MetricsService,
     ) -> Self {
         let gateway_origin = default_gateway
             .unwrap_or_else(|| GatewayUri::from_str(DEFAULT_GATEWAY).expect("valid gateway uri"));
-        let config = RelayConfig::new(gateway_origin, root_store, sentinel_tag);
+        let config = RelayConfig::new(gateway_origin, root_store, sentinel_tag, metrics);
         config.prober.assert_opt_in(&config.default_gateway).await;
         Self { config: Arc::new(config) }
     }
@@ -184,7 +193,13 @@ where
         (&Method::GET, _) | (&Method::CONNECT, _) => {
             match parse_gateway_uri(&method, path, authority, config).await {
                 Ok(gateway_uri) =>
-                    bootstrap::handle_ohttp_keys(req, gateway_uri, &config.tunnel_limits).await,
+                    bootstrap::handle_ohttp_keys(
+                        req,
+                        gateway_uri,
+                        &config.tunnel_limits,
+                        &config.metrics,
+                    )
+                    .await,
                 Err(e) => Err(e),
             }
         }

--- a/payjoin-mailroom/src/ohttp_relay/mod.rs
+++ b/payjoin-mailroom/src/ohttp_relay/mod.rs
@@ -42,6 +42,8 @@ struct RelayConfig {
     client: HttpClient,
     prober: Prober,
     sentinel_tag: SentinelTag,
+    #[cfg(any(feature = "connect-bootstrap", feature = "ws-bootstrap"))]
+    tunnel_limits: bootstrap::TunnelLimits,
 }
 
 impl RelayConfig {
@@ -56,7 +58,14 @@ impl RelayConfig {
     ) -> Self {
         let client = into_client.into();
         let prober = Prober::new_with_client(client.clone());
-        RelayConfig { default_gateway, client, prober, sentinel_tag }
+        RelayConfig {
+            default_gateway,
+            client,
+            prober,
+            sentinel_tag,
+            #[cfg(any(feature = "connect-bootstrap", feature = "ws-bootstrap"))]
+            tunnel_limits: bootstrap::TunnelLimits::default(),
+        }
     }
 }
 
@@ -175,7 +184,7 @@ where
         (&Method::GET, _) | (&Method::CONNECT, _) => {
             match parse_gateway_uri(&method, path, authority, config).await {
                 Ok(gateway_uri) =>
-                    crate::ohttp_relay::bootstrap::handle_ohttp_keys(req, gateway_uri).await,
+                    bootstrap::handle_ohttp_keys(req, gateway_uri, &config.tunnel_limits).await,
                 Err(e) => Err(e),
             }
         }


### PR DESCRIPTION
2026-06-23 Update: This PR has been reworked [according to this comment](https://github.com/payjoin/rust-payjoin/pull/1610#issuecomment-4776886568) to focus on fixing the OHTTP bootstrap mechanism specifically. Rather than have a global FD permit because the runaway FD issue was solved by multiplexing in #1655

---

#1608  increased the process file descriptor limit but did not address the reason the limit was being reached. this addresses that with transport-level fd hygeine including timeing out idle/header-stalled connections, software admission caps below the EMFILE limit, and optional, per-source limits.

Permits are acquired at the listener level, right after a TCP socket is accepted. If mailroom waits til the request gets to the middleware, it may have already admitted idle connections without ever producing HTTP requests.

There's a global inbound cap clamped by RLIMIT_NOFILE - fd_reserve so that fds for logging, acme, config reading that keep the process moving have headroom, and for outbound bootstrap connections.

The per-source cap is added but disabled by default. So in the future if there's one peer OHTTP relay that's using up all the fds with inbound, it can be individually limited. For now there are few relays and one may  be producing the lion's share of inbound descriptor usage. A default cap of `None` avoids a stale default becoming an overlooked bottleneck when max_inbound_connections is raised.

The tunnel cap is separate because CONNECT/WebSocket bootstrap tunnels pin both inbound upgraded connection and an outbound gateway connection.

h2 was already served before this PR (but I'm not sure if it has been used in practice). header_read_timeout is reused as the h2 keep-alive ping interval & timeout. This doesn't introduce h1-style header idle reaping for h2.

`connection` metrics now actually count actual TCP connections instead of request middleware events. These measure transport health infrastructure overload risk rather than actual payjoin usage. Payjoin activity would be more accurately measured from domain events or HTTP request events, tbd in follow-up.

Disclosure: authored & reviewed with adversarial runs of Claude/Codex models.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
