### PR TITLE
Assert bech32 encoding is uppercase

### DIFF
--- a/payjoin/src/bech32.rs
+++ b/payjoin/src/bech32.rs
@@ -41,7 +41,7 @@ mod test {
             (hrp.as_str().len() + 1) as f32 + (bytes.len() as f32 * 8.0 / 5.0).ceil()
         );
 
-        // TODO assert uppercase
+        assert_eq!(encoded, encoded.to_ascii_uppercase());
 
         // should not error
         let corrupted = encoded + "QQPP";


### PR DESCRIPTION
Replace the placeholder TODO in the bech32 QR encoding test with an explicit uppercase assertion.

Disclosure: co-authored by Codex