### PR TITLE
Use time-based uuid instead of raw increment for session ids

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2930,6 +2930,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -52,6 +52,7 @@ tokio-rustls = { version = "0.26.4", features = [
 ], default-features = false, optional = true }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+uuid = { version = "1.18.0", features = ["v7"] }
 
 # Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -239,6 +239,7 @@ impl AppTrait for App {
                         (SendSession::WithReplyKey(sender), persister)
                     }
                 };
+                println!("Send session established: {}", persister.session_id());
                 let mut interrupt = self.interrupt.clone();
                 tokio::select! {
                     res = self.process_sender_session(sender_state, &persister) => {
@@ -290,7 +291,7 @@ impl AppTrait for App {
         }
         let session = receiver_builder.build().save(&persister)?;
 
-        println!("Receive session established");
+        println!("Receive session established: {}", persister.session_id());
         let pj_uri = session.pj_uri();
         println!("Request Payjoin by sharing this Payjoin Uri:");
         println!("{pj_uri}");

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -493,12 +493,19 @@ impl AppTrait for App {
             }
         });
 
-        // Print receiver and sender rows separately
+        // Collect every row (active + inactive, sender + receiver), sort by
+        // session id, and print in a single stable order regardless of which
+        // table or active/inactive bucket the row came from.
+        let mut rows: Vec<(SessionId, String)> = Vec::new();
         for row in send_rows {
-            println!("{row}");
+            rows.push((row.session_id.clone(), format!("{row}")));
         }
         for row in recv_rows {
-            println!("{row}");
+            rows.push((row.session_id.clone(), format!("{row}")));
+        }
+        rows.sort_by_key(|(id, _)| id.clone());
+        for (_, line) in rows {
+            println!("{line}");
         }
 
         Ok(())

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -137,7 +137,7 @@ pub enum Commands {
     Cancel {
         /// The session ID to cancel
         #[arg(required = true)]
-        session_id: i64,
+        session_id: String,
 
         /// Cancel without broadcasting the fallback transaction
         #[arg(long = "no-broadcast")]

--- a/payjoin-cli/src/db/mod.rs
+++ b/payjoin-cli/src/db/mod.rs
@@ -40,7 +40,7 @@ impl Database {
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS send_sessions (
-                session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT PRIMARY KEY,
                 pj_uri TEXT NOT NULL,
                 receiver_pubkey BLOB NOT NULL,
                 completed_at INTEGER
@@ -50,7 +50,7 @@ impl Database {
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS receive_sessions (
-                session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT PRIMARY KEY,
                 completed_at INTEGER
             )",
             [],
@@ -59,7 +59,7 @@ impl Database {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS send_session_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id INTEGER NOT NULL,
+                session_id TEXT NOT NULL,
                 event_data TEXT NOT NULL,
                 created_at INTEGER NOT NULL,
                 FOREIGN KEY(session_id) REFERENCES send_sessions(session_id)
@@ -70,7 +70,7 @@ impl Database {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS receive_session_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id INTEGER NOT NULL,
+                session_id TEXT NOT NULL,
                 event_data TEXT NOT NULL,
                 created_at INTEGER NOT NULL,
                 FOREIGN KEY(session_id) REFERENCES receive_sessions(session_id)

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -8,7 +8,7 @@ use rusqlite::params;
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct SessionId(pub(crate) uuid::Uuid);
 
 impl std::fmt::Display for SessionId {

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -8,13 +8,8 @@ use rusqlite::params;
 
 use super::*;
 
-#[derive(Debug, Clone)]
-pub(crate) struct SessionId(pub(crate) i64);
-
-impl core::ops::Deref for SessionId {
-    type Target = i64;
-    fn deref(&self) -> &Self::Target { &self.0 }
-}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionId(pub(crate) uuid::Uuid);
 
 impl std::fmt::Display for SessionId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.0) }
@@ -50,11 +45,10 @@ impl SenderPersister {
             return Err(Error::DuplicateSendSession(DuplicateKind::ReceiverPubkey));
         }
 
-        // Create a new session in send_sessions and get its ID
-        let session_id: i64 = conn.query_row(
-            "INSERT INTO send_sessions (pj_uri, receiver_pubkey) VALUES (?1, ?2) RETURNING session_id",
-            params![pj_uri, &receiver_pubkey_bytes],
-            |row| row.get(0),
+        let session_id = uuid::Uuid::now_v7();
+        conn.execute(
+            "INSERT INTO send_sessions (session_id, pj_uri, receiver_pubkey) VALUES (?1, ?2, ?3)",
+            params![session_id.to_string(), pj_uri, &receiver_pubkey_bytes],
         )?;
 
         Ok(Self { db, session_id: SessionId(session_id) })
@@ -77,7 +71,7 @@ impl SessionPersister for SenderPersister {
 
         conn.execute(
             "INSERT INTO send_session_events (session_id, event_data, created_at) VALUES (?1, ?2, ?3)",
-            params![*self.session_id, event_data, now()],
+            params![self.session_id.0.to_string(), event_data, now()],
         )?;
 
         Ok(())
@@ -92,7 +86,7 @@ impl SessionPersister for SenderPersister {
             "SELECT event_data FROM send_session_events WHERE session_id = ?1 ORDER BY id ASC",
         )?;
 
-        let event_rows = stmt.query_map(params![*self.session_id], |row| {
+        let event_rows = stmt.query_map(params![self.session_id.0.to_string()], |row| {
             let event_data: String = row.get(0)?;
             Ok(event_data)
         })?;
@@ -113,7 +107,7 @@ impl SessionPersister for SenderPersister {
 
         conn.execute(
             "UPDATE send_sessions SET completed_at = ?1 WHERE session_id = ?2",
-            params![now(), *self.session_id],
+            params![now(), self.session_id.0.to_string()],
         )?;
 
         Ok(())
@@ -130,11 +124,10 @@ impl ReceiverPersister {
     pub fn new(db: Arc<Database>) -> crate::db::Result<Self> {
         let conn = db.get_connection()?;
 
-        // Create a new session in receive_sessions and get its ID
-        let session_id: i64 = conn.query_row(
-            "INSERT INTO receive_sessions (session_id) VALUES (NULL) RETURNING session_id",
-            [],
-            |row| row.get(0),
+        let session_id = uuid::Uuid::now_v7();
+        conn.execute(
+            "INSERT INTO receive_sessions (session_id) VALUES (?1)",
+            params![session_id.to_string()],
         )?;
 
         Ok(Self { db, session_id: SessionId(session_id) })
@@ -158,7 +151,7 @@ impl SessionPersister for ReceiverPersister {
 
         conn.execute(
             "INSERT INTO receive_session_events (session_id, event_data, created_at) VALUES (?1, ?2, ?3)",
-            params![*self.session_id, event_data, now()],
+            params![self.session_id.0.to_string(), event_data, now()],
         )?;
 
         Ok(())
@@ -175,7 +168,7 @@ impl SessionPersister for ReceiverPersister {
             "SELECT event_data FROM receive_session_events WHERE session_id = ?1 ORDER BY id ASC",
         )?;
 
-        let event_rows = stmt.query_map(params![*self.session_id], |row| {
+        let event_rows = stmt.query_map(params![self.session_id.0.to_string()], |row| {
             let event_data: String = row.get(0)?;
             Ok(event_data)
         })?;
@@ -196,7 +189,7 @@ impl SessionPersister for ReceiverPersister {
 
         conn.execute(
             "UPDATE receive_sessions SET completed_at = ?1 WHERE session_id = ?2",
-            params![now(), *self.session_id],
+            params![now(), self.session_id.0.to_string()],
         )?;
 
         Ok(())
@@ -210,7 +203,9 @@ impl Database {
             conn.prepare("SELECT session_id FROM receive_sessions WHERE completed_at IS NULL")?;
 
         let session_rows = stmt.query_map([], |row| {
-            let session_id: i64 = row.get(0)?;
+            let session_id: String = row.get(0)?;
+            let session_id = uuid::Uuid::parse_str(&session_id)
+                .expect("Database corruption: invalid session_id UUID");
             Ok(SessionId(session_id))
         })?;
 
@@ -229,7 +224,9 @@ impl Database {
             conn.prepare("SELECT session_id FROM send_sessions WHERE completed_at IS NULL")?;
 
         let session_rows = stmt.query_map([], |row| {
-            let session_id: i64 = row.get(0)?;
+            let session_id: String = row.get(0)?;
+            let session_id = uuid::Uuid::parse_str(&session_id)
+                .expect("Database corruption: invalid session_id UUID");
             Ok(SessionId(session_id))
         })?;
 
@@ -249,7 +246,8 @@ impl Database {
         let conn = self.get_connection()?;
         let mut stmt =
             conn.prepare("SELECT receiver_pubkey FROM send_sessions WHERE session_id = ?1")?;
-        let receiver_pubkey: Vec<u8> = stmt.query_row(params![session_id.0], |row| row.get(0))?;
+        let receiver_pubkey: Vec<u8> =
+            stmt.query_row(params![session_id.0.to_string()], |row| row.get(0))?;
         Ok(HpkePublicKey::from_compressed_bytes(&receiver_pubkey).expect("Valid receiver pubkey"))
     }
 
@@ -259,7 +257,9 @@ impl Database {
             "SELECT session_id, completed_at FROM send_sessions WHERE completed_at IS NOT NULL",
         )?;
         let session_rows = stmt.query_map([], |row| {
-            let session_id: i64 = row.get(0)?;
+            let session_id: String = row.get(0)?;
+            let session_id = uuid::Uuid::parse_str(&session_id)
+                .expect("Database corruption: invalid session_id UUID");
             let completed_at: u64 = row.get(1)?;
             Ok((SessionId(session_id), completed_at))
         })?;
@@ -278,7 +278,9 @@ impl Database {
             "SELECT session_id, completed_at FROM receive_sessions WHERE completed_at IS NOT NULL",
         )?;
         let session_rows = stmt.query_map([], |row| {
-            let session_id: i64 = row.get(0)?;
+            let session_id: String = row.get(0)?;
+            let session_id = uuid::Uuid::parse_str(&session_id)
+                .expect("Database corruption: invalid session_id UUID");
             let completed_at: u64 = row.get(1)?;
             Ok((SessionId(session_id), completed_at))
         })?;
@@ -296,7 +298,7 @@ impl Database {
         let conn = self.get_connection()?;
         let exists: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM send_sessions WHERE session_id = ?1)",
-            params![session_id.0],
+            params![session_id.0.to_string()],
             |row| row.get(0),
         )?;
         Ok(exists)
@@ -307,7 +309,7 @@ impl Database {
         let conn = self.get_connection()?;
         let exists: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM receive_sessions WHERE session_id = ?1)",
-            params![session_id.0],
+            params![session_id.0.to_string()],
             |row| row.get(0),
         )?;
         Ok(exists)

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -80,7 +80,10 @@ async fn main() -> Result<()> {
         }
         #[cfg(feature = "v2")]
         Commands::Cancel { session_id, no_broadcast, role } => {
-            app.cancel(SessionId(*session_id), *no_broadcast, *role).await?;
+            let session_id = SessionId(
+                session_id.parse().map_err(|e| anyhow::anyhow!("Invalid session ID UUID: {e}"))?,
+            );
+            app.cancel(session_id, *no_broadcast, *role).await?;
         }
     };
 

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -35,6 +35,23 @@ mod e2e {
         bip21
     }
 
+    /// Helper function to extract the first session id from history stdout
+    async fn get_session_id_from_role(mut cli_role: tokio::process::Child) -> String {
+        let mut stdout = cli_role.stdout.take().expect("failed to take stdout of child process");
+        let session_id =
+            wait_for_stdout_match(&mut stdout, |line| line.contains("session established: "))
+                .await
+                .expect("payjoin-cli should output a SessionId on session startup")
+                .split_terminator(":")
+                .nth(1)
+                .expect("could not split stdout")
+                .trim()
+                .to_string();
+
+        terminate(cli_role).await.expect("Failed to kill payjoin-cli");
+        session_id
+    }
+
     /// Read lines from `child_stdout` until `match_pattern` is found and the corresponding
     /// line is returned.
     /// Also writes every read line to tokio::io::stdout();
@@ -739,6 +756,7 @@ mod e2e {
             let bip21 = get_bip21_from_receiver(cli_receiver).await;
 
             // Start sender and let it time out waiting for a response
+            // We read its stdout to capture both the session ID and the timeout.
             let cli_sender = Command::new(payjoin_cli)
                 .arg("--root-certificate")
                 .arg(cert_path)
@@ -759,10 +777,7 @@ mod e2e {
                 .spawn()
                 .expect("Failed to execute payjoin-cli sender");
 
-            send_until_request_timeout(cli_sender).await?;
-
-            // There is only one sender session in progress.
-            let session_id = 1i64;
+            let session_id = get_session_id_from_role(cli_sender).await;
 
             // Run `payjoin-cli cancel <session-id>`: cancels and broadcasts the fallback tx
             let mut cli_cancel = Command::new(payjoin_cli)
@@ -777,7 +792,7 @@ mod e2e {
                 .arg("--ohttp-relays")
                 .arg(ohttp_relays)
                 .arg("cancel")
-                .arg(session_id.to_string())
+                .arg(&session_id)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()
@@ -817,7 +832,7 @@ mod e2e {
                 .arg("--ohttp-relays")
                 .arg(ohttp_relays)
                 .arg("cancel")
-                .arg(session_id.to_string())
+                .arg(&session_id)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()
@@ -911,10 +926,8 @@ mod e2e {
                 .stderr(Stdio::inherit())
                 .spawn()
                 .expect("Failed to execute payjoin-cli receiver");
-            let _bip21 = get_bip21_from_receiver(cli_receiver).await;
 
-            // There is only one receiver session in progress.
-            let session_id = 1i64;
+            let session_id = get_session_id_from_role(cli_receiver).await;
 
             // Run `payjoin-cli cancel <session-id> --role receiver`: the session is at
             // Initialized so there is no fallback transaction to broadcast.
@@ -930,7 +943,7 @@ mod e2e {
                 .arg("--ohttp-relays")
                 .arg(ohttp_relays)
                 .arg("cancel")
-                .arg(session_id.to_string())
+                .arg(&session_id)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()
@@ -969,7 +982,7 @@ mod e2e {
                 .arg("--ohttp-relays")
                 .arg(ohttp_relays)
                 .arg("cancel")
-                .arg(session_id.to_string())
+                .arg(&session_id)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()


### PR DESCRIPTION
Closes #1631

This is a demonstration of the session ids being time based uuids in our reference implementation instead of a raw incremented integer

With the nature of seconds based time + a uuid I think that this is the best way for both user initiated and high frequency payjoin session management should be handled.

This is a breaking change in the database for any payjoin-cli with existing sessions

Coded up by deepseek v4

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
