### PR TITLE
Introduce `arbitrary` crate

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -7,6 +7,7 @@ exclude_re = [
   "deserialize",
   "Iterator",
   ".*Error",
+  "impl\\s+arbitrary::Arbitrary",
 
   # ---------------------Crate-specific exclusions ---------------------
   # Timeout loops

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -156,9 +156,9 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arbitrary"
-version = "1.0.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
@@ -2569,6 +2569,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 name = "payjoin"
 version = "1.0.0-rc.6"
 dependencies = [
+ "arbitrary",
  "bhttp",
  "bitcoin",
  "bitcoin-hpke",
@@ -2648,6 +2649,7 @@ dependencies = [
 name = "payjoin-fuzz"
 version = "0.0.1"
 dependencies = [
+ "arbitrary",
  "home",
  "libfuzzer-sys",
  "payjoin",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -156,9 +156,9 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arbitrary"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
+checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
 
 [[package]]
 name = "arc-swap"
@@ -541,6 +541,7 @@ version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
 dependencies = [
+ "arbitrary",
  "base58ck",
  "base64 0.21.3",
  "bech32",
@@ -629,6 +630,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
 dependencies = [
+ "arbitrary",
  "bitcoin-internals 0.3.0",
  "serde",
 ]
@@ -2569,6 +2571,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 name = "payjoin"
 version = "1.0.0"
 dependencies = [
+ "arbitrary",
  "bhttp",
  "bitcoin",
  "bitcoin-hpke",
@@ -2648,6 +2651,7 @@ dependencies = [
 name = "payjoin-fuzz"
 version = "0.0.1"
 dependencies = [
+ "arbitrary",
  "home",
  "libfuzzer-sys",
  "payjoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -538,6 +538,7 @@ version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
+ "arbitrary",
  "base58ck",
  "base64 0.21.7",
  "bech32",
@@ -624,6 +625,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
+ "arbitrary",
  "bitcoin-consensus-encoding",
  "serde",
 ]
@@ -2699,6 +2701,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 name = "payjoin"
 version = "1.0.0"
 dependencies = [
+ "arbitrary",
  "bhttp",
  "bitcoin",
  "bitcoin-hpke",
@@ -2778,6 +2781,7 @@ dependencies = [
 name = "payjoin-fuzz"
 version = "0.0.1"
 dependencies = [
+ "arbitrary",
  "home",
  "libfuzzer-sys",
  "payjoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2700,6 +2700,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 name = "payjoin"
 version = "1.0.0-rc.6"
 dependencies = [
+ "arbitrary",
  "bhttp",
  "bitcoin",
  "bitcoin-hpke",
@@ -2779,6 +2780,7 @@ dependencies = [
 name = "payjoin-fuzz"
 version = "0.0.1"
 dependencies = [
+ "arbitrary",
  "home",
  "libfuzzer-sys",
  "payjoin",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,11 @@ cargo-fuzz = true
 default = []
 
 [dependencies]
+arbitrary = { version = "1.0.1" }
 home = "=0.5.11"
 libfuzzer-sys = { version = "0.4.10" }
 payjoin = { path = "../payjoin", default-features = false, features = [
+  "arbitrary",
   "_core",
   "v1",
   "v2",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,11 @@ cargo-fuzz = true
 default = []
 
 [dependencies]
+arbitrary = { version = "1.4.2" }
 home = "=0.5.11"
 libfuzzer-sys = { version = "0.4.10" }
 payjoin = { path = "../payjoin", default-features = false, features = [
+  "arbitrary",
   "_core",
   "v1",
   "v2",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -36,3 +36,9 @@ name = "url_decode_url"
 path = "fuzz_targets/url/decode_url.rs"
 doc = false
 bench = false
+
+[[bin]]
+name = "url_arbitrary_url"
+path = "fuzz_targets/url/arbitrary_url.rs"
+doc = false
+bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -42,3 +42,9 @@ name = "directory_short_id"
 path = "fuzz_targets/directory/short_id.rs"
 doc = false
 bench = false
+
+[[bin]]
+name = "url_arbitrary_url"
+path = "fuzz_targets/url/arbitrary_url.rs"
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/url/arbitrary_url.rs
+++ b/fuzz/fuzz_targets/url/arbitrary_url.rs
@@ -1,0 +1,42 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use payjoin::Url;
+
+fn do_test(data: &[u8]) {
+    let mut u = Unstructured::new(data);
+    if let Ok(mut url) = Url::arbitrary(&mut u) {
+        if let Ok(port) = u.arbitrary::<Option<u16>>() {
+            url.set_port(port);
+        }
+        if let Ok(fragment) = u.arbitrary::<Option<&str>>() {
+            url.set_fragment(fragment);
+        }
+        if let Ok((key, value)) = u.arbitrary::<(&str, &str)>() {
+            url.query_pairs_mut().append_pair(key, value);
+            url.clear_query();
+        }
+        if let Some(mut segs) = url.path_segments_mut() {
+            if let Ok(segment) = u.arbitrary::<&str>() {
+                segs.push(segment);
+            }
+        }
+        if let Ok(segment) = String::arbitrary(&mut u) {
+            let _ = url.join(&segment);
+        }
+    }
+}
+
+fuzz_target!(|data| {
+    do_test(data);
+});
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn duplicate_crash() {
+        let data = b"\x00";
+        super::do_test(&data[..]);
+    }
+}

--- a/fuzz/fuzz_targets/url/decode_url.rs
+++ b/fuzz/fuzz_targets/url/decode_url.rs
@@ -9,7 +9,7 @@ use payjoin::Url;
 fn do_test(data: &[u8]) {
     let Ok(s) = str::from_utf8(data) else { return };
 
-    let Ok(mut url) = Url::parse(s) else { return };
+    let Ok(url) = Url::parse(s) else { return };
 
     let _ = url.scheme();
     let _ = url.domain();
@@ -44,23 +44,6 @@ fn do_test(data: &[u8]) {
             reparsed.as_str()
         );
     }
-
-    url.set_port(Some(8080));
-    url.set_port(None);
-    url.set_fragment(Some("fuzz"));
-    url.set_fragment(None);
-    url.query_pairs_mut().append_pair("k", "v");
-    url.clear_query();
-    url.query_pairs_mut().append_pair("fuzz_key", "fuzz_val");
-
-    if let Some(mut segs) = url.path_segments_mut() {
-        segs.push("fuzz_segment");
-    }
-
-    let _ = url.join("relative/path");
-    let _ = url.join("/absolute/path");
-    let _ = url.join("../dotdot");
-    let _ = url.join("https://other.example.com/new");
 }
 
 fuzz_target!(|data| {

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -37,8 +37,10 @@ v2 = ["_core", "hpke", "hkdf", "bhttp", "ohttp", "directory"]
 #[doc = "Functions to fetch OHTTP keys via CONNECT proxy using reqwest. Enables `v2` since only `v2` uses OHTTP."]
 io = ["v2", "reqwest/rustls-tls"]
 _manual-tls = ["rustls"]
+arbitrary = ["dep:arbitrary", "bitcoin/arbitrary"]
 
 [dependencies]
+arbitrary = { version = "1.0.1", optional = true }
 bhttp = { version = "0.6.1", optional = true }
 bitcoin = { version = "0.32.9", features = ["base64"] }
 bitcoin-units = "0.1.3"

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -39,6 +39,7 @@ io = ["v2", "reqwest/rustls-tls"]
 _manual-tls = ["rustls"]
 
 [dependencies]
+arbitrary = { version = "1.4.2", optional = true }
 bhttp = { version = "0.6.1", optional = true }
 bitcoin = { version = "0.32.9", features = ["base64"] }
 bitcoin-units = "0.1.3"

--- a/payjoin/src/core/url.rs
+++ b/payjoin/src/core/url.rs
@@ -544,6 +544,32 @@ impl<'de> serde::Deserialize<'de> for Url {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Host {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        match u.int_in_range(0..=2)? {
+            0 => Ok(Self::Domain(u.arbitrary()?)),
+            1 => Ok(Self::Ipv4(u.arbitrary()?)),
+            _ => Ok(Self::Ipv6(u.arbitrary()?)),
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Url {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Url {
+            raw: u.arbitrary()?,
+            scheme: u.arbitrary()?,
+            host: u.arbitrary()?,
+            port: u.arbitrary()?,
+            path: u.arbitrary()?,
+            query: u.arbitrary()?,
+            fragment: u.arbitrary()?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
I've written a bunch of [`arbitrary` impls for rust-bitcoin](https://github.com/search?q=repo%3Arust-bitcoin%2Frust-bitcoin%20Arbitrary&type=code), so I was curious if there's any interest to do it here as well. Those changes haven't been released yet but should be released in rust-bitcoin v0.33 (or whatever the next version is named), and at that point, we will be able to use them to test this crate as well. I've looked through rust-bitcoin to implement all of the types that are used here (`Amount`, `FeeRate`, `Psbt`, etc), so when the new release gets cut, we should be able to add a lot of extensive fuzzing here if we use `arbitrary` as well. 

Note: There's a `derive` feature, but rust-bitcoin doesn't have it enabled to cut down on dependencies, so I didn't do it here either

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
