### PR TITLE
Specify version for payjoin-mailroom dependency in test-utils

### DIFF
--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,7 +32,7 @@ http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
 payjoin = { version = "1.0.0-rc.3", default-features = false }
-payjoin-mailroom = { path = "../payjoin-mailroom", features = ["_manual-tls"] }
+payjoin-mailroom = { version = "0.1.1", features = ["_manual-tls"] }
 # Pin to 0.14.7 (last version to support our MSRV 1.85)
 rcgen = { version = "=0.14.7", optional = true }
 reqwest = { version = "0.12.23", default-features = false, features = [


### PR DESCRIPTION
This is more in line with the pattern from other crates afaict.

Publishing payjoin-test-utils failed verification because its payjoin-mailroom dependency specified only a path and no version requirement. Cargo requires every dependency of a published crate to carry a version so the path can be stripped from the uploaded manifest.

Add the version requirement and drop the redundant path. The workspace [patch.crates-io] entry continues to redirect payjoin-mailroom to the local crate for development builds.

Disclosure: discovered & co-authored by Claude Code when `cargo publish --dry-run` at root.

Requesting @chavic's review while he's up and then it'd be good to get @benalleng's eyes before merge because he's taking a look at the published dep tree this week.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
