### PR TITLE
Fix check_payment docstring

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1479,7 +1479,7 @@ impl Receiver<Monitor> {
     /// For example, the condition can be if the transaction has been broadcast to the
     /// network, or if it has some number of confirmations on the blockchain.
     ///
-    /// If the receiver input address type in the fallback transaction is non-SegWit, then this
+    /// If the input address type in the fallback transaction is non-SegWit, then this
     /// function will directly conclude the Payjoin session with a Success without running the
     /// provided `transaction_exists` closure. `transaction_exists` uses the transaction ID to
     /// search for the transaction in the network. Since a non-SegWit input signature is going to


### PR DESCRIPTION
### Summary

Fixes and `check_payment` inaccurate docstring by removing reference to receiver inputs being in the fallback tx (there are not receiver inputs in the fallback tx). Inaccuracy first identified in https://github.com/payjoin/rust-payjoin/issues/1548.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
