### PR TITLE
Mailroom metrics requests

### DIFF
--- a/payjoin-mailroom/src/lib.rs
+++ b/payjoin-mailroom/src/lib.rs
@@ -452,7 +452,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::metrics::{ACTIVE_CONNECTIONS, HTTP_REQUESTS, TOTAL_CONNECTIONS};
+    use crate::metrics::{HTTP_REQUESTS_IN_FLIGHT, HTTP_REQUESTS_STARTED, HTTP_REQUESTS_TOTAL};
 
     async fn start_service(
         cert_der: Vec<u8>,
@@ -587,9 +587,12 @@ mod tests {
             .flat_map(|sm| sm.metrics())
             .map(|m| m.name())
             .collect();
-        assert!(metric_names.contains(&HTTP_REQUESTS), "missing http_request_total");
-        assert!(metric_names.contains(&TOTAL_CONNECTIONS), "missing total_connections");
-        assert!(metric_names.contains(&ACTIVE_CONNECTIONS), "missing active_connections");
+        assert!(metric_names.contains(&HTTP_REQUESTS_TOTAL), "missing http_requests_total");
+        assert!(
+            metric_names.contains(&HTTP_REQUESTS_STARTED),
+            "missing http_requests_started_total"
+        );
+        assert!(metric_names.contains(&HTTP_REQUESTS_IN_FLIGHT), "missing http_requests_in_flight");
     }
 
     #[tokio::test]
@@ -636,7 +639,7 @@ mod tests {
             .iter()
             .flat_map(|rm| rm.scope_metrics())
             .flat_map(|sm| sm.metrics())
-            .filter(|m| m.name() == HTTP_REQUESTS)
+            .filter(|m| m.name() == HTTP_REQUESTS_TOTAL)
             .flat_map(|m| match m.data() {
                 AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
                     .data_points()

--- a/payjoin-mailroom/src/lib.rs
+++ b/payjoin-mailroom/src/lib.rs
@@ -596,7 +596,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn middleware_sanitizes_short_id_in_metrics() {
+    async fn middleware_bounds_endpoint_labels_in_metrics() {
         use axum::body::Body;
         use axum::http::Request;
         use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
@@ -626,15 +626,23 @@ mod tests {
 
         let app = build_app(services);
 
+        // A 13-char bech32 mailbox id collapses to the /{mailbox} template,
+        // keeping the id itself out of the metric label.
         let short_id = payjoin::directory::ShortId([0u8; 8]).to_string();
-        let uri = format!("/{short_id}");
-        let request = Request::builder().method("GET").uri(&uri).body(Body::empty()).unwrap();
-        let _response = ServiceExt::<Request<Body>>::oneshot(app, request).await.unwrap();
+        let mailbox_uri = format!("/{short_id}");
+        let mailbox_req =
+            Request::builder().method("GET").uri(&mailbox_uri).body(Body::empty()).unwrap();
+        let _ = ServiceExt::<Request<Body>>::oneshot(app.clone(), mailbox_req).await.unwrap();
+
+        // A scanner-style path is not a known template, so it must collapse to
+        // `other` rather than leak a client-controlled, unbounded label value.
+        let scanner_req =
+            Request::builder().method("GET").uri("/wp-login.php").body(Body::empty()).unwrap();
+        let _ = ServiceExt::<Request<Body>>::oneshot(app, scanner_req).await.unwrap();
 
         provider.force_flush().expect("flush failed");
 
         let finished = exporter.get_finished_metrics().expect("metrics");
-        println!("finished: {:?}", finished);
         let endpoint_attrs: Vec<String> = finished
             .iter()
             .flat_map(|rm| rm.scope_metrics())
@@ -656,11 +664,26 @@ mod tests {
             })
             .collect();
 
-        println!("endpoint_attrs: {:?}", endpoint_attrs);
-
+        const ALLOWED: &[&str] = &[
+            "/{mailbox}",
+            "/{gateway}",
+            "/",
+            "/health",
+            "/ohttp-keys",
+            "/.well-known/ohttp-gateway",
+            "other",
+        ];
         assert!(
-            endpoint_attrs.iter().all(|ep| ep == "/{mailbox}"),
-            "short ID must be sanitized in metrics, got: {endpoint_attrs:?}"
+            endpoint_attrs.iter().all(|ep| ALLOWED.contains(&ep.as_str())),
+            "endpoint labels must stay within the bounded set, got: {endpoint_attrs:?}"
+        );
+        assert!(
+            endpoint_attrs.iter().any(|ep| ep == "/{mailbox}"),
+            "mailbox request should record the /{{mailbox}} template, got: {endpoint_attrs:?}"
+        );
+        assert!(
+            endpoint_attrs.iter().any(|ep| ep == "other"),
+            "scanner path should collapse to `other`, got: {endpoint_attrs:?}"
         );
         assert!(
             endpoint_attrs.iter().all(|ep| !ep.contains(&short_id)),

--- a/payjoin-mailroom/src/metrics.rs
+++ b/payjoin-mailroom/src/metrics.rs
@@ -287,12 +287,20 @@ impl MetricsService {
         );
     }
 
-    pub fn record_connection_open(&self) {
+    /// Records the start of an HTTP request and returns a guard that marks it
+    /// finished when dropped.
+    ///
+    /// Increments `http_requests_started_total` and `http_requests_in_flight`
+    /// immediately. The returned [`InFlightGuard`] decrements
+    /// `http_requests_in_flight` in its `Drop`, so the in-flight count is
+    /// corrected on normal return, on client cancellation (the request future
+    /// is dropped), and on a handler panic during unwind -- none of which a
+    /// manual decrement after the handler could guarantee.
+    pub(crate) fn track_request(&self) -> InFlightGuard {
         self.http_requests_started_total.add(1, &[]);
         self.http_requests_in_flight.add(1, &[]);
+        InFlightGuard { in_flight: self.http_requests_in_flight.clone() }
     }
-
-    pub fn record_connection_close(&self) { self.http_requests_in_flight.add(-1, &[]); }
 
     pub fn record_tunnel_open(&self) { self.active_tunnels.add(1, &[]); }
 
@@ -305,4 +313,120 @@ impl MetricsService {
     }
 
     pub fn record_short_id(&self, id: &ShortId) { self.tracker.add_id(id); }
+}
+
+/// Guard that decrements `http_requests_in_flight` when dropped.
+///
+/// Returned by [`MetricsService::track_request`] and held for the duration of a
+/// request. Because the decrement happens in `Drop`, the in-flight count is
+/// corrected whether the request returns normally, is cancelled (the future is
+/// dropped without completing), or panics. A manual decrement placed after the
+/// request future would be skipped on cancellation and on unwind, leaking the
+/// count upward.
+pub(crate) struct InFlightGuard {
+    in_flight: UpDownCounter<i64>,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        // Kept trivial and non-panicking: this runs during stack unwinding.
+        self.in_flight.add(-1, &[]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    use super::*;
+
+    fn sum_i64(exporter: &InMemoryMetricExporter, name: &str) -> i64 {
+        let finished = exporter.get_finished_metrics().expect("metrics");
+        finished
+            .iter()
+            .flat_map(|rm| rm.scope_metrics())
+            .flat_map(|sm| sm.metrics())
+            .filter(|m| m.name() == name)
+            .flat_map(|m| match m.data() {
+                AggregatedMetrics::I64(MetricData::Sum(sum)) =>
+                    sum.data_points().map(|dp| dp.value()).collect::<Vec<_>>(),
+                _ => Vec::new(),
+            })
+            .sum()
+    }
+
+    fn sum_u64(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
+        let finished = exporter.get_finished_metrics().expect("metrics");
+        finished
+            .iter()
+            .flat_map(|rm| rm.scope_metrics())
+            .flat_map(|sm| sm.metrics())
+            .filter(|m| m.name() == name)
+            .flat_map(|m| match m.data() {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) =>
+                    sum.data_points().map(|dp| dp.value()).collect::<Vec<_>>(),
+                _ => Vec::new(),
+            })
+            .sum()
+    }
+
+    #[test]
+    fn track_request_guard_decrements_in_flight_on_drop() {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone()).build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let metrics = MetricsService::new(Some(provider.clone()));
+
+        // Two requests start; one finishes (its guard is dropped at the end of
+        // the inner scope), one is still in flight across the flush.
+        let _held = metrics.track_request();
+        {
+            let _finished = metrics.track_request();
+        }
+
+        provider.force_flush().expect("flush failed");
+
+        assert_eq!(
+            sum_u64(&exporter, HTTP_REQUESTS_STARTED),
+            2,
+            "track_request increments the started counter once per call"
+        );
+        assert_eq!(
+            sum_i64(&exporter, HTTP_REQUESTS_IN_FLIGHT),
+            1,
+            "two started, one guard dropped => exactly one still in flight"
+        );
+    }
+
+    #[test]
+    fn in_flight_guard_decrements_during_panic_unwind() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone()).build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let metrics = MetricsService::new(Some(provider.clone()));
+
+        // A handler that panics while holding the guard must still decrement the
+        // in-flight count as the stack unwinds (the crate builds panic=unwind).
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = metrics.track_request();
+            panic!("handler blew up mid-request");
+        }));
+        assert!(result.is_err(), "the closure was expected to panic");
+
+        provider.force_flush().expect("flush failed");
+
+        assert_eq!(
+            sum_u64(&exporter, HTTP_REQUESTS_STARTED),
+            1,
+            "the request was counted as started before the panic"
+        );
+        assert_eq!(
+            sum_i64(&exporter, HTTP_REQUESTS_IN_FLIGHT),
+            0,
+            "the guard's Drop decremented in-flight while unwinding"
+        );
+    }
 }

--- a/payjoin-mailroom/src/metrics.rs
+++ b/payjoin-mailroom/src/metrics.rs
@@ -10,11 +10,11 @@ use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use payjoin::directory::ShortId;
 
-pub(crate) const TOTAL_CONNECTIONS: &str = "total_connections";
-pub(crate) const ACTIVE_CONNECTIONS: &str = "active_connections";
+pub(crate) const HTTP_REQUESTS_STARTED: &str = "http_requests_started_total";
+pub(crate) const HTTP_REQUESTS_IN_FLIGHT: &str = "http_requests_in_flight";
 pub(crate) const ACTIVE_TUNNELS: &str = "bootstrap_active_tunnels";
 pub(crate) const TUNNEL_SHEDS: &str = "bootstrap_tunnel_shed_total";
-pub(crate) const HTTP_REQUESTS: &str = "http_request_total";
+pub(crate) const HTTP_REQUESTS_TOTAL: &str = "http_requests_total";
 pub(crate) const DB_ENTRIES: &str = "db_entries_total";
 pub(crate) const UNIQUE_SHORT_IDS: &str = "unique_short_ids";
 
@@ -155,12 +155,18 @@ impl Default for UniqueShortIdTracker {
 
 #[derive(Clone)]
 pub struct MetricsService {
-    /// Total number of HTTP requests by endpoint type, method, and status code
+    /// Total number of HTTP requests that ran to completion, by endpoint
+    /// type, method, and status code. Recorded after the handler returns, so
+    /// requests that did not complete are absent. The gap from
+    /// `http_requests_started_total` is therefore an upper bound on dropped
+    /// requests -- client cancellation before the handler returned, requests
+    /// still in flight at scrape time, or a handler panic -- not a precise
+    /// cancellation count.
     http_requests_total: Counter<u64>,
-    /// Total number of connections
-    total_connections: Counter<u64>,
-    /// Number of active connections right now
-    active_connections: UpDownCounter<i64>,
+    /// Total number of HTTP requests started (counted before the handler runs)
+    http_requests_started_total: Counter<u64>,
+    /// Number of HTTP requests currently in flight
+    http_requests_in_flight: UpDownCounter<i64>,
     /// Number of OHTTP bootstrap tunnels open right now
     active_tunnels: UpDownCounter<i64>,
     /// Total OHTTP bootstrap tunnels shed at the concurrency cap
@@ -197,18 +203,18 @@ impl MetricsService {
         let meter = provider.meter("payjoin-mailroom");
 
         let http_requests_total = meter
-            .u64_counter(HTTP_REQUESTS)
-            .with_description("Total number of HTTP requests")
+            .u64_counter(HTTP_REQUESTS_TOTAL)
+            .with_description("Total number of HTTP requests completed")
             .build();
 
-        let total_connections = meter
-            .u64_counter(TOTAL_CONNECTIONS)
-            .with_description("Total number of connections")
+        let http_requests_started_total = meter
+            .u64_counter(HTTP_REQUESTS_STARTED)
+            .with_description("Total number of HTTP requests started")
             .build();
 
-        let active_connections = meter
-            .i64_up_down_counter(ACTIVE_CONNECTIONS)
-            .with_description("Number of active connections")
+        let http_requests_in_flight = meter
+            .i64_up_down_counter(HTTP_REQUESTS_IN_FLIGHT)
+            .with_description("Number of HTTP requests currently in flight")
             .build();
 
         let active_tunnels = meter
@@ -260,8 +266,8 @@ impl MetricsService {
 
         Self {
             http_requests_total,
-            total_connections,
-            active_connections,
+            http_requests_started_total,
+            http_requests_in_flight,
             active_tunnels,
             tunnel_sheds_total,
             db_entries_total,
@@ -282,11 +288,11 @@ impl MetricsService {
     }
 
     pub fn record_connection_open(&self) {
-        self.total_connections.add(1, &[]);
-        self.active_connections.add(1, &[]);
+        self.http_requests_started_total.add(1, &[]);
+        self.http_requests_in_flight.add(1, &[]);
     }
 
-    pub fn record_connection_close(&self) { self.active_connections.add(-1, &[]); }
+    pub fn record_connection_close(&self) { self.http_requests_in_flight.add(-1, &[]); }
 
     pub fn record_tunnel_open(&self) { self.active_tunnels.add(1, &[]); }
 

--- a/payjoin-mailroom/src/middleware.rs
+++ b/payjoin-mailroom/src/middleware.rs
@@ -61,13 +61,18 @@ fn sanitize_short_id(path: &str) -> String {
     }
 }
 
+/// Tracks per-request lifecycle metrics: marks the request started and in
+/// flight on arrival and marks it no longer in flight when it finishes.
+///
+/// The in-flight count is decremented by the `InFlightGuard` held across the
+/// inner future, so it is corrected even if the request is cancelled (a
+/// long-poll client disconnects) or the handler panics -- cases where a manual
+/// decrement after `next.run` would be skipped and leak the count upward.
 pub async fn track_connections(
     metrics: axum::extract::State<MetricsService>,
     req: Request,
     next: Next,
 ) -> Response {
-    metrics.record_connection_open();
-    let response = next.run(req).await;
-    metrics.record_connection_close();
-    response
+    let _guard = metrics.track_request();
+    next.run(req).await
 }

--- a/payjoin-mailroom/src/middleware.rs
+++ b/payjoin-mailroom/src/middleware.rs
@@ -1,4 +1,5 @@
 use axum::extract::Request;
+use axum::http::Method;
 use axum::middleware::Next;
 use axum::response::Response;
 
@@ -33,31 +34,92 @@ pub async fn check_geoip(req: Request, next: Next) -> Response {
     next.run(req).await
 }
 
+/// Records one completed HTTP request with bounded `endpoint` and `method`
+/// labels.
+///
+/// The labels are normalized to a small fixed set by `endpoint_label` and
+/// `method_label` before they reach the metric, so a client cannot inflate
+/// label cardinality. Completion is recorded after `next.run` resolves, which
+/// is when the response head is produced: a request cancelled before then
+/// never reaches `http_requests_total`, but one cancelled while its body is
+/// still streaming is counted as completed.
 pub async fn track_metrics(
     metrics: axum::extract::State<MetricsService>,
     req: Request,
     next: Next,
 ) -> Response {
-    let method = req.method().to_string();
-    let path = sanitize_short_id(req.uri().path());
+    let method = method_label(req.method());
+    let endpoint = endpoint_label(req.uri().path());
 
     let response = next.run(req).await;
     let status = response.status().as_u16();
 
-    metrics.record_http_request(&path, &method, status);
+    metrics.record_http_request(endpoint, method, status);
 
     response
 }
 
-fn sanitize_short_id(path: &str) -> String {
-    // This function ensures that ShortID isn't recorded in the metrics
+/// Collapses a request path to a bounded set of `endpoint` label values.
+///
+/// The path is client-controlled and otherwise unbounded (opt-in gateway
+/// URLs, 404 scanner probes), so it must never reach a metric label verbatim:
+/// OpenTelemetry aggregates label sets in memory under cumulative temporality
+/// and never evicts them, so unbounded labels are a memory-exhaustion vector.
+///
+/// Every request maps to exactly one of:
+/// - `/{mailbox}` -- a 13-character bech32 mailbox id (also keeps the id out
+///   of metrics)
+/// - `/{gateway}` -- an opt-in gateway path (`/http://...` or `/https://...`),
+///   the RFC 9540 and WebSocket bootstrap forms recognized by the relay
+/// - `/`, `/health`, `/ohttp-keys`, `/.well-known/ohttp-gateway` -- exact,
+///   server-defined routes. These are a fixed, finite set, so echoing the path
+///   verbatim cannot inflate label cardinality, and keeping them distinct lets
+///   health checks, key fetches, and gateway traffic be told apart in metrics.
+/// - `other` -- everything else: 404s, scanner probes, and the `CONNECT`
+///   bootstrap whose path is a client-controlled authority (its `method` label
+///   already distinguishes it)
+fn endpoint_label(path: &str) -> &'static str {
     const BECH32_CHARSET: &[u8] = b"qpzry9x8gf2tvdw0s3jn54khce6mua7l";
-    match path.strip_prefix('/') {
-        Some(segment)
-            if segment.len() == 13
-                && segment.bytes().all(|b| BECH32_CHARSET.contains(&b.to_ascii_lowercase())) =>
-            "/{mailbox}".to_string(),
-        _ => path.to_string(),
+
+    // Exact, server-defined routes shared by the relay and directory. The set
+    // is fixed and finite, so returning the path verbatim is cardinality-safe.
+    match path {
+        "/" => return "/",
+        "/health" => return "/health",
+        "/ohttp-keys" => return "/ohttp-keys",
+        "/.well-known/ohttp-gateway" => return "/.well-known/ohttp-gateway",
+        _ => {}
+    }
+    if let Some(segment) = path.strip_prefix('/') {
+        if segment.len() == 13
+            && segment.bytes().all(|b| BECH32_CHARSET.contains(&b.to_ascii_lowercase()))
+        {
+            return "/{mailbox}";
+        }
+    }
+    if path.starts_with("/http://") || path.starts_with("/https://") {
+        return "/{gateway}";
+    }
+    "other"
+}
+
+/// Clamps an HTTP method to a bounded set of `method` label values.
+///
+/// `http::Method` admits arbitrary extension tokens, which are client
+/// controlled, so any method outside the standard set collapses to `other` to
+/// keep label cardinality bounded.
+fn method_label(method: &Method) -> &'static str {
+    match *method {
+        Method::GET => "GET",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::DELETE => "DELETE",
+        Method::HEAD => "HEAD",
+        Method::OPTIONS => "OPTIONS",
+        Method::CONNECT => "CONNECT",
+        Method::PATCH => "PATCH",
+        Method::TRACE => "TRACE",
+        _ => "other",
     }
 }
 
@@ -75,4 +137,76 @@ pub async fn track_connections(
 ) -> Response {
     let _guard = metrics.track_request();
     next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENDPOINT_LABELS: &[&str] = &[
+        "/{mailbox}",
+        "/{gateway}",
+        "/",
+        "/health",
+        "/ohttp-keys",
+        "/.well-known/ohttp-gateway",
+        "other",
+    ];
+
+    #[test]
+    fn endpoint_label_maps_known_templates() {
+        assert_eq!(endpoint_label("/"), "/");
+        assert_eq!(endpoint_label("/health"), "/health");
+        assert_eq!(endpoint_label("/ohttp-keys"), "/ohttp-keys");
+        assert_eq!(endpoint_label("/.well-known/ohttp-gateway"), "/.well-known/ohttp-gateway");
+        // A 13-character bech32 mailbox id, lower and upper case.
+        let mailbox = format!("/{}", "q".repeat(13));
+        assert_eq!(endpoint_label(&mailbox), "/{mailbox}");
+        let mailbox_upper = format!("/{}", "Q".repeat(13));
+        assert_eq!(endpoint_label(&mailbox_upper), "/{mailbox}");
+        // Opt-in gateway paths (RFC 9540 and WebSocket bootstrap forms).
+        assert_eq!(endpoint_label("/https://gateway.example/ohttp"), "/{gateway}");
+        assert_eq!(endpoint_label("/http://gateway.example"), "/{gateway}");
+    }
+
+    #[test]
+    fn endpoint_label_collapses_everything_else_to_other() {
+        let twelve = format!("/{}", "q".repeat(12));
+        let fourteen = format!("/{}", "q".repeat(14));
+        // 'b' is not in the bech32 charset, so 13 of them is not a mailbox.
+        let not_bech32 = format!("/{}", "b".repeat(13));
+        for path in [
+            "",              // authority-form / empty path (e.g. CONNECT)
+            "/wp-login.php", // scanner probe
+            not_bech32.as_str(),
+            twelve.as_str(),   // wrong length
+            fourteen.as_str(), // wrong length
+            "/http",           // gateway prefix not satisfied
+            "/https:/gateway", // malformed gateway prefix
+            "/../../etc/passwd",
+            "/healthz",
+            "/ohttp-keys/extra",
+            "/.well-known",
+            "/.well-known/ohttp-gateway/extra",
+        ] {
+            assert_eq!(endpoint_label(path), "other", "path {path:?} must collapse to other");
+        }
+    }
+
+    #[test]
+    fn endpoint_label_never_escapes_the_bounded_set() {
+        for path in ["/", &format!("/{}", "q".repeat(13)), "/https://x", "/anything", "", "/a/b/c"]
+        {
+            assert!(
+                ENDPOINT_LABELS.contains(&endpoint_label(path)),
+                "endpoint label for {path:?} escaped the bounded set"
+            );
+        }
+    }
+
+    #[test]
+    fn method_label_collapses_extension_methods_to_other() {
+        let custom = Method::from_bytes(b"FROBNICATE").expect("valid method token");
+        assert_eq!(method_label(&custom), "other");
+    }
 }


### PR DESCRIPTION
Commit messages cover changes & rationale. These are necessary changes for our mailroom update.

### Notes on scope (deliberate non-changes)

- `endpoint` keeps 4 bounded buckets. the server's own non-relay routes (`/health`,
  `/ohttp-keys`, `/.well-known/ohttp-gateway`) deliberately bucket into `other` (documented on
  `endpoint_label`). Giving them dedicated labels is a safe, bounded follow-up if wanted. I could see us wanting these in the future potentially, but they're distinctly different from the rest which measure ~"how much payjoin is happening?"
- `status_code` stays a full code label. It is bounded (server-emitted, the `http` crate constrains
  it to 100–999) and not client-controlled, so it is not a residual cardinality DoS.
- The `http_requests_total` doc describes the started-vs-completed gap as an **upper bound** on
  dropped requests (cancellation before the response head, in-flight at scrape, or panic), not a
  precise cancellation rate; `track_metrics` notes that completion is recorded at the response
  head, so a request cancelled mid-body-stream still counts as completed.

Co-authored by Opus 4.8

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
