### PR TITLE
Update bitcoind async client 0.14

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -421,10 +421,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.8"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee0966d78f8b91e2801e3e870535410b2057ed54e5c140c705c3218151f6ac"
+checksum = "fbfef338cdb79b56b6ef8133a8b18058d8b64e057164674a0ff41199b5cd44de"
 dependencies = [
  "base64 0.22.1",
  "bitcoin 0.32.9",
@@ -734,15 +734,15 @@ dependencies = [
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08221cf31c5f00fb6fc8fa697cea54176b06801a518bd9d3482aa27099827a3a"
+checksum = "6df90cd78f0510165fd370574676aeb57dbec0ee3bfff68645bb7b0e9a65dbd5"
 dependencies = [
- "rustls 0.21.8",
- "rustls-webpki 0.101.7",
+ "rustls 0.23.38",
+ "rustls-webpki 0.103.13",
  "tokio",
- "tokio-rustls 0.24.0",
- "webpki-roots 0.25.2",
+ "tokio-rustls",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2029,13 +2029,13 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2778,7 +2778,7 @@ dependencies = [
  "payjoin-test-utils",
  "percent-encoding-rfc3986",
  "reqwest",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "serde",
  "serde_json",
  "tokio",
@@ -2812,7 +2812,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2885,12 +2885,12 @@ dependencies = [
  "rand 0.8.0",
  "rcgen 0.12.0",
  "reqwest",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "serde",
  "tempfile",
  "tokio",
  "tokio-listener",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tokio-rustls-acme",
  "tokio-stream",
  "tokio-tungstenite",
@@ -2916,7 +2916,7 @@ dependencies = [
  "payjoin-mailroom",
  "rcgen 0.14.7",
  "reqwest",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "tar",
  "tempfile",
  "time",
@@ -3155,7 +3155,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 1.1.0",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "thiserror 1.0.37",
  "tokio",
  "tracing",
@@ -3171,7 +3171,7 @@ dependencies = [
  "rand 0.8.0",
  "ring 0.17.12",
  "rustc-hash 1.1.0",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "slab",
  "thiserror 1.0.37",
  "tinyvec",
@@ -3410,7 +3410,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -3418,7 +3418,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3426,7 +3426,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3551,14 +3551,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "ring 0.17.12",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3617,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.12",
  "rustls-pki-types",
@@ -4374,21 +4374,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.21.8",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -4410,14 +4400,14 @@ dependencies = [
  "rcgen 0.14.7",
  "reqwest",
  "ring 0.17.12",
- "rustls 0.23.31",
+ "rustls 0.23.38",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tokio-rustls 0.26.2",
- "webpki-roots 1.0.0",
+ "tokio-rustls",
+ "webpki-roots 1.0.7",
  "x509-parser",
 ]
 
@@ -5353,9 +5343,9 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5844,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.9"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810a38a65b5484410841b073581672570c55781eaf3f850dac4c4b4246fb3149"
+checksum = "fbfef338cdb79b56b6ef8133a8b18058d8b64e057164674a0ff41199b5cd44de"
 dependencies = [
  "base64 0.22.1",
  "bitcoin 0.32.100",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -28,7 +28,7 @@ v2 = ["payjoin/v2", "payjoin/io"]
 ahash = "0.7.8"
 anyhow = "1.0.99"
 async-trait = "0.1.89"
-bitcoind-async-client = ">=0.10.8, <0.10.10"
+bitcoind-async-client = "0.14.0"
 clap = { version = "4.5.45", features = ["derive"] }
 config = "0.15.17"
 dirs = "6.0.0"
@@ -47,7 +47,7 @@ rusqlite = { version = "0.29.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.52.3", features = ["full"] }
-tokio-rustls = { version = "0.26.2", features = [
+tokio-rustls = { version = "0.26.4", features = [
   "ring",
 ], default-features = false, optional = true }
 tracing = "0.1.41"

--- a/payjoin-cli/src/app/wallet.rs
+++ b/payjoin-cli/src/app/wallet.rs
@@ -119,7 +119,7 @@ impl BitcoindWallet {
     pub fn broadcast_tx(&self, tx: &Transaction) -> Result<Txid> {
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current()
-                .block_on(async { self.rpc.send_raw_transaction(tx).await })
+                .block_on(async { self.rpc.send_raw_transaction(tx, None).await })
         })
         .context("Failed to broadcast transaction")
     }

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -63,7 +63,7 @@ rand = "0.8"
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls",
 ], optional = true }
-rustls = { version = "0.23.31", default-features = false, features = [
+rustls = { version = "0.23.38", default-features = false, features = [
   "ring",
 ], optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
@@ -77,7 +77,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 unicode-segmentation = "=1.12.0"
 
-# unicode segmentation is ignored because it needs to be pinned due to the use of an unstable 
+# unicode segmentation is ignored because it needs to be pinned due to the use of an unstable
 # feature from within the config crate
 [package.metadata.cargo-machete]
 ignored = ["unicode-segmentation"]
@@ -92,7 +92,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
 ] }
 tempfile = "3.20.0"
 tokio = { version = "1.52.3", features = ["test-util"] }
-tokio-rustls = { version = "0.26.2", default-features = false, features = [
+tokio-rustls = { version = "0.26.4", default-features = false, features = [
   "ring",
 ] }
 uuid = { version = "1.18.0", features = ["v4"] }

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -40,7 +40,7 @@ rcgen = { version = "=0.14.7", optional = true }
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls",
 ], optional = true }
-rustls = { version = "0.23.31", default-features = false, features = [
+rustls = { version = "0.23.38", default-features = false, features = [
   "ring",
 ], optional = true }
 tempfile = { version = "3.20.0", optional = true }

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -48,7 +48,7 @@ http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 percent-encoding-rfc3986 = { version = "0.1.3", optional = true }
 reqwest = { version = "0.12.23", default-features = false, optional = true }
-rustls = { version = "0.23.31", optional = true, default-features = false, features = [
+rustls = { version = "0.23.38", optional = true, default-features = false, features = [
   "ring",
 ] }
 serde = { version = "1.0.228", default-features = false, optional = true }


### PR DESCRIPTION
Closes #1642

The previous constraint (>=0.10.8, <0.10.10) was a workaround for
a breaking change accidentally backported into 0.10.10 upstream.
Move to 0.14.0.

This requires:

- Passing `None` for the new `options: Option<BroadcastOptions>`
  parameter of `send_raw_transaction`, added in the 0.10.10/0.14.0
  API change.
- Raising the minimum versions of tokio-rustls (0.26.2 -> 0.26.4)
  and rustls (0.23.31 -> 0.23.38) in payjoin, payjoin-mailroom,
  and payjoin-test-utils, since bitreq (a transitive dependency of
  bitcoind-async-client 0.14.0) requires these minimums and
  direct-minimal-versions resolution fails otherwise.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
