### PR TITLE
Decouple test-utils v2 to make payjoin publishable

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -33,7 +33,7 @@ _core = [
 ]
 directory = []
 v1 = ["_core"]
-v2 = ["_core", "hpke", "bhttp", "ohttp", "directory", "payjoin-test-utils/v2"]
+v2 = ["_core", "hpke", "bhttp", "ohttp", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
 _manual-tls = ["rustls"]
@@ -63,7 +63,7 @@ ignored = ["bitcoin-units"]
 
 [dev-dependencies]
 once_cell = "1.21.3"
-payjoin-test-utils = { version = "0.0.1", default-features = false }
+payjoin-test-utils = { path = "../payjoin-test-utils", features = ["v2"] }
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 


### PR DESCRIPTION
The public `v2` feature referenced `payjoin-test-utils/v2`, but payjoin-test-utils is a dev-dependency that itself depends on payjoin. Referencing a dev-dependency feature from a published feature makes the manifest unpublishable: cargo resolves the dev-dependency against crates.io, where no test-utils version exposes `v2`, and none could, since test-utils depends on this still-unpublished payjoin version.

Drop the test-utils edge from the `v2` feature and declare the dev-dependency path-only with `v2` enabled directly. Cargo omits path-only dev-dependencies from the published manifest, so payjoin packages cleanly. The test-utils helpers are only used under cfg(test), so the shipped library is unchanged.

This reintroduces v2 into `--features v1` test builds through feature unification (lib test count rises from 125 to 217), undoing the isolation added in #1599. Restoring that isolation requires splitting payjoin-test-utils and is tracked as a follow-up.

Disclosure: discovered & fixed with Claude code co-authorship

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
