### PR TITLE
refactor(cli): consolidate relay logic in `RelayManager`

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use payjoin::bitcoin::consensus::encode::serialize_hex;
@@ -42,7 +42,7 @@ pub(crate) struct App {
     db: Arc<Database>,
     wallet: BitcoindWallet,
     interrupt: watch::Receiver<()>,
-    relay_manager: Arc<Mutex<RelayManager>>,
+    relay_manager: RelayManager,
 }
 
 trait StatusText {
@@ -142,7 +142,7 @@ impl<Status: StatusText> fmt::Display for SessionHistoryRow<Status> {
 impl AppTrait for App {
     async fn new(config: Config) -> Result<Self> {
         let db = Arc::new(Database::create(&config.db_path)?);
-        let relay_manager = Arc::new(Mutex::new(RelayManager::new(config.clone())));
+        let relay_manager = RelayManager::new(config.clone());
         let (interrupt_tx, interrupt_rx) = watch::channel(());
         tokio::spawn(handle_interrupt(interrupt_tx));
         let wallet = BitcoindWallet::new(&config.bitcoind).await?;
@@ -1059,17 +1059,13 @@ impl App {
         E: Into<anyhow::Error>,
     {
         loop {
-            let relay =
-                self.relay_manager.lock().expect("Lock should not be poisoned").choose_relay()?;
+            let relay = self.relay_manager.choose_relay()?;
             let (req, ctx) = build(relay.as_str()).map_err(Into::into)?;
             match self.post_request(req).await {
                 Ok(resp) => return Ok((resp, ctx)),
                 Err(e) => {
                     tracing::debug!("Request to relay {relay} failed: {e:?}");
-                    self.relay_manager
-                        .lock()
-                        .expect("Lock should not be poisoned")
-                        .add_failed_relay(relay);
+                    self.relay_manager.add_failed_relay(relay);
                 }
             }
         }

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -23,7 +23,7 @@ use tokio::sync::watch;
 use super::config::Config;
 use super::wallet::BitcoindWallet;
 use super::App as AppTrait;
-use crate::app::v2::ohttp::{unwrap_ohttp_keys_or_else_fetch, RelayManager};
+use crate::app::v2::ohttp::RelayManager;
 use crate::app::{handle_interrupt, http_agent};
 use crate::cli::Role as CliRole;
 use crate::db::v2::{ReceiverPersister, SenderPersister, SessionId};
@@ -278,9 +278,7 @@ impl AppTrait for App {
 
     async fn receive_payjoin(&self, amount: Amount) -> Result<()> {
         let address = self.wallet().get_new_address()?;
-        let ohttp_keys = unwrap_ohttp_keys_or_else_fetch(&self.config, self.relay_manager.clone())
-            .await?
-            .ohttp_keys;
+        let ohttp_keys = self.relay_manager.unwrap_ohttp_keys_or_else_fetch().await?.ohttp_keys;
         let persister = ReceiverPersister::new(self.db.clone())?;
         let mut receiver_builder =
             ReceiverBuilder::new(address, self.config.v2()?.pj_directory.as_str(), ohttp_keys)?

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -46,7 +46,7 @@ impl RelayManager {
             .ok_or_else(|| anyhow!("Failed to select from remaining relays"))
     }
 
-    pub async fn unwrap_ohttp_keys_or_else_fetch(&self) -> Result<ValidatedOhttpKeys> {
+    pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(&self) -> Result<ValidatedOhttpKeys> {
         if let Some(ohttp_keys) = self.config.v2()?.ohttp_keys.clone() {
             return Ok(ValidatedOhttpKeys { ohttp_keys });
         }

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -46,6 +46,13 @@ impl RelayManager {
             .ok_or_else(|| anyhow!("Failed to select from remaining relays"))
     }
 
+    pub async fn unwrap_ohttp_keys_or_else_fetch(&self) -> Result<ValidatedOhttpKeys> {
+        if let Some(ohttp_keys) = self.config.v2()?.ohttp_keys.clone() {
+            return Ok(ValidatedOhttpKeys { ohttp_keys });
+        }
+        self.fetch_ohttp_keys().await
+    }
+
     async fn fetch_ohttp_keys(&self) -> Result<ValidatedOhttpKeys> {
         let payjoin_directory = &self.config.v2()?.pj_directory;
 
@@ -92,14 +99,4 @@ impl RelayManager {
 
 pub(crate) struct ValidatedOhttpKeys {
     pub(crate) ohttp_keys: payjoin::OhttpKeys,
-}
-
-pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
-    config: &Config,
-    relay_manager: RelayManager,
-) -> Result<ValidatedOhttpKeys> {
-    if let Some(ohttp_keys) = config.v2()?.ohttp_keys.clone() {
-        return Ok(ValidatedOhttpKeys { ohttp_keys });
-    }
-    relay_manager.fetch_ohttp_keys().await
 }

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -45,6 +45,49 @@ impl RelayManager {
             .cloned()
             .ok_or_else(|| anyhow!("Failed to select from remaining relays"))
     }
+
+    async fn fetch_ohttp_keys(&self) -> Result<ValidatedOhttpKeys> {
+        let payjoin_directory = &self.config.v2()?.pj_directory;
+
+        loop {
+            let selected_relay = self.choose_relay()?;
+
+            let ohttp_keys = {
+                #[cfg(feature = "_manual-tls")]
+                {
+                    if let Some(cert_path) = self.config.root_certificate.as_ref() {
+                        let cert_der = std::fs::read(cert_path)?;
+                        payjoin::io::fetch_ohttp_keys_with_cert(
+                            selected_relay.as_str(),
+                            payjoin_directory.as_str(),
+                            &cert_der,
+                        )
+                        .await
+                    } else {
+                        payjoin::io::fetch_ohttp_keys(
+                            selected_relay.as_str(),
+                            payjoin_directory.as_str(),
+                        )
+                        .await
+                    }
+                }
+                #[cfg(not(feature = "_manual-tls"))]
+                payjoin::io::fetch_ohttp_keys(selected_relay.as_str(), payjoin_directory.as_str())
+                    .await
+            };
+
+            match ohttp_keys {
+                Ok(keys) => return Ok(ValidatedOhttpKeys { ohttp_keys: keys }),
+                Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
+                    return Err(payjoin::io::Error::UnexpectedStatusCode(e).into());
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to connect to relay: {selected_relay}, {e:?}");
+                    self.add_failed_relay(selected_relay);
+                }
+            }
+        }
+    }
 }
 
 pub(crate) struct ValidatedOhttpKeys {
@@ -58,50 +101,5 @@ pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
     if let Some(ohttp_keys) = config.v2()?.ohttp_keys.clone() {
         return Ok(ValidatedOhttpKeys { ohttp_keys });
     }
-    fetch_ohttp_keys(config, relay_manager).await
-}
-
-async fn fetch_ohttp_keys(
-    config: &Config,
-    relay_manager: RelayManager,
-) -> Result<ValidatedOhttpKeys> {
-    let payjoin_directory = config.v2()?.pj_directory.clone();
-
-    loop {
-        let selected_relay = relay_manager.choose_relay()?;
-
-        let ohttp_keys = {
-            #[cfg(feature = "_manual-tls")]
-            {
-                if let Some(cert_path) = config.root_certificate.as_ref() {
-                    let cert_der = std::fs::read(cert_path)?;
-                    payjoin::io::fetch_ohttp_keys_with_cert(
-                        selected_relay.as_str(),
-                        payjoin_directory.as_str(),
-                        &cert_der,
-                    )
-                    .await
-                } else {
-                    payjoin::io::fetch_ohttp_keys(
-                        selected_relay.as_str(),
-                        payjoin_directory.as_str(),
-                    )
-                    .await
-                }
-            }
-            #[cfg(not(feature = "_manual-tls"))]
-            payjoin::io::fetch_ohttp_keys(selected_relay.as_str(), payjoin_directory.as_str()).await
-        };
-
-        match ohttp_keys {
-            Ok(keys) => return Ok(ValidatedOhttpKeys { ohttp_keys: keys }),
-            Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
-                return Err(payjoin::io::Error::UnexpectedStatusCode(e).into());
-            }
-            Err(e) => {
-                tracing::debug!("Failed to connect to relay: {selected_relay}, {e:?}");
-                relay_manager.add_failed_relay(selected_relay);
-            }
-        }
-    }
+    relay_manager.fetch_ohttp_keys().await
 }

--- a/payjoin-cli/src/app/v2/ohttp.rs
+++ b/payjoin-cli/src/app/v2/ohttp.rs
@@ -17,19 +17,24 @@ use super::Config;
 #[derive(Debug, Clone)]
 pub struct RelayManager {
     config: Config,
-    failed_relays: Vec<Url>,
+    failed_relays: Arc<Mutex<Vec<Url>>>,
 }
 
 impl RelayManager {
-    pub fn new(config: Config) -> Self { RelayManager { config, failed_relays: Vec::new() } }
+    pub fn new(config: Config) -> Self {
+        RelayManager { config, failed_relays: Arc::new(Mutex::new(Vec::new())) }
+    }
 
-    pub fn add_failed_relay(&mut self, relay: Url) { self.failed_relays.push(relay); }
+    pub fn add_failed_relay(&self, relay: Url) {
+        self.failed_relays.lock().expect("Lock should not be poisoned").push(relay);
+    }
 
     pub fn choose_relay(&self) -> Result<Url> {
         use payjoin::bitcoin::secp256k1::rand::prelude::SliceRandom;
-        let relays = self.config.v2()?.ohttp_relays.clone();
+        let relays = &self.config.v2()?.ohttp_relays;
+        let failed_relays = self.failed_relays.lock().expect("Lock should not be poisoned");
         let remaining_relays: Vec<_> =
-            relays.iter().filter(|r| !self.failed_relays.contains(r)).cloned().collect();
+            relays.iter().filter(|r| !failed_relays.contains(r)).cloned().collect();
 
         if remaining_relays.is_empty() {
             return Err(anyhow!("No valid relays available"));
@@ -48,7 +53,7 @@ pub(crate) struct ValidatedOhttpKeys {
 
 pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
     config: &Config,
-    relay_manager: Arc<Mutex<RelayManager>>,
+    relay_manager: RelayManager,
 ) -> Result<ValidatedOhttpKeys> {
     if let Some(ohttp_keys) = config.v2()?.ohttp_keys.clone() {
         return Ok(ValidatedOhttpKeys { ohttp_keys });
@@ -58,13 +63,12 @@ pub(crate) async fn unwrap_ohttp_keys_or_else_fetch(
 
 async fn fetch_ohttp_keys(
     config: &Config,
-    relay_manager: Arc<Mutex<RelayManager>>,
+    relay_manager: RelayManager,
 ) -> Result<ValidatedOhttpKeys> {
     let payjoin_directory = config.v2()?.pj_directory.clone();
 
     loop {
-        let selected_relay =
-            relay_manager.lock().expect("Lock should not be poisoned").choose_relay()?;
+        let selected_relay = relay_manager.choose_relay()?;
 
         let ohttp_keys = {
             #[cfg(feature = "_manual-tls")]
@@ -96,10 +100,7 @@ async fn fetch_ohttp_keys(
             }
             Err(e) => {
                 tracing::debug!("Failed to connect to relay: {selected_relay}, {e:?}");
-                relay_manager
-                    .lock()
-                    .expect("Lock should not be poisoned")
-                    .add_failed_relay(selected_relay);
+                relay_manager.add_failed_relay(selected_relay);
             }
         }
     }


### PR DESCRIPTION
Relates to #1582

Done per the plan from https://github.com/payjoin/rust-payjoin/issues/1582#issuecomment-4662619802:
- Drop the `Arc<Mutex<>>` wrapper around `RelayManager`
- Put `Arc<Mutex<>>` on the `failed_relays` field instead
- Move the functions into `&self` methods on `RelayManager`

The original plan mentioned three functions, but `App::unwrap_relay_or_else_fetch` was turned into `App::post_via_relay` in #1628, so only two methods were moved here. It could be worth moving `post_via_relay` into `RelayManager` as well, but I'd suggest leaving that out of the scope of this PR.

Commands to verify the function moves (bash/zsh; strips the method's extra `impl` indent so only the signature/`self`-receiver changes show up). `b28a1d8e` is the master tip this branch is based on, pinned so the line ranges stay valid:

`fetch_ohttp_keys`:

```bash
diff -u \
  <(git show b28a1d8e:payjoin-cli/src/app/v2/ohttp.rs | sed -n '59,106p') \
  <(git show HEAD:payjoin-cli/src/app/v2/ohttp.rs      | sed -n '56,97p' | sed 's/^    //')
```

`unwrap_ohttp_keys_or_else_fetch`:

```bash
diff -u \
  <(git show b28a1d8e:payjoin-cli/src/app/v2/ohttp.rs | sed -n '49,57p') \
  <(git show HEAD:payjoin-cli/src/app/v2/ohttp.rs      | sed -n '49,54p' | sed 's/^    //')
```

Disclosure: code written by hand, Claude was used for review and discussion.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>


