### PR TITLE
Bump payjoin-mailroom version to 0.1.2

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin-mailroom"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin-mailroom"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/payjoin-mailroom/CHANGELOG.md
+++ b/payjoin-mailroom/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Payjoin Mailroom Changelog
 
+## 0.1.2
+
+- Add db entry metrics (#1412)
+- Sanitize shortid when storing metrics (#1434)
+- Unify mailbox TTL to a single value (#1457)
+- Handle Retry-After header for 429 and 503 in gateway prober (#1475)
+- Reject post requests over capacity (#1509)
+- Track unique shortids seen (#1459)
+- Recover from transient accept errors and raise file-descriptor limit (#1608)
+- Bump payjoin version to 1.0.0-rc.3 (#1611)
+- Delegate http tracing to tower middleware (#1588)
+- Enable HTTP/2 multiplexing on relay-directory hop (#1655)
+- Bound OHTTP bootstrap tunnel resource usage and export its metrics (#1610)
+- Add per-request metrics middleware (#1674)
+
 ## 0.1.1
 
 - Implement Directory and its db as a tower-service (#1361)

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin-mailroom"
-version = "0.1.1"
+version = "0.1.2"
 description = "Combined Payjoin Directory and OHTTP Relay"
 repository = "https://github.com/payjoin/rust-payjoin/tree/master/payjoin-mailroom"
 keywords = ["bip77", "bitcoin", "ohttp", "payjoin", "privacy"]


### PR DESCRIPTION
Cut the `payjoin-mailroom` 0.1.2 patch release. Bumps the crate version
0.1.1 → 0.1.2 and updates the tracked `Cargo-minimal.lock` /
`Cargo-recent.lock` to match.

Part of #1675.

## Changelog

- Add db entry metrics (#1412)
- Sanitize shortid when storing metrics (#1434)
- Unify mailbox TTL to a single value (#1457)
- Handle Retry-After header for 429 and 503 in gateway prober (#1475)
- Reject post requests over capacity (#1509)
- Track unique shortids seen (#1459)
- Recover from transient accept errors and raise file-descriptor limit (#1608)
- Bump payjoin version to 1.0.0-rc.3 (#1611)
- Delegate http tracing to tower middleware (#1588)
- Enable HTTP/2 multiplexing on relay-directory hop (#1655)
- Bound OHTTP bootstrap tunnel resource usage and export its metrics (#1610)
- Add per-request metrics middleware (#1674)

`cargo publish --dry-run` succeeds against the bumped manifest, and both
lock files pass `cargo metadata --locked`.

Disclosure: co-authored by Claude Code