### PR TITLE
Bump payjoin version to 1.0.0-rc.3

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2773,7 +2773,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "0.25.0"
+version = "1.0.0-rc.3"
 dependencies = [
  "bhttp",
  "bitcoin 0.32.100",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -1984,7 +1984,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2749,7 +2749,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "payjoin"
-version = "0.25.0"
+version = "1.0.0-rc.3"
 dependencies = [
  "bhttp",
  "bitcoin 0.32.100",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6.0.0"
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.6.0", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1.16", optional = true }
-payjoin = { version = "0.25.0", default-features = false }
+payjoin = { version = "1.0.0-rc.3", default-features = false }
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"
 reqwest = { version = "0.12.23", default-features = false, features = [

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -28,10 +28,7 @@ icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 lazy_static = "1.5.0"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
-payjoin = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "c528143be31769b03e23bb891d4ec81c5d30c705", features = [
-  "v1",
-  "v2",
-] }
+payjoin = { version = "1.0.0-rc.3", features = ["v1", "v2"] }
 payjoin-test-utils = { version = "0.0.1", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -56,7 +56,7 @@ opentelemetry-otlp = { version = "0.31", optional = true, features = [
   "reqwest-rustls",
 ] }
 opentelemetry_sdk = "0.31"
-payjoin = { version = "0.25.0", features = [
+payjoin = { version = "1.0.0-rc.3", features = [
   "directory",
 ], default-features = false }
 rand = "0.8"

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -31,7 +31,7 @@ corepc-node = { version = "0.10.0", features = ["download", "29_0"] }
 http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "0.25.0", default-features = false }
+payjoin = { version = "1.0.0-rc.3", default-features = false }
 payjoin-mailroom = { path = "../payjoin-mailroom", features = ["_manual-tls"] }
 # Pin to 0.14.7 (last version to support our MSRV 1.85)
 rcgen = { version = "=0.14.7", optional = true }

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Payjoin Changelog
 
+## 1.0.0-rc.3
+
+This release introduces sender and receiver cancel() APIs, fallback typestates for both sender and receiver, merges Cancel/Failure error variants and carves out dedicated errors (CoinSelectionError, DecapsulationError, dedicated create-request error), promotes InMemoryTestPersister to InMemoryPersister while removing NoopSessionPersister, replaces the url crate dependency with an internal Url type, adds is_expired and ErrorCode/WellKnownError::code to the error hierarchy, and removes sender sigs from receiver psbt_to_sign.
+
+Selected Improvements:
+
+### Error Stabilization
+
+- Stabilize 1.0 errors by carving out errors used in state machine control flow & keeping the rest opaque (#1602)
+- Merge `Cancel` and `Failure` variants in sender and receiver (#1607)
+- Rename `EncapsulationError` to `DecapsulationError` (#1601)
+- Rename `SelectionError` to `CoinSelectionError`
+
+### Fallback and Cancel APIs
+
+- Receiver fallback typestate (#1558)
+- Sender Pending Fallback state (#1557)
+- Send `cancel()` (#1496)
+- Receive `cancel()` (#1470)
+- Remove sender sigs from receiver `psbt_to_sign` (#1560)
+
+### Persistence
+
+- Ship `InMemoryPersister`, replacing `NoopSessionPersister` (#1528)
+- Enforce single-owner contract on `InMemoryPersister` (#1534)
+- Document persistence backwards/forwards compatibility consideration (#1465)
+
+### Dependency and API Refinements
+
+- Use internal Url struct to replace the url crate dependency (#1377)
+- Disable `reqwest` dep when `_manual-tls` is enabled (#1484)
+- Use official bitcoind-async-client release (#1441)
+- Update use of deprecated `from_sat_per_vb_unchecked` (#1502)
+- Test utils feature unification (#1599)
+- Not --all-features test suite (#1038)
+
+### Testing and Documentation
+
+- Add tests for `OriginalPayload` and `PsbtContext` (#1583)
+- Light refactor to v2 receiver for readability (#1585)
+- Fix unused results in session unit tests (#1512)
+- Document BIP77 v1 fallback behavior in `create_post_request` (#1593)
+- Remove redundant language from `finalize_proposal` rustdocs (#1567)
+
 ## 0.25.0
 
 Introduce monitoring typestates, replyable error handling, async

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "0.25.0"
+version = "1.0.0-rc.3"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
- "Bump" payjoin crate version from 0.25.0 to 1.0.0-rc.3
- Update all workspace crates that depend on payjoin to reference 1.0.0-rc.3
- Update both Cargo-minimal.lock and Cargo-recent.lock

Deepseek helped organize the PR lists and attribution

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
