### PR TITLE
Document payjoin cli supported bitcoind versions

### DIFF
--- a/payjoin-cli/README.md
+++ b/payjoin-cli/README.md
@@ -11,6 +11,8 @@ transactions via `bitcoind`. By default it supports Payjoin v2, which is
 backwards compatible with v1. Enable the `v1` feature to disable Payjoin v2 to
 send and receive using only v1.
 
+This tool supports bitcoin core versions 29.0 and above as we depend on [bitcoind-async-client](https://github.com/alpenlabs/bitcoind-async-client) for our bitcoin client API.
+
 While this code and design have had significant testing, it is still alpha-quality experimental software. Use at your own risk.
 
 Independent audit is welcome.


### PR DESCRIPTION
Closes #1383 

This documents the payjoin-cli bitcoind support is tied to bitcoind-async-client

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
