### PR TITLE
Constrain bitcoind client API version

### DIFF
--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -28,7 +28,7 @@ v2 = ["payjoin/v2", "payjoin/io"]
 [dependencies]
 anyhow = "1.0.99"
 async-trait = "0.1.89"
-bitcoind-async-client = "0.10.8"
+bitcoind-async-client = ">=0.10.8, <0.10.10"
 clap = { version = "4.5.45", features = ["derive"] }
 config = "0.15.14"
 dirs = "6.0.0"


### PR DESCRIPTION
breaking change got released as a point release in bitcoind-async-client accidentally
- see https://github.com/alpenlabs/bitcoind-async-client/issues/124

This constraint fixes that. Discovered in #1610 


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
