### PR TITLE
Bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/cron-directory-monitor.yml
+++ b/.github/workflows/cron-directory-monitor.yml
@@ -6,6 +6,6 @@ jobs:
   health-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check /health endpoint
         run: cd payjoin-mailroom && bash contrib/health-check.sh

--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-mutants@27.1.0

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Install nix"
@@ -38,7 +38,7 @@ jobs:
         working-directory: payjoin-ffi/csharp
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust 1.85.0
         uses: dtolnay/rust-toolchain@1.85.0
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Install nix"

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -19,7 +19,7 @@ jobs:
           - maintenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/flake-maintenance.yml
+++ b/.github/workflows/flake-maintenance.yml
@@ -16,7 +16,7 @@ jobs:
           - nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Install nix"
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Install nix"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Install nix"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -58,7 +58,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Install ${{ matrix.rust }} toolchain"
         uses: dtolnay/rust-toolchain@master
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Install nix"
@@ -69,7 +69,7 @@ jobs:
       RUSTUP_TOOLCHAIN: stable
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Install toolchain"
         # rust-cache usage with stable Rust is most effective, as a cache is tied to the Rust version
         uses: dtolnay/rust-toolchain@stable
@@ -96,7 +96,7 @@ jobs:
     name: Code spell check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: codespell-project/actions-codespell@v2
 
   DiffMutants:
@@ -106,7 +106,7 @@ jobs:
       RUSTUP_TOOLCHAIN: stable
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # required for full diff context
       - name: Fetch base branch for diff
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Install nightly toolchain"
         uses: dtolnay/rust-toolchain@nightly
       - name: "Use cache"

--- a/.github/workflows/standup-compile.yml
+++ b/.github/workflows/standup-compile.yml
@@ -10,7 +10,7 @@ jobs:
   compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/standup-on-comment.yml
+++ b/.github/workflows/standup-on-comment.yml
@@ -14,7 +14,7 @@ jobs:
       contains(github.event.comment.body, '/check-in')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/standup-prompt.yml
+++ b/.github/workflows/standup-prompt.yml
@@ -15,7 +15,7 @@ jobs:
   create-discussion:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
Closes #1637

Upgrades `actions/checkout` from v4 to v6 across all workflows.

`actions/checkout@v4` runs on Node.js 20, which is being deprecated on GitHub Actions runners. Node.js 24 becomes the default, and Node.js 20 will be removed entirely on September 16, 2026.

Affected workflows:
- `rust.yml`
- `javascript.yml`
- `dart.yml`
- `python.yml`
- `csharp.yml`
- `release-image.yml`
- `flake-check.yml`
- `flake-maintenance.yml`
- `format.yml`
- `cron-weekly-mutants.yml`
- `cron-directory-monitor.yml`
- `standup-on-comment.yml`
- `standup-compile.yml`
- `standup-prompt.yml`

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
