### PR TITLE
Add tests to catch mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -26,6 +26,4 @@ exclude_re = [
   # TODO exclusions
   # payjoin/src/core/receive/v1/mod.rs
   "replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is
-  # payjoin/src/core/send/mod.rs
-  "replace match guard proposed_txout.script_pubkey == original_output.script_pubkey with true in PsbtContext::check_outputs", # This non-deterministic mutation has a possible test to catch it
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -22,8 +22,4 @@ exclude_re = [
   "replace < with <= in PsbtContextBuilder::build_recommended", # clamping the fee contribution when the fee equals to the recommended fee does not do anything
   # payjoin/src/core/receive/v2/mod.rs	 
   "payjoin/src/core/receive/v2.mod.*replace \\* with [+/]$", # This targets mutations on the static TWENTY_FOUR_HOURS_DEFAULT_EXPIRATION that is not particularly useful to test for
-
-  # TODO exclusions
-  # payjoin/src/core/receive/v1/mod.rs
-  "replace > with >= in WantsInputs::avoid_uih", # This mutation I am unsure about whether or not it is a trivial mutant and have not decided on how the best way to approach testing it is
 ]

--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -617,6 +617,25 @@ mod tests {
     }
 
     #[test]
+    fn avoid_uih_selects_candidate_when_min_in_greater_than_min_out() {
+        let original = original_from_test_vector();
+        let wants_inputs = WantsOutputs::new(original, vec![0]).commit_outputs();
+        let candidate = candidate_input_from_test_vector(Amount::from_sat(3_000_000));
+        let result = wants_inputs.avoid_uih(std::slice::from_ref(&candidate));
+        assert_eq!(result.unwrap(), candidate);
+    }
+
+    #[test]
+    fn try_preserving_privacy_falls_back_when_min_in_equals_min_out() {
+        let original = original_from_test_vector();
+        let wants_inputs = WantsOutputs::new(original, vec![0]).commit_outputs();
+        let small = candidate_input_from_test_vector(Amount::ONE_SAT);
+        let boundary = candidate_input_from_test_vector(Amount::from_sat(2_000_000));
+        let result = wants_inputs.try_preserving_privacy([small.clone(), boundary.clone()]);
+        assert_eq!(result.unwrap(), small);
+    }
+
+    #[test]
     fn try_preserving_privacy_falls_back_when_avoid_uih_unsupported() {
         let original = original_from_test_vector();
         let mut wants_inputs = WantsOutputs::new(original, vec![0]).commit_outputs();

--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -500,12 +500,12 @@ mod tests {
     use bitcoin::hashes::Hash;
     use bitcoin::key::rand::rngs::StdRng;
     use bitcoin::key::rand::SeedableRng;
-    use bitcoin::psbt::Input;
+    use bitcoin::psbt::{Input, PsbtSighashType};
     use bitcoin::secp256k1::Secp256k1;
     use bitcoin::taproot::LeafVersion;
     use bitcoin::{
-        Amount, Network, OutPoint, PubkeyHash, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn,
-        TxOut, Weight,
+        Amount, Network, OutPoint, PubkeyHash, ScriptBuf, Sequence, TapLeafHash, TapNodeHash,
+        Transaction, TxIn, TxOut, Weight, Witness,
     };
     use payjoin_test_utils::{DUMMY20, RECEIVER_INPUT_CONTRIBUTION};
 
@@ -862,6 +862,15 @@ mod tests {
         assert_eq!(p2tr_proposal.additional_input_weight(), Weight::from_wu(230));
     }
 
+    fn run_prepare_psbt(processed_psbt: Psbt) -> Psbt {
+        let psbt_context = WantsOutputs::new(original_from_test_vector(), vec![0])
+            .commit_outputs()
+            .commit_inputs()
+            .calculate_psbt_context_with_fee_range(None, None)
+            .expect("Contributed inputs should allow for valid fee contributions");
+        psbt_context.finalize_proposal(|_| Ok(processed_psbt.clone())).expect("Valid psbt")
+    }
+
     #[test]
     fn test_prepare_psbt_excludes_keypaths() {
         let original = original_from_test_vector();
@@ -901,26 +910,110 @@ mod tests {
             output.tap_internal_key = Some(x_only);
         }
 
-        let psbt_context = WantsOutputs::new(original_from_test_vector(), vec![0])
-            .commit_outputs()
-            .commit_inputs()
-            .calculate_psbt_context_with_fee_range(None, None)
-            .expect("Contributed inputs should allow for valid fee contributions");
-        let payjoin_proposal =
-            psbt_context.finalize_proposal(|_| Ok(processed_psbt.clone())).expect("Valid psbt");
+        let result = run_prepare_psbt(processed_psbt);
 
-        assert!(payjoin_proposal.xpub.is_empty());
-
-        for input in &payjoin_proposal.inputs {
+        assert!(result.xpub.is_empty());
+        for input in &result.inputs {
             assert!(input.bip32_derivation.is_empty());
             assert!(input.tap_key_origins.is_empty());
             assert!(input.tap_internal_key.is_none());
         }
-
-        for output in &payjoin_proposal.outputs {
+        for output in &result.outputs {
             assert!(output.bip32_derivation.is_empty());
             assert!(output.tap_key_origins.is_empty());
             assert!(output.tap_internal_key.is_none());
+        }
+    }
+
+    #[test]
+    fn test_prepare_psbt_preserves_input_fields() {
+        let original = original_from_test_vector();
+        let mut processed_psbt = original.psbt.clone();
+        let dummy_tx = processed_psbt.unsigned_tx.clone();
+
+        for input in &mut processed_psbt.inputs {
+            input.witness_utxo =
+                Some(TxOut { value: Amount::from_sat(100_000), script_pubkey: ScriptBuf::new() });
+            input.non_witness_utxo = Some(dummy_tx.clone());
+            input.final_script_sig = Some(ScriptBuf::from(vec![0x00, 0x01, 0x02]));
+            input.final_script_witness = Some(Witness::from_slice(&[&[0x03, 0x04, 0x05]]));
+        }
+
+        let result = run_prepare_psbt(processed_psbt);
+
+        for input in &result.inputs {
+            assert!(input.witness_utxo.is_some());
+            assert!(input.non_witness_utxo.is_some());
+            assert!(input.final_script_sig.is_some());
+            assert!(input.final_script_witness.is_some());
+        }
+    }
+
+    #[test]
+    fn test_prepare_psbt_strips_metadata() {
+        let original = original_from_test_vector();
+        let mut processed_psbt = original.psbt.clone();
+        let secp = Secp256k1::new();
+        let (_, pk) = secp.generate_keypair(&mut bitcoin::key::rand::thread_rng());
+        let (x_only, _) = pk.x_only_public_key();
+
+        for input in &mut processed_psbt.inputs {
+            input.sighash_type = Some(PsbtSighashType::from_u32(0x01));
+            input.tap_key_sig =
+                Some(bitcoin::taproot::Signature::from_slice(&[42u8; 64]).expect("valid sig"));
+            let sig = bitcoin::taproot::Signature::from_slice(&[42u8; 64]).expect("valid sig");
+            input.tap_script_sigs.insert(
+                (x_only, TapLeafHash::from_script(&ScriptBuf::new(), LeafVersion::TapScript)),
+                sig,
+            );
+            input.tap_merkle_root =
+                Some(TapNodeHash::from_slice(&[42u8; 32]).expect("valid tap node hash"));
+            input.bip32_derivation.insert(pk, (Fingerprint::default(), DerivationPath::default()));
+            input.tap_key_origins.insert(
+                x_only,
+                (
+                    vec![TapLeafHash::from_script(&ScriptBuf::new(), LeafVersion::TapScript)],
+                    (Fingerprint::default(), DerivationPath::default()),
+                ),
+            );
+            input.tap_internal_key = Some(x_only);
+            input.redeem_script = Some(ScriptBuf::new());
+            input.witness_script = Some(ScriptBuf::new());
+        }
+
+        for output in &mut processed_psbt.outputs {
+            output.bip32_derivation.insert(pk, (Fingerprint::default(), DerivationPath::default()));
+            output.tap_key_origins.insert(
+                x_only,
+                (
+                    vec![TapLeafHash::from_script(&ScriptBuf::new(), LeafVersion::TapScript)],
+                    (Fingerprint::default(), DerivationPath::default()),
+                ),
+            );
+            output.tap_internal_key = Some(x_only);
+            output.redeem_script = Some(ScriptBuf::new());
+            output.witness_script = Some(ScriptBuf::new());
+        }
+
+        let result = run_prepare_psbt(processed_psbt);
+
+        for input in &result.inputs {
+            assert!(input.sighash_type.is_none());
+            assert!(input.tap_key_sig.is_none());
+            assert!(input.tap_script_sigs.is_empty());
+            assert!(input.tap_merkle_root.is_none());
+            assert!(input.bip32_derivation.is_empty());
+            assert!(input.tap_key_origins.is_empty());
+            assert!(input.tap_internal_key.is_none());
+            assert!(input.redeem_script.is_none());
+            assert!(input.witness_script.is_none());
+        }
+        for output in &result.outputs {
+            assert!(output.bip32_derivation.is_empty());
+            assert!(output.tap_key_origins.is_empty());
+            assert!(output.tap_internal_key.is_none());
+            assert!(output.redeem_script.is_none());
+            assert!(output.witness_script.is_none());
         }
     }
 }

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -272,12 +272,8 @@ impl PsbtContext {
             filtered_psbt.inputs.push(bitcoin::psbt::Input {
                 witness_utxo: input.witness_utxo.clone(),
                 non_witness_utxo: input.non_witness_utxo.clone(),
-                sighash_type: input.sighash_type,
                 final_script_sig: input.final_script_sig.clone(),
                 final_script_witness: input.final_script_witness.clone(),
-                tap_key_sig: input.tap_key_sig,
-                tap_script_sigs: input.tap_script_sigs.clone(),
-                tap_merkle_root: input.tap_merkle_root,
                 ..Default::default()
             });
         }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1578,7 +1578,7 @@ pub(crate) fn pj_uri<'a>(
 pub mod test {
     use std::str::FromStr;
 
-    use bitcoin::{FeeRate, ScriptBuf, Witness};
+    use bitcoin::{Amount, FeeRate, ScriptBuf, Witness};
     use once_cell::sync::Lazy;
     use payjoin_test_utils::{
         BoxError, EXAMPLE_URL, KEM, KEY_ID, ORIGINAL_PSBT, PARSED_ORIGINAL_PSBT,
@@ -2233,6 +2233,36 @@ pub mod test {
             Receiver { state: provisional_proposal, session_context: SHARED_CONTEXT.clone() };
         let psbt = receiver.psbt_to_sign();
         assert_eq!(psbt, PARSED_PAYJOIN_PROPOSAL.clone());
+    }
+
+    #[test]
+    fn test_builder_with_amount() {
+        let persister = InMemoryPersister::default();
+        let amount = Amount::from_sat(100_000);
+        let receiver = ReceiverBuilder::new(
+            SHARED_CONTEXT.address.clone(),
+            SHARED_CONTEXT.directory.as_str(),
+            SHARED_CONTEXT.ohttp_keys.clone(),
+        )
+        .expect("constructor on test vector should not fail")
+        .with_amount(amount)
+        .build()
+        .save(&persister)
+        .expect("Persister shouldn't fail");
+
+        assert_eq!(receiver.session_context.amount, Some(amount));
+
+        let receiver = ReceiverBuilder::new(
+            SHARED_CONTEXT.address.clone(),
+            SHARED_CONTEXT.directory.as_str(),
+            SHARED_CONTEXT.ohttp_keys.clone(),
+        )
+        .expect("constructor on test vector should not fail")
+        .build()
+        .save(&persister)
+        .expect("Persister shouldn't fail");
+
+        assert_eq!(receiver.session_context.amount, None);
     }
 
     #[test]

--- a/payjoin/src/core/send/mod.rs
+++ b/payjoin/src/core/send/mod.rs
@@ -1421,6 +1421,38 @@ mod test {
         }
 
         #[test]
+        fn test_process_proposal_rejects_different_script_in_our_output() -> Result<(), BoxError> {
+            let mut ctx = create_psbt_context()?;
+            ctx.fee_contribution = None;
+            ctx.output_substitution = OutputSubstitution::Enabled;
+
+            let mut proposal = PARSED_PAYJOIN_PROPOSAL.clone();
+            let original_change = &ctx.original_psbt.unsigned_tx.output[0];
+            assert_ne!(original_change.script_pubkey, ctx.payee);
+
+            let change_pos = proposal
+                .unsigned_tx
+                .output
+                .iter()
+                .position(|o| o.script_pubkey == original_change.script_pubkey)
+                .expect("proposal should contain the change output");
+
+            // Replace the change output with one that has a different script
+            // but the same value, so the mutation would cause arm 3 to match
+            // and the value guard would pass (value >= original.value = true).
+            let dummy_script =
+                ScriptBuf::from_hex("0014ffffffffffffffffffffffffffffffffffffffffff")?;
+            proposal.unsigned_tx.output[change_pos] =
+                TxOut { value: original_change.value, script_pubkey: dummy_script };
+            assert!(
+                ctx.process_proposal(proposal).is_err(),
+                "arm 3 must reject script mismatch in our output"
+            );
+
+            Ok(())
+        }
+
+        #[test]
         fn test_process_proposal_when_output_missing() -> Result<(), BoxError> {
             let ctx = create_psbt_context()?;
             let mut proposal: bitcoin::Psbt = PARSED_PAYJOIN_PROPOSAL.clone();

--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -434,6 +434,17 @@ mod test {
     }
 
     #[test]
+    fn test_always_disable_output_substitution() {
+        let mut pj_uri = pj_uri();
+        pj_uri.extras.output_substitution = OutputSubstitution::Enabled;
+        let sender = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri)
+            .always_disable_output_substitution()
+            .build_recommended(FeeRate::BROADCAST_MIN)
+            .expect("sender should succeed");
+        assert_eq!(sender.psbt_ctx.output_substitution, OutputSubstitution::Disabled);
+    }
+
+    #[test]
     fn handle_json_errors() {
         let ctx = create_v1_context();
         let known_json_error = serde_json::json!({


### PR DESCRIPTION
```
$ cargo mutants -j4
Found 633 mutants to test
ok       Unmutated baseline in 41s build + 7s test
 INFO Auto-set test timeout to 36s
633 mutants tested in 18m: 407 caught, 226 unviable
```

Closes #1689
Closes #778 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
