### PR TITLE
Enable HTTP/2 multiplexing on relay-directory hop

### DIFF
--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -25,7 +25,7 @@ telemetry = ["dep:opentelemetry-otlp"]
 
 [dependencies]
 anyhow = "1.0.99"
-axum = "0.8"
+axum = { version = "0.8", features = ["http2"] }
 axum-server = { version = "0.8", features = [
   "tls-rustls-no-provider",
 ], optional = true }
@@ -40,13 +40,18 @@ futures = "0.3.21"
 hex = { package = "hex-conservative", version = "0.1.1" }
 http = "1.3.1"
 http-body-util = "0.1.3"
-hyper = { version = "1.8.0", features = ["http1", "server"] }
+hyper = { version = "1.8.0", features = ["http1", "http2", "server"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = [
   "webpki-roots",
   "http1",
+  "http2",
   "ring",
 ] }
-hyper-util = { version = "0.1.18", features = ["client-legacy", "service"] }
+hyper-util = { version = "0.1.18", features = [
+  "client-legacy",
+  "http2",
+  "service",
+] }
 hyperloglogplus = "0.4.1"
 ipnet = { version = "2.9", optional = true }
 maxminddb = { version = "0.27", optional = true }

--- a/payjoin-mailroom/src/lib.rs
+++ b/payjoin-mailroom/src/lib.rs
@@ -190,9 +190,15 @@ pub async fn serve_acme(
 
     let acme = acme_config.into_rustls_config(&config.storage_dir);
     let mut state = acme.state();
-    let rustls_config = Arc::new(
-        rustls::ServerConfig::builder().with_no_client_auth().with_cert_resolver(state.resolver()),
-    );
+    // Advertise HTTP/2 in ALPN so peer relays multiplex their forwarded
+    // requests over a single connection instead of one per concurrent
+    // long-poll. tokio-rustls-acme only injects the `acme-tls/1` challenge
+    // protocol, so application ALPN must be set here. Without this the server
+    // config negotiates no protocol and clients fall back to HTTP/1.1.
+    let mut server_config =
+        rustls::ServerConfig::builder().with_no_client_auth().with_cert_resolver(state.resolver());
+    server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    let rustls_config = Arc::new(server_config);
     let acceptor = state.axum_acceptor(rustls_config);
 
     // Drive ACME cert renewal in background

--- a/payjoin-mailroom/src/ohttp_relay/mod.rs
+++ b/payjoin-mailroom/src/ohttp_relay/mod.rs
@@ -126,7 +126,11 @@ impl std::ops::Deref for HttpClient {
 
 impl From<HttpsConnectorBuilder<WantsSchemes>> for HttpClient {
     fn from(builder: HttpsConnectorBuilder<WantsSchemes>) -> Self {
-        let https = builder.https_or_http().enable_http1().build();
+        // Enable HTTP/2 so concurrent relayed requests (notably long-poll
+        // mailbox reads) multiplex over a single connection to the gateway
+        // instead of pinning one file descriptor each. Falls back to HTTP/1.1
+        // when the gateway does not negotiate h2 via ALPN.
+        let https = builder.https_or_http().enable_http1().enable_http2().build();
         Self(Client::builder(TokioExecutor::new()).build(https))
     }
 }


### PR DESCRIPTION
The relay's outbound client and the directory's ACME server now negotiate HTTP/2, so a relay's concurrent forwarded requests multiplex over one connection instead of pinning one directory file descriptor each.

Note that HTTP/2 over TLS is selected by ALPN during the TLS handshake. So multiplexing only reaches the mailroom if the process that the relay's TLS connection terminates against negotiates h2. payjo.in runs direct ACME on port 443, so this change is sufficient to multiplex relay -> directory in production with no proxy change.

The `multiplexing_tests` are more of a demo than real unit tests so I'm leaving this PR in draft with those included until we agree on an approach, then I think these can be dropped.

co-authored by Claude Opus 4.8

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
