### PR TITLE
Fix commented test assert

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -2052,10 +2052,10 @@ pub mod test {
             .process_error_response(&response, ctx)
             .save(&persister)
             .expect_err("fatal response should error");
-        let pending_fallback = err.error_state().expect("pending fallback should be carried");
 
+        assert!(err.api_error_ref().is_some());
+        let pending_fallback = err.error_state().expect("pending fallback should be carried");
         assert_eq!(pending_fallback.fallback_tx(), &expected_tx);
-        // assert!(err.api_error_ref().is_some());
         assert_events(&persister, &[SessionEvent::ProtocolFailed], false);
         Ok(())
     }


### PR DESCRIPTION
### Summary

Small follow up introduced by https://github.com/payjoin/rust-payjoin/pull/1558. Uncomments an assert in the `process_error_response_fatal_with_fallback_enters_pending_fallback` unit test.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
