### PR TITLE
Expose InputPair outpoint over FFI

### DIFF
--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -306,30 +306,6 @@ public class ValidationTests
     }
 
     [Fact]
-    public void InputPairExposesOutpoint()
-    {
-        const string txid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        const uint vout = 7;
-        var txin = new TxIn(
-            new OutPoint(txid, vout),
-            new byte[] {},
-            uint.MaxValue,
-            new byte[][] {}
-        );
-        var psbtIn = new PsbtInput(
-            new TxOut(12345, Convert.FromHexString("00140000000000000000000000000000000000000000")),
-            null,
-            null
-        );
-        using var inputPair = new InputPair(txin, psbtIn, null);
-
-        var outpoint = inputPair.Outpoint();
-
-        Assert.Equal(txid, outpoint.txid);
-        Assert.Equal(vout, outpoint.vout);
-    }
-
-    [Fact]
     public void SenderBuilderRejectsBadPsbt()
     {
         using var parsed = Uri.Parse("bitcoin:tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4?pj=https://example.com/pj");

--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -306,6 +306,30 @@ public class ValidationTests
     }
 
     [Fact]
+    public void InputPairExposesPreviousOutpoint()
+    {
+        const string txid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const uint vout = 7;
+        var txin = new TxIn(
+            new OutPoint(txid, vout),
+            new byte[] {},
+            uint.MaxValue,
+            new byte[][] {}
+        );
+        var psbtIn = new PsbtInput(
+            new TxOut(12345, Convert.FromHexString("00140000000000000000000000000000000000000000")),
+            null,
+            null
+        );
+        using var inputPair = new InputPair(txin, psbtIn, null);
+
+        var outpoint = inputPair.PreviousOutpoint();
+
+        Assert.Equal(txid, outpoint.txid);
+        Assert.Equal(vout, outpoint.vout);
+    }
+
+    [Fact]
     public void SenderBuilderRejectsBadPsbt()
     {
         using var parsed = Uri.Parse("bitcoin:tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4?pj=https://example.com/pj");

--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -306,7 +306,7 @@ public class ValidationTests
     }
 
     [Fact]
-    public void InputPairExposesPreviousOutpoint()
+    public void InputPairExposesOutpoint()
     {
         const string txid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         const uint vout = 7;
@@ -323,7 +323,7 @@ public class ValidationTests
         );
         using var inputPair = new InputPair(txin, psbtIn, null);
 
-        var outpoint = inputPair.PreviousOutpoint();
+        var outpoint = inputPair.Outpoint();
 
         Assert.Equal(txid, outpoint.txid);
         Assert.Equal(vout, outpoint.vout);

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1114,6 +1114,9 @@ impl InputPair {
             .map(Self)
             .map_err(|err| InputPairError::InvalidPsbtInput(Arc::new(err.into())))
     }
+
+    /// Returns the outpoint spent by this input pair.
+    pub fn previous_outpoint(&self) -> OutPoint { self.0.previous_outpoint().into() }
 }
 
 impl From<InputPair> for payjoin::receive::InputPair {

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1116,7 +1116,7 @@ impl InputPair {
     }
 
     /// Returns the outpoint spent by this input pair.
-    pub fn previous_outpoint(&self) -> OutPoint { self.0.previous_outpoint().into() }
+    pub fn outpoint(&self) -> OutPoint { self.0.outpoint().into() }
 }
 
 impl From<InputPair> for payjoin::receive::InputPair {

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -216,6 +216,9 @@ impl InputPair {
         Self::new_segwit_input_pair(txout, outpoint, Some(expected_weight))
     }
 
+    /// Returns the outpoint spent by this input pair.
+    pub fn previous_outpoint(&self) -> OutPoint { self.txin.previous_output }
+
     pub(crate) fn previous_txout(&self) -> TxOut {
         InternalInputPair::from(self)
             .previous_txout()
@@ -539,6 +542,18 @@ pub(crate) mod tests {
         .unwrap();
 
         assert_eq!(input_pair.expected_weight, expected_satifiability_weight);
+    }
+
+    #[test]
+    fn input_pair_previous_outpoint_returns_previous_output() {
+        let txout = TxOut {
+            value: Amount::from_sat(123),
+            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::from_byte_array(DUMMY20)),
+        };
+        let outpoint = OutPoint { txid: Txid::from_byte_array(DUMMY32), vout: 31 };
+        let input_pair = InputPair::new_p2wpkh(txout, outpoint).unwrap();
+
+        assert_eq!(input_pair.previous_outpoint(), outpoint);
     }
 
     #[test]

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -217,7 +217,7 @@ impl InputPair {
     }
 
     /// Returns the outpoint spent by this input pair.
-    pub fn previous_outpoint(&self) -> OutPoint { self.txin.previous_output }
+    pub fn outpoint(&self) -> OutPoint { self.txin.previous_output }
 
     pub(crate) fn previous_txout(&self) -> TxOut {
         InternalInputPair::from(self)
@@ -545,7 +545,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn input_pair_previous_outpoint_returns_previous_output() {
+    fn input_pair_outpoint_returns_previous_output() {
         let txout = TxOut {
             value: Amount::from_sat(123),
             script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::from_byte_array(DUMMY20)),
@@ -553,7 +553,7 @@ pub(crate) mod tests {
         let outpoint = OutPoint { txid: Txid::from_byte_array(DUMMY32), vout: 31 };
         let input_pair = InputPair::new_p2wpkh(txout, outpoint).unwrap();
 
-        assert_eq!(input_pair.previous_outpoint(), outpoint);
+        assert_eq!(input_pair.outpoint(), outpoint);
     }
 
     #[test]

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -545,18 +545,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn input_pair_outpoint_returns_previous_output() {
-        let txout = TxOut {
-            value: Amount::from_sat(123),
-            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::from_byte_array(DUMMY20)),
-        };
-        let outpoint = OutPoint { txid: Txid::from_byte_array(DUMMY32), vout: 31 };
-        let input_pair = InputPair::new_p2wpkh(txout, outpoint).unwrap();
-
-        assert_eq!(input_pair.outpoint(), outpoint);
-    }
-
-    #[test]
     fn create_p2pkh_input_pair() {
         let p2sh_txout = TxOut {
             value: Amount::from_sat(123),

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -545,6 +545,18 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn input_pair_outpoint_preserves_txid_and_vout() {
+        let txout = TxOut {
+            value: Amount::from_sat(123),
+            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::from_byte_array(DUMMY20)),
+        };
+        let outpoint = OutPoint { txid: Txid::from_byte_array(DUMMY32), vout: 31 };
+        let input_pair = InputPair::new_p2wpkh(txout, outpoint).unwrap();
+
+        assert_eq!(input_pair.outpoint(), outpoint);
+    }
+
+    #[test]
     fn create_p2pkh_input_pair() {
         let p2sh_txout = TxOut {
             value: Amount::from_sat(123),


### PR DESCRIPTION
This exposes the outpoint carried by a receiver `InputPair` through a small `outpoint()` accessor and regenerates the C# binding surface.

BTCPay uses `WantsInputs::try_preserving_privacy` through UniFFI in https://github.com/ValeraFinebits/btcpayserver-payjoin-plugin/pull/59. The selected `InputPair` crosses the FFI boundary as an opaque object, while BTCPay keeps spendable wallet metadata in its own `ReceivedCoin` model. BTCPay needs the selected input `OutPoint` to map that choice back to the coin it can reserve across sessions and later sign.


Disclosure: co-authored by GPT-5 Codex