### PR TITLE
Add issue open comment in contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,6 +34,8 @@ Good documentation is essential to understanding what PDK does and how to use it
 
 If you're looking for somewhere to start contributing code changes, see the [good first issue](https://github.com/payjoin/rust-payjoin/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) list. If you intend to start working on an issue, please leave a comment stating your intent.
 
+If you find a perceived issue like a bug or existing `// TODO` comment, please open an issue first to ensure that the behavior you wish to change can be agreed upon before you sit down to write the fix in earnest.
+
 To contribute a code change:
 
 1. [Fork the repository](https://github.com/payjoin/rust-payjoin/fork).


### PR DESCRIPTION
A minor behavioral suggestion to try and resolve some bad patterns that arose around #1482 namely fixes on perceived issues without fully understanding the required fix. Namely, todo comments can get outdated quickly or simply be under-cooked. There is a reason they were not added as actual code in the first place.

While this did actually happen with #1472 the PR #1473 was opened immediately afterwards. I suppose the only thing to drive home is that there should be some agreement about the fix first.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
