### PR TITLE
Standardized cargo-machete comments

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,7 @@ payjoin = { path = "../payjoin", default-features = false, features = [
   "v2",
 ] }
 
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["home"]
 

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -53,6 +53,7 @@ tokio-rustls = { version = "0.26.4", features = [
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["ahash", "pest_derive"]
 

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -39,10 +39,7 @@ uniffi-bindgen-cs = { git = "https://github.com/benalleng/uniffi-bindgen-cs.git"
 uniffi-dart = { git = "https://github.com/benalleng/uniffi-dart.git", rev = "ce97870a934cd6046eef059c5805359ac0d59964", optional = true }
 url = "2.5.4"
 
-# getrandom is ignored here because it's required by the wasm_js feature
-# icu deps are ignored here because they're required to be pinned as transitive deps of url
-# socks is ignored as a transitive dep of bdk
-# Even though they may appear unused in the default feature set, they are legitimate dependencies.
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["getrandom", "icu_provider", "icu_locale_core", "socks"]
 

--- a/payjoin-ffi/javascript/test-utils/Cargo.toml
+++ b/payjoin-ffi/javascript/test-utils/Cargo.toml
@@ -15,8 +15,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 
-# icu deps are ignored here because they're required to be pinned as transitive deps of url
-# Even though they may appear unused in the default feature set, they are legitimate dependencies.
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["icu_provider", "icu_locale_core"]
 

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -78,8 +78,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 unicode-segmentation = "=1.12.0"
 
-# unicode segmentation is ignored because it needs to be pinned due to the use of an unstable
-# feature from within the config crate
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["unicode-segmentation"]
 

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -50,6 +50,6 @@ tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
-# time and tar are transient dependencies, but needs to be specified explicitly to pin the version for MSRV
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["time", "tar"]

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -58,7 +58,7 @@ tracing = "0.1.41"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = "1.1.0"
 
-# bitcoin-units and hkdf are transient dependencies that need to be specified for our MSRV
+# Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]
 ignored = ["bitcoin-units", "hkdf"]
 


### PR DESCRIPTION
Fixes #1647

<details>
  <summary>Removed package-specific names from cargo-machete comments so they do not go stale when the ignored list changes. Applied a uniform comment to all Cargo.toml files that define [package.metadata.cargo-machete].t</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
