### PR TITLE
Attach --no-run to the feature gated test runs just to ensure compilation

### DIFF
--- a/payjoin/contrib/test.sh
+++ b/payjoin/contrib/test.sh
@@ -7,6 +7,6 @@ cargo test --locked --package payjoin --verbose --all-features --lib
 cargo test --locked --package payjoin --verbose --all-features --test integration
 
 for feature in "${features[@]}"; do
-    cargo test --locked --package payjoin --verbose --no-default-features --features "$feature" --lib
-    cargo test --locked --package payjoin --verbose --no-default-features --features "$feature" --test integration
+    cargo test --locked --package payjoin --verbose --no-default-features --features "$feature" --lib --no-run
+    cargo test --locked --package payjoin --verbose --no-default-features --features "$feature" --test integration --no-run
 done


### PR DESCRIPTION
Closes #1620

Given that it is not possible to feature gate dev-dependencies following our latest release attempt we should not worry about splitting the relevant test functions into their individual feature sets.  Instead the feature gated test runs should have the `--no-run` flag just to ensure compilation without the use of `--all-features`. Incidentally this also saves a small amount of test time while not affecting our overall coverage.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
