### PR TITLE
Upgrade docker/login-action to v4

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -27,7 +27,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.PAYJOIN_DOCKER_RW }}


### PR DESCRIPTION
## Description

The `docker/login-action@v3` tag still runs on Node.js 20, which GitHub Actions has deprecated. Every run of the release-image workflow emits:

> Node 20 is being deprecated. This workflow is running with Node 24 by default.

`docker/login-action` v4.0.0 switches the default runtime to Node 24, silencing the warning. This follows the same convention already used in the repo for major-version tags (e.g. `actions/checkout@v6`).

Closes #1679

Disclosure: co-authored by Claude Code