### PR TITLE
Fix spelling mistakes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,7 +47,7 @@ To contribute a code change:
 The git repository is our source of truth for development history. Therefore the commit history is the most important communication
 artifact we produce. Commit messages must follow [the seven rules in this guide by cbeams](https://cbea.ms/git-commit/#seven-rules).
 
-Every commit should be [hygenic](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches) and pass CI. This means tests, linting, and formatting should pass without issues on each commit. Below is a [git hook](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) you may choose to add to `.git/hooks/pre-commit` in your local repository to perform these checks before each commit:
+Every commit should be [hygienic](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches) and pass CI. This means tests, linting, and formatting should pass without issues on each commit. Below is a [git hook](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) you may choose to add to `.git/hooks/pre-commit` in your local repository to perform these checks before each commit:
 
 ```sh
 #!/usr/bin/env bash

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -10,15 +10,15 @@ assignees: ""
 
 ### Summary
 
-<--release summary to be used in announcements-->
+<!-- release summary to be used in announcements -->
 
 ### Commit
 
-<--latest commit ID to include in this release-->
+<!-- latest commit ID to include in this release -->
 
 ### Changelog
 
-<--add notices from PRs merged since the prior release, see ["keep a changelog"]-->
+<!-- add notices from PRs merged since the prior release, see ["keep a changelog"] -->
 
 ### Checklist
 
@@ -33,7 +33,7 @@ Change the `master` branch to the next MINOR+1 version:
 - [ ] Create a new PR branch called `bump-CRATE-MAJOR-MINOR+1`, eg. `bump-CRATE-0-22`.
 - [ ] Bump the `bump-CRATE-MAJOR-MINOR+1` branch to the next development MINOR+1 version.
   - Change the `Cargo.toml` version value to `MAJOR.MINOR+1.0` for all crates in the workspace.
-  - Run `contrib/update-lock-files.sh ` to apply upgrades to the Cargo lock files.
+  - Run `contrib/update-lock-files.sh` to apply upgrades to the Cargo lock files.
   - Update the `CHANGELOG.md` file.
   - The commit message should be "Bump CRATE version to MAJOR.MINOR+1.0".
 - [ ] Create PR for the `bump-CRATE-MAJOR-MINOR+1` branch to `master`.
@@ -59,7 +59,7 @@ Tag and publish new release:
 - [ ] Wait for the CI to finish one last time.
 - [ ] Build the docs locally to ensure they are building correctly.
 - [ ] Push the new tag to the `payjoin/rust-payjoin` repo.
-- [ ] Publish the crate in question crates to crates.io.
+- [ ] Publish the crate in question to crates.io.
 - [ ] Create the release on GitHub.
   - Go to "tags", click on the dots on the right and select "Create Release".
   - Set the title to `Release CRATE-MAJOR.MINOR+1.0`.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -18,7 +18,7 @@ cd fuzz/
 
 ### Running fuzzers
 
-The `fuzz.sh` and `cycle.sh` shell scripts allow for single pass fuzzing and continuous long term fuzzing respectively.
+The `fuzz.sh` and `cycle.sh` shell scripts allow for single-pass fuzzing and continuous long-term fuzzing respectively.
 
 #### Using `fuzz.sh`
 

--- a/payjoin-cli/CHANGELOG.md
+++ b/payjoin-cli/CHANGELOG.md
@@ -66,7 +66,7 @@ This release attempts to stabilize the Payjoin V2 Bitcoin URI format. That inclu
 - Include more verbose context when bitcoind fails (#251)
 - Use `*rpcpassword` instead of `*rpcpass` config and option to match bitcoind
 - Test with JoinMarket
-- respect `disableoutputsubtitution` send parameter
+- respect `disableoutputsubstitution` send parameter
 - depend on `payjoin-0.16.0`
 - separate V1 `pj_endpoint` and V2 `pj_directory` config params / cli arguments
 

--- a/payjoin-cli/contrib/lint.sh
+++ b/payjoin-cli/contrib/lint.sh
@@ -5,6 +5,6 @@ set -e
 features=("v1" "v2")
 
 for feature in "${features[@]}"; do
-    # Don't duplicate --all-targets clippy. Clilppy end-user code, not tests.
+    # Don't duplicate --all-targets clippy. Clippy end-user code, not tests.
     cargo clippy --locked --no-default-features --features "$feature" -- -D warnings
 done

--- a/payjoin-ffi/CHANGELOG.md
+++ b/payjoin-ffi/CHANGELOG.md
@@ -68,7 +68,7 @@ This release updates the bindings libraries to `payjoin` version `0.21.0`.
 
 #### APIs changed
 
-- Removed `contribute_non_nitness_input` from `v1` & `v2`.
+- Removed `contribute_non_witness_input` from `v1` & `v2`.
 - Allow receivers to make `payjoins` out of sweep transactions ([#259](https://github.com/payjoin/rust-payjoin/pull/259)).
 - Encode &ohttp= and &exp= parameters in the &pj= URL as a fragment instead of as URI params ([#298](https://github.com/payjoin/rust-payjoin/pull/298))
 
@@ -79,7 +79,7 @@ This release updates the bindings libraries to `payjoin` version `0.18.0`.
 #### APIs changed
 
 - Upgrade `receive/v2` type state machine to resume multiple `payjoins` simultaneously ([#283](https://github.com/payjoin/rust-payjoin/pull/283))
-- Refactor output substitution with new fallable `try_substitute_outputs` ([#277](https://github.com/payjoin/rust-payjoin/pull/277))
+- Refactor output substitution with new fallible `try_substitute_outputs` ([#277](https://github.com/payjoin/rust-payjoin/pull/277))
 - Replaced `Enroller` with `SessionInitializer`.
 - Replaced `Enrolled` with `ActiveSession`.
 - Replaced `fallback_target()` with `pj_url`.

--- a/payjoin-ffi/python/CHANGELOG.md
+++ b/payjoin-ffi/python/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### APIs changed
 
-- Removed `contribute_non_nitness_input` from `v1` & `v2`.
+- Removed `contribute_non_witness_input` from `v1` & `v2`.
 - Allow receivers to make `payjoins` out of sweep transactions ([#259](https://github.com/payjoin/rust-payjoin/pull/259)).
 - Encode &ohttp= and &exp= parameters in the &pj= URL as a fragment instead of as URI params ([#298](https://github.com/payjoin/rust-payjoin/pull/298))
 

--- a/payjoin-ffi/src/error.rs
+++ b/payjoin-ffi/src/error.rs
@@ -53,6 +53,6 @@ pub enum ForeignError {
 
 impl From<uniffi::UnexpectedUniFFICallbackError> for ForeignError {
     fn from(_: uniffi::UnexpectedUniFFICallbackError) -> Self {
-        Self::InternalError("Unexpected Uniffi callback error".to_string())
+        Self::InternalError("Unexpected UniFFI callback error".to_string())
     }
 }

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -844,7 +844,7 @@ pub trait IsScriptOwned: Send + Sync {
 
 #[uniffi::export]
 impl MaybeInputsOwned {
-    ///The Sender’s Original PSBT
+    /// The Sender’s Original PSBT
     pub fn extract_tx_to_schedule_broadcast(&self) -> Vec<u8> {
         payjoin::bitcoin::consensus::encode::serialize(
             &self.0.clone().extract_tx_to_schedule_broadcast(),

--- a/payjoin-ffi/src/request.rs
+++ b/payjoin-ffi/src/request.rs
@@ -1,5 +1,5 @@
-///Represents data that needs to be transmitted to the receiver.
-///You need to send this request over HTTP(S) to the receiver.
+/// Represents data that needs to be transmitted to the receiver.
+/// You need to send this request over HTTP(S) to the receiver.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct Request {
     /// URL to send the request to.

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -323,9 +323,9 @@ impl InitialSendTransition {
     }
 }
 
-///Builder for sender-side payjoin parameters
+/// Builder for sender-side payjoin parameters
 ///
-///These parameters define how client wants to handle Payjoin.
+/// These parameters define how client wants to handle Payjoin.
 #[derive(Clone, uniffi::Object)]
 pub struct SenderBuilder(payjoin::send::v2::SenderBuilder);
 
@@ -508,8 +508,10 @@ impl WithReplyKey {
     }
 
     /// Decodes and validates the response.
-    /// Call this method with response from receiver to continue BIP-??? flow. A successful response can either be None if the relay has not response yet or Some(Psbt).
-    /// If the response is some valid PSBT you should sign and broadcast.
+    /// Call this method with a response from the receiver to continue the BIP77 flow.
+    /// A successful response can either be `None` if the relay has no response yet,
+    /// or `Some(Psbt)`.
+    /// If the response is a valid PSBT you should sign and broadcast it.
     pub fn process_response(
         &self,
         response: &[u8],
@@ -537,7 +539,7 @@ impl From<payjoin::send::v1::V1Context> for V1Context {
 
 #[uniffi::export]
 impl V1Context {
-    ///Decodes and validates the response.
+    /// Decodes and validates the response.
     /// Call this method with response from receiver to continue BIP78 flow. If the response is valid you will get appropriate PSBT that you should sign and broadcast.
     pub fn process_response(&self, response: &[u8]) -> Result<String, ResponseError> {
         <payjoin::send::v1::V1Context as Clone>::clone(&self.0.clone())
@@ -626,8 +628,10 @@ impl PollingForProposal {
     }
 
     /// Decodes and validates the response.
-    /// Call this method with response from receiver to continue BIP-??? flow. A successful response can either be None if the relay has not response yet or Some(Psbt).
-    /// If the response is some valid PSBT you should sign and broadcast.
+    /// Call this method with a response from the receiver to continue the BIP77 flow.
+    /// A successful response can either be `None` if the relay has no response yet,
+    /// or `Some(Psbt)`.
+    /// If the response is a valid PSBT you should sign and broadcast it.
     pub fn process_response(
         &self,
         response: &[u8],

--- a/payjoin-mailroom/src/db/files.rs
+++ b/payjoin-mailroom/src/db/files.rs
@@ -29,7 +29,7 @@ struct V2WaitMapEntry {
 
 #[derive(Debug)]
 struct V1WaitMapEntry {
-    /// The V1 payload. `take()`n after the first read for data minimization —
+    /// The V1 payload. Taken after the first read for data minimization —
     /// plaintext PSBTs should not linger in memory longer than needed.
     payload: Option<Arc<Vec<u8>>>,
     sender: oneshot::Sender<Vec<u8>>,

--- a/payjoin-mailroom/src/ohttp_relay/gateway_prober.rs
+++ b/payjoin-mailroom/src/ohttp_relay/gateway_prober.rs
@@ -609,7 +609,7 @@ mod tests {
 
         // test happy path
         let status = prober.check_opt_in(&url).await.expect("probing must succeed");
-        assert!(status.bip77_allowed, "asserte opt-in should be cached");
+        assert!(status.bip77_allowed, "asserted opt-in should be cached");
     }
 
     #[tokio::test]

--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -84,7 +84,7 @@ fn create_and_fund_wallets<W: AsRef<str>>(
     Ok(funded_wallets)
 }
 
-pub fn init_bitcoind_multi_sender_single_reciever(
+pub fn init_bitcoind_multi_sender_single_receiver(
     number_of_senders: usize,
 ) -> Result<(corepc_node::Node, Vec<corepc_node::Client>, corepc_node::Client), BoxError> {
     let bitcoind = init_bitcoind()?;

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -122,7 +122,7 @@ Introduce the Session Event Log for Session Replay
 
 Selected Improvements:
 
-### Introduce Granualar event-based session log for replay
+### Introduce granular event-based session log for replay
 
 - Alter receiver session as_ref assert and persist::Value import for ReceiverToken (#658)
 - Add SessionPersister trait (#716)
@@ -235,7 +235,7 @@ This release attempts to stabilize the Payjoin V2 Bitcoin URI format. That inclu
     - Include a bitcoin address in `SessionContext`
   - Document it all ([#308](https://github.com/payjoin/rust-payjoin/pull/308))
 - `send::ResponseError` variants fields got explicit names ([#304](https://github.com/payjoin/rust-payjoin/pull/304))
-- Refactor output substitution with new fallable `try_substitute_outputs` ([#277](https://github.com/payjoin/rust-payjoin/pull/277))
+- Refactor output substitution with new fallible `try_substitute_outputs` ([#277](https://github.com/payjoin/rust-payjoin/pull/277))
 
 ### Contributors:
 
@@ -345,7 +345,7 @@ Bumping `bitcoin` and other crates was a breaking api change. This is a 0.8.1 se
 - Test receiver compatibility with BlueWallet
 - Rename `sender`, `receiver` features `send`, `receive`
 - Rename `PayJoin` `Payjoin`
-- introduce `receive::Error` for fallable checklist items [#59](https://github.com/payjoin/rust-payjoin/pull/59)
+- introduce `receive::Error` for fallible checklist items [#59](https://github.com/payjoin/rust-payjoin/pull/59)
 - Display receiver errors, RequestErrors with JSON (https://github.com/payjoin/rust-payjoin/pull/49)
 
 ## 0.7.0

--- a/payjoin/contrib/lint.sh
+++ b/payjoin/contrib/lint.sh
@@ -5,6 +5,6 @@ set -e
 features=("v1" "v2" "directory")
 
 for feature in "${features[@]}"; do
-    # Don't duplicate --all-targets clippy. Clilppy end-user code, not tests.
+    # Don't duplicate --all-targets clippy. Clippy end-user code, not tests.
     cargo clippy --locked --no-default-features --features "$feature" -- -D warnings
 done

--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -204,7 +204,7 @@ pub(crate) enum InternalPayloadError {
     /// The sender is trying to spend the receiver input
     InputOwned(bitcoin::ScriptBuf),
     #[allow(dead_code)]
-    /// Original PSBT input has been seen before. Only automatic receivers, aka "interactive" in the spec
+    /// Original PSBT input has been seen before. Only automatic receivers, aka "non-interactive" in the spec
     /// look out for these to prevent probing attacks.
     InputSeen(bitcoin::OutPoint),
     /// Original PSBT fee rate is below minimum fee rate set by the receiver.

--- a/payjoin/src/core/uri/v2.rs
+++ b/payjoin/src/core/uri/v2.rs
@@ -174,7 +174,7 @@ fn check_fragment_delimiter(fragment: &str) -> Result<char, ParseFragmentError> 
     // For backwards compatibility, also accept `+` as a
     // fragment parameter delimiter. This was previously
     // specified, but may be interpreted as ` ` by some
-    // URI parsoing libraries. Therefore if `-` is missing,
+    // URI parsing libraries. Therefore if `-` is missing,
     // assume the URI was generated following the older
     // version of the spec.
 


### PR DESCRIPTION
While I was scanning the repo, my AI went rogue and started fixing unrelated issues. This PR took a few of those and only contains:
- Fix spelling and typo issues in docs, changelogs, comments, and release checklist text.
- Correct the misspelled test utility helper name.

Figured not to waste the tokens

Disclosure: co-authored by Codex