### PR TITLE
Offset cron job timing on directory health check

### DIFF
--- a/.github/workflows/cron-directory-monitor.yml
+++ b/.github/workflows/cron-directory-monitor.yml
@@ -1,7 +1,7 @@
 name: Payjoin directory health check
 on:
   schedule:
-    - cron: "*/15 * * * *" # Every 15 minutes
+    - cron: "9,23,38,53 * * * *" # Runs 4 times per hour offset from the high traffic quarters that may delay or cancel a run from occuring
 jobs:
   health-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A bit of a shot in the dark but this offsets the 4 quarter-hourly cron job directory health checks to odd times in the hopes that it does not overlap the hundreds of other projects running workflows at those times. Created referencing the notes about delays here https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
