### PR TITLE
Resume v2 polling on transient directory errors

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -12,6 +12,7 @@ use payjoin::receive::v2::{
     ReceiverBuilder, SessionOutcome as ReceiverSessionOutcome, UncheckedOriginalPayload,
     WantsFeeRange, WantsInputs, WantsOutputs,
 };
+use payjoin::schedule::PollSchedule;
 use payjoin::send::v2::{
     replay_event_log as replay_sender_event_log, PendingFallback as SenderPendingFallback,
     PollingForProposal, SendSession, Sender, SenderBuilder, SessionOutcome as SenderSessionOutcome,
@@ -35,6 +36,7 @@ const W_ID: usize = 12;
 const W_ROLE: usize = 25;
 const W_DONE: usize = 15;
 const W_STATUS: usize = 15;
+const POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Clone)]
 pub(crate) struct App {
@@ -704,27 +706,44 @@ impl App {
         sender: Sender<PollingForProposal>,
         persister: &SenderPersister,
     ) -> Result<()> {
-        let mut session = sender.clone();
-        // Long poll until we get a response
+        let session = sender;
+        let mut schedule = PollSchedule::new();
+        let mut polls = tokio::task::JoinSet::new();
+        let next = tokio::time::sleep(schedule.next_gap());
+        tokio::pin!(next);
         loop {
-            let (response, ctx) =
-                self.post_via_relay(|relay| session.create_poll_request(relay)).await?;
-            let res = session.process_response(&response.bytes().await?, ctx).save(persister);
-            match res {
-                Ok(OptionalTransitionOutcome::Progress(psbt)) => {
-                    println!("Proposal received. Processing...");
-                    self.process_pj_response(psbt)?;
-                    return Ok(());
+            tokio::select! {
+                Some(joined) = polls.join_next(), if !polls.is_empty() => {
+                    let (body, ctx): (Vec<u8>, _) = match joined {
+                        Ok(Ok(v)) => v,
+                        _ => continue,
+                    };
+                    match session.clone().process_response(&body, ctx).save(persister) {
+                        Ok(OptionalTransitionOutcome::Progress(psbt)) => {
+                            println!("Proposal received. Processing...");
+                            self.process_pj_response(psbt)?;
+                            return Ok(());
+                        }
+                        Ok(OptionalTransitionOutcome::Stasis(_)) => {
+                            println!("No response yet.");
+                        }
+                        Err(re) => {
+                            println!("{re}");
+                            tracing::debug!("{re:?}");
+                            return Err(anyhow!("Response error").context(re));
+                        }
+                    }
                 }
-                Ok(OptionalTransitionOutcome::Stasis(current_state)) => {
-                    println!("No response yet.");
-                    session = current_state;
-                    continue;
-                }
-                Err(re) => {
-                    println!("{re}");
-                    tracing::debug!("{re:?}");
-                    return Err(anyhow!("Response error").context(re));
+                () = &mut next => {
+                    next.as_mut().reset(tokio::time::Instant::now() + schedule.next_gap());
+                    let relay = self.relay_manager.choose_relay()?;
+                    let (req, ctx) = session.create_poll_request(relay.as_str())?;
+                    let app = self.clone();
+                    polls.spawn(async move {
+                        let resp =
+                            tokio::time::timeout(POLL_TIMEOUT, app.post_request(req)).await??;
+                        Ok::<_, anyhow::Error>((resp.bytes().await?.to_vec(), ctx))
+                    });
                 }
             }
         }
@@ -735,24 +754,37 @@ impl App {
         session: Receiver<Initialized>,
         persister: &ReceiverPersister,
     ) -> Result<Receiver<UncheckedOriginalPayload>> {
-        let mut session = session;
+        let mut schedule = PollSchedule::new();
+        let mut polls = tokio::task::JoinSet::new();
+        let next = tokio::time::sleep(schedule.next_gap());
+        tokio::pin!(next);
         loop {
-            println!("Polling receive request...");
-            let (ohttp_response, context) =
-                self.post_via_relay(|relay| session.create_poll_request(relay)).await?;
-            let state_transition = session
-                .process_response(ohttp_response.bytes().await?.to_vec().as_slice(), context)
-                .save(persister);
-            match state_transition {
-                Ok(OptionalTransitionOutcome::Progress(next_state)) => {
-                    println!("Got a request from the sender. Responding with a Payjoin proposal.");
-                    return Ok(next_state);
+            tokio::select! {
+                Some(joined) = polls.join_next(), if !polls.is_empty() => {
+                    let (body, ctx): (Vec<u8>, _) = match joined {
+                        Ok(Ok(v)) => v,
+                        _ => continue,
+                    };
+                    match session.clone().process_response(&body, ctx).save(persister) {
+                        Ok(OptionalTransitionOutcome::Progress(next_state)) => {
+                            println!("Got a request from the sender. Responding with a Payjoin proposal.");
+                            return Ok(next_state);
+                        }
+                        Ok(OptionalTransitionOutcome::Stasis(_)) => {}
+                        Err(e) => return Err(e.into()),
+                    }
                 }
-                Ok(OptionalTransitionOutcome::Stasis(current_state)) => {
-                    session = current_state;
-                    continue;
+                () = &mut next => {
+                    next.as_mut().reset(tokio::time::Instant::now() + schedule.next_gap());
+                    let relay = self.relay_manager.choose_relay()?;
+                    let (req, ctx) = session.create_poll_request(relay.as_str())?;
+                    let app = self.clone();
+                    polls.spawn(async move {
+                        let resp =
+                            tokio::time::timeout(POLL_TIMEOUT, app.post_request(req)).await??;
+                        Ok::<_, anyhow::Error>((resp.bytes().await?.to_vec(), ctx))
+                    });
                 }
-                Err(e) => return Err(e.into()),
             }
         }
     }

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -727,6 +727,9 @@ impl App {
                         Ok(OptionalTransitionOutcome::Stasis(_)) => {
                             println!("No response yet.");
                         }
+                        Err(re) if re.is_transient() => {
+                            tracing::debug!("Transient directory error, retrying poll: {re:?}");
+                        }
                         Err(re) => {
                             println!("{re}");
                             tracing::debug!("{re:?}");
@@ -771,6 +774,9 @@ impl App {
                             return Ok(next_state);
                         }
                         Ok(OptionalTransitionOutcome::Stasis(_)) => {}
+                        Err(e) if e.is_transient() => {
+                            tracing::debug!("Transient directory error, retrying poll: {e:?}");
+                        }
                         Err(e) => return Err(e.into()),
                     }
                 }

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -421,7 +421,7 @@ mod e2e {
         async fn respond_with_payjoin(mut cli_receive_resumer: Child) -> Result<()> {
             let mut stdout =
                 cli_receive_resumer.stdout.take().expect("Failed to take stdout of child process");
-            let timeout = tokio::time::Duration::from_secs(10);
+            let timeout = tokio::time::Duration::from_secs(45);
             let res = tokio::time::timeout(
                 timeout,
                 wait_for_stdout_match(&mut stdout, |line| line.contains("Response successful")),
@@ -436,7 +436,7 @@ mod e2e {
         async fn check_payjoin_sent(mut cli_send_resumer: Child) -> Result<()> {
             let mut stdout =
                 cli_send_resumer.stdout.take().expect("Failed to take stdout of child process");
-            let timeout = tokio::time::Duration::from_secs(10);
+            let timeout = tokio::time::Duration::from_secs(45);
             let res = tokio::time::timeout(
                 timeout,
                 wait_for_stdout_match(&mut stdout, |line| line.contains("Payjoin sent")),
@@ -466,7 +466,7 @@ mod e2e {
         async fn check_resume_completed(mut cli_resumer: Child) -> Result<()> {
             let mut stdout =
                 cli_resumer.stdout.take().expect("Failed to take stdout of child process");
-            let timeout = tokio::time::Duration::from_secs(10);
+            let timeout = tokio::time::Duration::from_secs(45);
             let res = tokio::time::timeout(
                 timeout,
                 wait_for_stdout_match(&mut stdout, |line| {

--- a/payjoin-mailroom/src/db/files.rs
+++ b/payjoin-mailroom/src/db/files.rs
@@ -246,6 +246,7 @@ impl DbTrait for FilesDb {
         Ok(guard.read(id).await?)
     }
 
+    // Unused by GET after the non-blocking switch; v2 waitmap removal is a follow-up.
     async fn wait_for_v2_payload(
         &self,
         id: &ShortId,

--- a/payjoin-mailroom/src/db/files.rs
+++ b/payjoin-mailroom/src/db/files.rs
@@ -238,6 +238,14 @@ impl DbTrait for FilesDb {
         Ok(guard.post_v2(id, payload).await?)
     }
 
+    async fn peek_v2_payload(
+        &self,
+        id: &ShortId,
+    ) -> Result<Option<Arc<Vec<u8>>>, DbError<Self::OperationalError>> {
+        let mut guard = self.mailboxes.lock().await;
+        Ok(guard.read(id).await?)
+    }
+
     async fn wait_for_v2_payload(
         &self,
         id: &ShortId,
@@ -1069,5 +1077,38 @@ mod tests {
         assert_all_paths_over_capacity(&db).await;
 
         Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn peek_returns_immediately_on_empty_mailbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = FilesDb::init(
+            Duration::from_secs(30),
+            dir.path().to_owned(),
+            Duration::from_secs(60 * 60 * 24 * 7),
+        )
+        .await
+        .unwrap();
+        let id = ShortId([0u8; 8]);
+        let start = tokio::time::Instant::now();
+        let got = db.peek_v2_payload(&id).await.expect("peek");
+        assert!(got.is_none());
+        assert_eq!(start.elapsed(), Duration::ZERO, "peek must not block");
+    }
+
+    #[tokio::test]
+    async fn peek_returns_present_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = FilesDb::init(
+            Duration::from_millis(10),
+            dir.path().to_owned(),
+            Duration::from_secs(60 * 60 * 24 * 7),
+        )
+        .await
+        .unwrap();
+        let id = ShortId([0u8; 8]);
+        db.post_v2_payload(&id, b"hi".to_vec()).await.unwrap().unwrap();
+        let got = db.peek_v2_payload(&id).await.expect("peek").expect("present");
+        assert_eq!(&got[..], b"hi");
     }
 }

--- a/payjoin-mailroom/src/db/mod.rs
+++ b/payjoin-mailroom/src/db/mod.rs
@@ -72,6 +72,12 @@ pub trait Db: Clone + Send + Sync + 'static {
         mailbox_id: &ShortId,
     ) -> impl Future<Output = Result<Arc<Vec<u8>>, Error<Self::OperationalError>>> + Send;
 
+    /// Read a stored v2 payload if present, without waiting.
+    fn peek_v2_payload(
+        &self,
+        mailbox_id: &ShortId,
+    ) -> impl Future<Output = Result<Option<Arc<Vec<u8>>>, Error<Self::OperationalError>>> + Send;
+
     /// Write a v1 response payload.
     fn post_v1_response(
         &self,
@@ -91,6 +97,7 @@ pub trait Db: Clone + Send + Sync + 'static {
 pub enum DbRequest {
     PostV2Payload { mailbox_id: ShortId, payload: Vec<u8> },
     WaitForV2Payload { mailbox_id: ShortId },
+    PeekV2Payload { mailbox_id: ShortId },
     PostV1Response { mailbox_id: ShortId, payload: Vec<u8> },
     PostV1RequestAndWaitForResponse { mailbox_id: ShortId, payload: Vec<u8> },
 }
@@ -99,6 +106,7 @@ pub enum DbRequest {
 pub enum DbResponse {
     PostV2Payload(Option<()>),
     WaitForV2Payload(Arc<Vec<u8>>),
+    PeekV2Payload(Option<Arc<Vec<u8>>>),
     PostV1Response(()),
     PostV1RequestAndWaitForResponse(Arc<Vec<u8>>),
 }
@@ -134,6 +142,8 @@ impl Service<DbRequest> for FilesDbService {
                     Ok(DbResponse::PostV2Payload(db.post_v2_payload(&mailbox_id, payload).await?)),
                 DbRequest::WaitForV2Payload { mailbox_id } =>
                     Ok(DbResponse::WaitForV2Payload(db.wait_for_v2_payload(&mailbox_id).await?)),
+                DbRequest::PeekV2Payload { mailbox_id } =>
+                    Ok(DbResponse::PeekV2Payload(db.peek_v2_payload(&mailbox_id).await?)),
                 DbRequest::PostV1Response { mailbox_id, payload } => {
                     db.post_v1_response(&mailbox_id, payload).await?;
                     Ok(DbResponse::PostV1Response(()))
@@ -196,6 +206,21 @@ impl Db for DbServiceAdapter {
         match response {
             DbResponse::WaitForV2Payload(result) => Ok(result),
             _ => Err(Self::invalid_response("wait_for_v2_payload")),
+        }
+    }
+
+    async fn peek_v2_payload(
+        &self,
+        mailbox_id: &ShortId,
+    ) -> Result<Option<Arc<Vec<u8>>>, Error<Self::OperationalError>> {
+        let response = self
+            .inner
+            .clone()
+            .oneshot(DbRequest::PeekV2Payload { mailbox_id: *mailbox_id })
+            .await?;
+        match response {
+            DbResponse::PeekV2Payload(result) => Ok(result),
+            _ => Err(Self::invalid_response("peek_v2_payload")),
         }
     }
 
@@ -270,6 +295,14 @@ impl<D: Db> Db for MetricsDb<D> {
     ) -> Result<Arc<Vec<u8>>, Error<Self::OperationalError>> {
         self.metrics.record_short_id(mailbox_id);
         self.inner.wait_for_v2_payload(mailbox_id).await
+    }
+
+    async fn peek_v2_payload(
+        &self,
+        mailbox_id: &ShortId,
+    ) -> Result<Option<Arc<Vec<u8>>>, Error<Self::OperationalError>> {
+        self.metrics.record_short_id(mailbox_id);
+        self.inner.peek_v2_payload(mailbox_id).await
     }
 
     async fn post_v1_response(

--- a/payjoin-mailroom/src/directory.rs
+++ b/payjoin-mailroom/src/directory.rs
@@ -284,8 +284,16 @@ impl<D: Db> Service<D> {
 
     async fn get_mailbox(&self, id: &str) -> Result<Response<Body>, HandlerError> {
         let id = ShortId::from_str(id)?;
-        let timeout_response = Response::builder().status(StatusCode::ACCEPTED).body(empty())?;
-        handle_peek(self.db.wait_for_v2_payload(&id).await, timeout_response)
+        let empty_response = Response::builder().status(StatusCode::ACCEPTED).body(empty())?;
+        match self.db.peek_v2_payload(&id).await {
+            Ok(Some(payload)) => Ok(Response::new(full((*payload).clone()))),
+            Ok(None) => Ok(empty_response),
+            Err(DbError::Operational(err)) => {
+                error!("Storage error: {err}");
+                Err(HandlerError::InternalServerError(anyhow::Error::msg("Internal server error")))
+            }
+            Err(_) => Ok(empty_response),
+        }
     }
 
     /// Screen a V1 PSBT body against the address blocklist.
@@ -870,6 +878,25 @@ mod tests {
             }
             other => panic!("expected U64 Sum, got {other:?}"),
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn get_mailbox_returns_immediately_when_empty() {
+        let svc = test_service(None).await;
+        let id = valid_short_id_path();
+        let start = tokio::time::Instant::now();
+        let res = svc.get_mailbox(&id).await.expect("get_mailbox");
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+        assert_eq!(start.elapsed(), Duration::ZERO, "GET must not block");
+    }
+
+    #[tokio::test]
+    async fn get_mailbox_returns_payload_when_present() {
+        let svc = test_service(None).await;
+        let id = valid_short_id_path();
+        svc.post_mailbox(&id, Body::from(b"hi".to_vec())).await.expect("post");
+        let res = svc.get_mailbox(&id).await.expect("get_mailbox");
+        assert_eq!(res.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -19,6 +19,8 @@ pub use into_url::{Error as IntoUrlError, IntoUrl};
 pub(crate) mod url;
 pub use url::{ParseError as UrlParseError, Url};
 #[cfg(feature = "v2")]
+pub mod schedule;
+#[cfg(feature = "v2")]
 pub mod time;
 pub mod uri;
 pub use uri::{PjParam, PjParseError, PjUri, Uri, UriExt};

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -745,6 +745,10 @@ where
         }
     }
 
+    pub fn is_transient(&self) -> bool {
+        matches!(&self.0, InternalPersistedError::Api(ApiError::Transient(_)))
+    }
+
     pub fn error_state(self) -> Option<ErrorState> {
         match self.0 {
             InternalPersistedError::Api(ApiError::FatalWithState(_, state)) => Some(state),
@@ -1596,5 +1600,28 @@ mod tests {
         );
         assert!(transient_error.storage_error_ref().is_none());
         assert!(transient_error.api_error_ref().is_some());
+    }
+
+    #[test]
+    fn is_transient_only_for_transient_api_error() {
+        let transient = PersistedError::<InMemoryTestError, InMemoryTestError>(
+            InternalPersistedError::Api(ApiError::Transient(InMemoryTestError {})),
+        );
+        assert!(transient.is_transient());
+
+        let fatal = PersistedError::<InMemoryTestError, InMemoryTestError>(
+            InternalPersistedError::Api(ApiError::Fatal(InMemoryTestError {})),
+        );
+        assert!(!fatal.is_transient());
+
+        let storage = PersistedError::<InMemoryTestError, InMemoryTestError>(
+            InternalPersistedError::Storage(InMemoryTestError {}),
+        );
+        assert!(!storage.is_transient());
+
+        let fatal_with_state = PersistedError::<InMemoryTestError, InMemoryTestError>(
+            InternalPersistedError::Api(ApiError::FatalWithState(InMemoryTestError {}, ())),
+        );
+        assert!(!fatal_with_state.is_transient());
     }
 }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -2524,4 +2524,21 @@ pub mod test {
             other => panic!("Expected HasReplyableError, got {other:?}"),
         }
     }
+
+    #[test]
+    fn poll_transient_directory_error_leaves_session_open() -> Result<(), BoxError> {
+        let receiver = receiver(Initialized {});
+        let (req, ctx) = receiver.create_poll_request(EXAMPLE_URL)?;
+        let response = ohttp_response_for(&req.body, http::StatusCode::INTERNAL_SERVER_ERROR);
+        let persister = InMemoryPersister::<SessionEvent>::default();
+
+        let err = receiver
+            .process_response(&response, ctx)
+            .save(&persister)
+            .expect_err("transient response should error");
+
+        assert!(err.is_transient());
+        assert_events(&persister, &[], false);
+        Ok(())
+    }
 }

--- a/payjoin/src/core/schedule.rs
+++ b/payjoin/src/core/schedule.rs
@@ -1,0 +1,80 @@
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
+use std::time::Duration;
+
+/// Mean gap of the Poisson poll schedule. The directory learns only this rate,
+/// so it must stay uniform across clients, not a per-user knob.
+pub const POLL_MEAN: Duration = Duration::from_secs(5);
+
+/// Samples inter-poll gaps from an Exp(1/mean) distribution. Emit polls on
+/// this clock independently of responses (reset on fire, before awaiting the
+/// poll) so the observed interval is the gap, not gap + round-trip.
+#[derive(Debug)]
+pub struct PollSchedule {
+    state: u64,
+    mean: Duration,
+}
+
+impl PollSchedule {
+    /// Create a schedule seeded from OS entropy at the standard [`POLL_MEAN`] rate.
+    pub fn new() -> Self {
+        // Seed from OS entropy via the standard library's randomly-keyed hasher:
+        // hashing a fixed value mixes those random keys into a u64.
+        let mut h = RandomState::new().build_hasher();
+        h.write_u64(0);
+        Self { state: h.finish(), mean: POLL_MEAN }
+    }
+
+    /// Sample the next inter-poll gap.
+    pub fn next_gap(&mut self) -> Duration {
+        Duration::from_secs_f64(-self.mean.as_secs_f64() * self.next_uniform().ln())
+    }
+
+    /// Draw the next uniform sample in (0, 1) from the SplitMix64 state.
+    fn next_uniform(&mut self) -> f64 {
+        // SplitMix64 (reference constants: golden-ratio increment + two mixers)
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        ((z >> 11) as f64 + 1.0) / (1u64 << 53) as f64
+    }
+}
+
+impl Default for PollSchedule {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn from_seed(seed: u64, mean: Duration) -> PollSchedule { PollSchedule { state: seed, mean } }
+
+    #[test]
+    fn uniform_sequence_is_pinned() {
+        let mut s = from_seed(1, Duration::from_secs(5));
+        assert_eq!(s.next_uniform(), 0.566561575172281);
+        assert_eq!(s.next_uniform(), 0.7457817572627012);
+        assert_eq!(s.next_uniform(), 0.9710027535867963);
+    }
+
+    #[test]
+    fn same_seed_is_deterministic() {
+        let mut a = from_seed(1, Duration::from_secs(5));
+        let mut b = from_seed(1, Duration::from_secs(5));
+        for _ in 0..100 {
+            assert_eq!(a.next_gap(), b.next_gap());
+        }
+    }
+
+    #[test]
+    fn mean_is_near_lambda_inverse() {
+        let mut s = from_seed(440, Duration::from_secs(5));
+        let n = 20_000;
+        let total: f64 = (0..n).map(|_| s.next_gap().as_secs_f64()).sum();
+        let mean = total / n as f64;
+        assert!((mean - 5.0).abs() < 0.2, "mean gap {mean} not ~5s");
+    }
+}

--- a/payjoin/src/core/send/v2/mod.rs
+++ b/payjoin/src/core/send/v2/mod.rs
@@ -817,4 +817,53 @@ mod test {
         do_cancel_test!(PollingForProposal);
         Ok(())
     }
+
+    fn ohttp_response_for(
+        ohttp_keys: &OhttpKeys,
+        req_body: &[u8],
+        status: http::StatusCode,
+    ) -> Vec<u8> {
+        let server =
+            ohttp::Server::new(ohttp_keys.0.clone()).expect("test OHTTP server should be valid");
+        let (_, probe_response) = server.decapsulate(req_body).expect("request should decapsulate");
+        let response_overhead =
+            probe_response.encapsulate(&[]).expect("probe should encrypt").len();
+
+        let (_, server_response) =
+            server.decapsulate(req_body).expect("request should decapsulate again");
+        let mut bhttp_response =
+            vec![0u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES - response_overhead];
+        bhttp::Message::response(
+            bhttp::StatusCode::try_from(status.as_u16()).expect("status should be valid"),
+        )
+        .write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_response.as_mut_slice())
+        .expect("BHTTP response should encode");
+        let encrypted =
+            server_response.encapsulate(&bhttp_response).expect("response should encrypt");
+        assert_eq!(encrypted.len(), crate::directory::ENCAPSULATED_MESSAGE_BYTES);
+        encrypted
+    }
+
+    #[test]
+    fn poll_transient_directory_error_is_transient() -> Result<(), BoxError> {
+        let expiration =
+            Time::from_now(Duration::from_secs(60)).expect("expiration should be valid");
+        let sender = create_sender_context(expiration)?;
+        let ohttp_keys = sender.session_context.pj_param.ohttp_keys().clone();
+        let sender = Sender { state: PollingForProposal, session_context: sender.session_context };
+        let (req, ctx) = sender.create_poll_request(EXAMPLE_URL)?;
+        let response =
+            ohttp_response_for(&ohttp_keys, &req.body, http::StatusCode::INTERNAL_SERVER_ERROR);
+        let persister = InMemoryPersister::<SessionEvent>::default();
+
+        let err = sender
+            .process_response(&response, ctx)
+            .save(&persister)
+            .expect_err("transient response should error");
+
+        assert!(err.is_transient());
+        assert!(!persister.inner.lock().expect("Shouldn't be poisoned").is_closed);
+        assert_eq!(persister.inner.lock().expect("Shouldn't be poisoned").events.len(), 0);
+        Ok(())
+    }
 }


### PR DESCRIPTION
v2 poll loops resume on a transient (5xx) directory error instead of aborting the session, honoring `RejectTransient` "resume from current state" contract; fatal (4xx) still terminates.

stacked on #1658, do not merge first. The first 4 commits here belong to #1658 and drop out on rebase once it merges. 

this PR's own 3 commits are viewable cleanly here: [bc1cindy:transient-poll-retry](https://github.com/bc1cindy/rust-payjoin/compare/poll-timing...transient-poll-retry)

part of #1670