### PR TITLE
Fix replayEventLog report closed session as expired.

### DIFF
--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -163,21 +163,17 @@ impl SessionHistory {
         // Terminal states take precedence over expiration: a session that has reached
         // a `Closed` outcome is done regardless of whether its expiration has elapsed.
         match self.events.last() {
-            Some(SessionEvent::Closed(outcome)) =>
-                return match outcome {
-                    SessionOutcome::Success(_) | SessionOutcome::PayjoinProposalSent =>
-                        SessionStatus::Completed,
-                    SessionOutcome::Aborted => SessionStatus::Failed,
-                    SessionOutcome::FallbackBroadcasted => SessionStatus::FallbackBroadcasted,
-                },
+            Some(SessionEvent::Closed(outcome)) => match outcome {
+                SessionOutcome::Success(_) | SessionOutcome::PayjoinProposalSent =>
+                    SessionStatus::Completed,
+                SessionOutcome::Aborted => SessionStatus::Failed,
+                SessionOutcome::FallbackBroadcasted => SessionStatus::FallbackBroadcasted,
+            },
             Some(SessionEvent::Cancelled | SessionEvent::ProtocolFailed) =>
-                return SessionStatus::PendingFallback,
-            _ => {}
+                SessionStatus::PendingFallback,
+            _ if self.session_context().expiration.elapsed() => SessionStatus::Expired,
+            _ => SessionStatus::Active,
         }
-        if self.session_context().expiration.elapsed() {
-            return SessionStatus::Expired;
-        }
-        SessionStatus::Active
     }
 }
 

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -26,11 +26,15 @@ fn replay_events(
 
 fn construct_history(
     session_events: Vec<SessionEvent>,
+    receiver: &ReceiveSession,
 ) -> Result<SessionHistory, ReplayError<ReceiveSession, SessionEvent>> {
     let history = SessionHistory::new(session_events);
-    let ctx = history.session_context();
-    if ctx.expiration.elapsed() {
-        return Err(InternalReplayError::Expired(ctx.expiration).into());
+    // Closed sessions terminated before expiration; do not surface an expired error for them.
+    if !matches!(receiver, ReceiveSession::Closed(_)) {
+        let ctx = history.session_context();
+        if ctx.expiration.elapsed() {
+            return Err(InternalReplayError::Expired(ctx.expiration).into());
+        }
     }
     Ok(history)
 }
@@ -59,7 +63,7 @@ where
         }
     };
 
-    let history = construct_history(session_events)?;
+    let history = construct_history(session_events, &receiver)?;
     Ok((receiver, history))
 }
 
@@ -87,7 +91,7 @@ where
         }
     };
 
-    let history = construct_history(session_events)?;
+    let history = construct_history(session_events, &receiver)?;
     Ok((receiver, history))
 }
 
@@ -156,20 +160,24 @@ impl SessionHistory {
 
     /// Helper method to query the current status of the session.
     pub fn status(&self) -> SessionStatus {
+        // Terminal states take precedence over expiration: a session that has reached
+        // a `Closed` outcome is done regardless of whether its expiration has elapsed.
+        match self.events.last() {
+            Some(SessionEvent::Closed(outcome)) =>
+                return match outcome {
+                    SessionOutcome::Success(_) | SessionOutcome::PayjoinProposalSent =>
+                        SessionStatus::Completed,
+                    SessionOutcome::Aborted => SessionStatus::Failed,
+                    SessionOutcome::FallbackBroadcasted => SessionStatus::FallbackBroadcasted,
+                },
+            Some(SessionEvent::Cancelled | SessionEvent::ProtocolFailed) =>
+                return SessionStatus::PendingFallback,
+            _ => {}
+        }
         if self.session_context().expiration.elapsed() {
             return SessionStatus::Expired;
         }
-        match self.events.last() {
-            Some(SessionEvent::Closed(outcome)) => match outcome {
-                SessionOutcome::Success(_) | SessionOutcome::PayjoinProposalSent =>
-                    SessionStatus::Completed,
-                SessionOutcome::Aborted => SessionStatus::Failed,
-                SessionOutcome::FallbackBroadcasted => SessionStatus::FallbackBroadcasted,
-            },
-            Some(SessionEvent::Cancelled | SessionEvent::ProtocolFailed) =>
-                SessionStatus::PendingFallback,
-            _ => SessionStatus::Active,
-        }
+        SessionStatus::Active
     }
 }
 
@@ -403,6 +411,65 @@ mod tests {
         let expected_err: ReplayError<ReceiveSession, SessionEvent> =
             InternalReplayError::Expired(expiration).into();
         assert_eq!(err.to_string(), expected_err.to_string());
+    }
+
+    #[test]
+    fn status_prefers_closed_outcome_over_expired() {
+        let expiration = (SystemTime::now() - Duration::from_secs(1)).try_into().unwrap();
+        let session_context = SessionContext { expiration, ..SHARED_CONTEXT.clone() };
+
+        let success = SessionHistory::new(vec![
+            SessionEvent::Created(session_context.clone()),
+            SessionEvent::Closed(SessionOutcome::Success(vec![])),
+        ]);
+        assert_eq!(success.status(), SessionStatus::Completed);
+
+        let aborted = SessionHistory::new(vec![
+            SessionEvent::Created(session_context.clone()),
+            SessionEvent::Closed(SessionOutcome::Aborted),
+        ]);
+        assert_eq!(aborted.status(), SessionStatus::Failed);
+
+        let fallback = SessionHistory::new(vec![
+            SessionEvent::Created(session_context.clone()),
+            SessionEvent::Closed(SessionOutcome::FallbackBroadcasted),
+        ]);
+        assert_eq!(fallback.status(), SessionStatus::FallbackBroadcasted);
+
+        // Sessions that never reached a terminal state still report Expired.
+        let still_open = SessionHistory::new(vec![SessionEvent::Created(session_context)]);
+        assert_eq!(still_open.status(), SessionStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn test_replaying_closed_session_past_expiration_is_not_expired() {
+        let expiration = (SystemTime::now() - Duration::from_secs(1)).try_into().unwrap();
+        let session_context = SessionContext { expiration, ..SHARED_CONTEXT.clone() };
+
+        let persister = InMemoryPersister::<SessionEvent>::default();
+        persister
+            .save_event(SessionEvent::Created(session_context.clone()))
+            .expect("in memory persister save should not fail");
+        persister
+            .save_event(SessionEvent::Closed(SessionOutcome::Success(vec![])))
+            .expect("in memory persister save should not fail");
+        let (state, _) =
+            replay_event_log(&persister).expect("closed session should replay successfully");
+        assert!(matches!(state, ReceiveSession::Closed(SessionOutcome::Success(_))));
+
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
+        persister
+            .save_event(SessionEvent::Created(session_context))
+            .await
+            .expect("in memory async persister save should not fail");
+        persister
+            .save_event(SessionEvent::Closed(SessionOutcome::Success(vec![])))
+            .await
+            .expect("in memory async persister save should not fail");
+        let (state, _) = replay_event_log_async(&persister)
+            .await
+            .expect("closed session should replay successfully");
+        assert!(matches!(state, ReceiveSession::Closed(SessionOutcome::Success(_))));
     }
 
     #[tokio::test]

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -23,11 +23,15 @@ fn replay_events(
 
 fn construct_history(
     session_events: Vec<SessionEvent>,
+    sender: &SendSession,
 ) -> Result<SessionHistory, ReplayError<SendSession, SessionEvent>> {
     let history = SessionHistory::new(session_events);
-    let pj_param = history.pj_param();
-    if pj_param.expiration().elapsed() {
-        return Err(InternalReplayError::Expired(pj_param.expiration()).into());
+    // Closed sessions terminated before expiration; do not surface an expired error for them.
+    if !matches!(sender, SendSession::Closed(_)) {
+        let pj_param = history.pj_param();
+        if pj_param.expiration().elapsed() {
+            return Err(InternalReplayError::Expired(pj_param.expiration()).into());
+        }
     }
     Ok(history)
 }
@@ -56,7 +60,7 @@ where
         }
     };
 
-    let history = construct_history(session_events)?;
+    let history = construct_history(session_events, &sender)?;
     Ok((sender, history))
 }
 
@@ -84,7 +88,7 @@ where
         }
     };
 
-    let history = construct_history(session_events)?;
+    let history = construct_history(session_events, &sender)?;
     Ok((sender, history))
 }
 
@@ -123,17 +127,18 @@ impl SessionHistory {
     }
 
     pub fn status(&self) -> SessionStatus {
+        // Terminal states take precedence over expiration: a session that has reached
+        // a `Closed` outcome is done regardless of whether its expiration has elapsed.
+        if let Some(SessionEvent::Closed(outcome)) = self.events.last() {
+            return match outcome {
+                SessionOutcome::Success(_) => SessionStatus::Completed,
+                SessionOutcome::Aborted => SessionStatus::Failed,
+            };
+        }
         if self.pj_param().expiration().elapsed() {
             return SessionStatus::Expired;
         }
-
-        match self.events.last() {
-            Some(SessionEvent::Closed(outcome)) => match outcome {
-                SessionOutcome::Success(_) => SessionStatus::Completed,
-                SessionOutcome::Aborted => SessionStatus::Failed,
-            },
-            _ => SessionStatus::Active,
-        }
+        SessionStatus::Active
     }
 }
 
@@ -170,6 +175,8 @@ pub enum SessionOutcome {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, SystemTime};
+
     use bitcoin::{FeeRate, ScriptBuf};
     use payjoin_test_utils::{KEM, KEY_ID, PARSED_ORIGINAL_PSBT, SYMMETRIC};
 
@@ -417,6 +424,90 @@ mod tests {
 
         let session = SessionHistory { events };
         assert_eq!(session.status(), SessionStatus::Completed);
+    }
+
+    #[test]
+    fn status_prefers_closed_outcome_over_expired() {
+        let psbt = PARSED_ORIGINAL_PSBT.clone();
+        let mut sender = SenderBuilder::new(
+            psbt,
+            Uri::try_from(PJ_URI)
+                .expect("Valid uri")
+                .assume_checked()
+                .check_pj_supported()
+                .expect("Payjoin to be supported"),
+        )
+        .build_recommended(FeeRate::BROADCAST_MIN)
+        .unwrap()
+        .save(&InMemoryPersister::default())
+        .unwrap();
+        sender.session_context.pj_param.expiration =
+            Time::try_from(SystemTime::now() - Duration::from_secs(1))
+                .expect("expiration in the past");
+
+        let success = SessionHistory {
+            events: vec![
+                SessionEvent::Created(Box::new(sender.session_context.clone())),
+                SessionEvent::Closed(SessionOutcome::Success(PARSED_ORIGINAL_PSBT.clone())),
+            ],
+        };
+        assert_eq!(success.status(), SessionStatus::Completed);
+
+        let aborted = SessionHistory {
+            events: vec![
+                SessionEvent::Created(Box::new(sender.session_context.clone())),
+                SessionEvent::Closed(SessionOutcome::Aborted),
+            ],
+        };
+        assert_eq!(aborted.status(), SessionStatus::Failed);
+
+        // Sessions that never reached a terminal state still report Expired.
+        let still_open = SessionHistory {
+            events: vec![SessionEvent::Created(Box::new(sender.session_context))],
+        };
+        assert_eq!(still_open.status(), SessionStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn test_replaying_closed_sender_session_past_expiration_is_not_expired() {
+        let psbt = PARSED_ORIGINAL_PSBT.clone();
+        let sender = SenderBuilder::new(
+            psbt,
+            Uri::try_from(PJ_URI)
+                .expect("Valid uri")
+                .assume_checked()
+                .check_pj_supported()
+                .expect("Payjoin to be supported"),
+        )
+        .build_recommended(FeeRate::BROADCAST_MIN)
+        .unwrap()
+        .save(&InMemoryPersister::default())
+        .unwrap();
+
+        let persister = InMemoryPersister::<SessionEvent>::default();
+        persister
+            .save_event(SessionEvent::Created(Box::new(sender.session_context.clone())))
+            .expect("in memory persister save should not fail");
+        persister
+            .save_event(SessionEvent::Closed(SessionOutcome::Success(PARSED_ORIGINAL_PSBT.clone())))
+            .expect("in memory persister save should not fail");
+        let (state, _) =
+            replay_event_log(&persister).expect("closed session should replay successfully");
+        assert!(matches!(state, SendSession::Closed(SessionOutcome::Success(_))));
+
+        let persister = InMemoryAsyncPersister::<SessionEvent>::default();
+        persister
+            .save_event(SessionEvent::Created(Box::new(sender.session_context)))
+            .await
+            .expect("in memory async persister save should not fail");
+        persister
+            .save_event(SessionEvent::Closed(SessionOutcome::Success(PARSED_ORIGINAL_PSBT.clone())))
+            .await
+            .expect("in memory async persister save should not fail");
+        let (state, _) = replay_event_log_async(&persister)
+            .await
+            .expect("closed session should replay successfully");
+        assert!(matches!(state, SendSession::Closed(SessionOutcome::Success(_))));
     }
 
     #[tokio::test]

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -129,16 +129,14 @@ impl SessionHistory {
     pub fn status(&self) -> SessionStatus {
         // Terminal states take precedence over expiration: a session that has reached
         // a `Closed` outcome is done regardless of whether its expiration has elapsed.
-        if let Some(SessionEvent::Closed(outcome)) = self.events.last() {
-            return match outcome {
+        match self.events.last() {
+            Some(SessionEvent::Closed(outcome)) => match outcome {
                 SessionOutcome::Success(_) => SessionStatus::Completed,
                 SessionOutcome::Aborted => SessionStatus::Failed,
-            };
+            },
+            _ if self.pj_param().expiration().elapsed() => SessionStatus::Expired,
+            _ => SessionStatus::Active,
         }
-        if self.pj_param().expiration().elapsed() {
-            return SessionStatus::Expired;
-        }
-        SessionStatus::Active
     }
 }
 
@@ -417,13 +415,12 @@ mod tests {
             },
         };
 
-        let events = vec![
-            SessionEvent::Created(Box::new(with_reply_key.session_context.clone())),
-            SessionEvent::Closed(SessionOutcome::Success(PARSED_ORIGINAL_PSBT.clone())),
-        ];
+        let mut events =
+            vec![SessionEvent::Created(Box::new(with_reply_key.session_context.clone()))];
+        assert_eq!(SessionHistory { events: events.clone() }.status(), SessionStatus::Active);
 
-        let session = SessionHistory { events };
-        assert_eq!(session.status(), SessionStatus::Completed);
+        events.push(SessionEvent::Closed(SessionOutcome::Success(PARSED_ORIGINAL_PSBT.clone())));
+        assert_eq!(SessionHistory { events }.status(), SessionStatus::Completed);
     }
 
     #[test]


### PR DESCRIPTION
This addresses #1651. During replaying of the session event log a completed session is being reported as expired if the expiration time has elapsed when the event is replayed. The fix skips expiration check when the replay state is Closed

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
