### PR TITLE
Rename `Receiver<Monitor>::check_for_broadcast` to `check_for_transaction`, etc.

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -985,7 +985,7 @@ impl App {
             loop {
                 interval.tick().await;
                 let check_result = proposal
-                    .check_for_broadcast(|txid| {
+                    .check_for_transaction(|txid| {
                         self.wallet()
                             .get_raw_transaction(&txid)
                             .map_err(|e| ImplementationError::from(e.into_boxed_dyn_error()))

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1437,7 +1437,7 @@ impl HasReplyableError {
 }
 
 #[uniffi::export(with_foreign)]
-pub trait TransactionExists: Send + Sync {
+pub trait TransactionFinder: Send + Sync {
     fn callback(&self, txid: String) -> Result<Option<Vec<u8>>, ForeignError>;
 }
 
@@ -1505,16 +1505,18 @@ fn try_deserialize_tx(
 
 #[uniffi::export]
 impl Monitor {
-    pub fn check_for_broadcast(
+    pub fn check_for_transaction(
         &self,
-        transaction_exists: Arc<dyn TransactionExists>,
+        find_transaction: Arc<dyn TransactionFinder>,
     ) -> MonitorTransition {
-        MonitorTransition(Arc::new(RwLock::new(Some(self.0.clone().check_for_broadcast(|txid| {
-            transaction_exists
-                .callback(txid.to_string())
-                .and_then(|buf| buf.map(try_deserialize_tx).transpose())
-                .map_err(|e| ImplementationError::new(e).into())
-        })))))
+        MonitorTransition(Arc::new(RwLock::new(Some(self.0.clone().check_for_transaction(
+            |txid| {
+                find_transaction
+                    .callback(txid.to_string())
+                    .and_then(|buf| buf.map(try_deserialize_tx).transpose())
+                    .map_err(|e| ImplementationError::new(e).into())
+            },
+        )))))
     }
 }
 

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1469,24 +1469,22 @@ pub struct Monitor {
 /// The caller should decide the condition that must be satisfied for the Payjoin to be considered
 /// successful.
 ///
-/// Call [`Receiver<Monitor>::check_for_broadcast`] to confirm the status of the transaction in the
+/// Call [`Receiver<Monitor>::check_for_transaction`] to confirm the status of the transaction in the
 /// network and conclude the Payjoin session.
 impl Receiver<Monitor> {
     /// Checks the network for the Payjoin proposal or the fallback transaction using the passed
-    /// `transaction_exists` closure. Concludes the Payjoin session with a Success if the
-    /// transaction satisfies the condition.
-    ///
-    /// For example, the condition can be if the transaction has been broadcast to the
-    /// network, or if it has some number of confirmations on the blockchain.
+    /// `find_transaction` closure, and concludes the Payjoin session once one is found. The
+    /// closure defines the condition that counts as found — for example presence in the mempool,
+    /// or some number of confirmations on the blockchain.
     ///
     /// If the input address type in the fallback transaction is non-SegWit, then this
     /// function will directly conclude the Payjoin session with a Success without running the
-    /// provided `transaction_exists` closure. `transaction_exists` uses the transaction ID to
+    /// provided `find_transaction` closure. `find_transaction` uses the transaction ID to
     /// search for the transaction in the network. Since a non-SegWit input signature is going to
     /// change the TXID of the Payjoin proposal, it cannot be monitored.
-    pub fn check_for_broadcast(
+    pub fn check_for_transaction(
         &self,
-        transaction_exists: impl Fn(Txid) -> Result<Option<bitcoin::Transaction>, ImplementationError>,
+        find_transaction: impl Fn(Txid) -> Result<Option<bitcoin::Transaction>, ImplementationError>,
     ) -> MaybeFatalOrSuccessTransition<SessionEvent, Self, Error> {
         let fallback_tx = self.state.fallback_tx();
 
@@ -1504,7 +1502,7 @@ impl Receiver<Monitor> {
         // If the sender is spending SegWit-only inputs, then the transaction ID of the Payjoin proposal
         // is not going to change when the sender signs it. So we can use the TXID to check the
         // network for the Payjoin proposal.
-        match transaction_exists(payjoin_txid) {
+        match find_transaction(payjoin_txid) {
             Ok(Some(tx)) => {
                 let tx_id = tx.compute_txid();
                 if tx_id != payjoin_txid {
@@ -1531,7 +1529,7 @@ impl Receiver<Monitor> {
 
         // If the Payjoin proposal was not found, check the fallback transaction, as it is
         // the second of two transactions whose IDs the receiver is aware of.
-        match transaction_exists(fallback_tx.compute_txid()) {
+        match find_transaction(fallback_tx.compute_txid()) {
             Ok(Some(_)) =>
                 return MaybeFatalOrSuccessTransition::success(SessionEvent::Closed(
                     SessionOutcome::FallbackBroadcasted,
@@ -1699,7 +1697,7 @@ pub mod test {
         // Nothing was spent, should be in the same state
         let persister = InMemoryPersister::default();
         let res = monitor
-            .check_for_broadcast(|_| Ok(None))
+            .check_for_transaction(|_| Ok(None))
             .save(&persister)
             .expect("InMemoryPersister shouldn't fail");
         assert!(matches!(res, OptionalTransitionOutcome::Stasis(_)));
@@ -1709,7 +1707,7 @@ pub mod test {
         // Payjoin was broadcasted, should progress to success
         let persister = InMemoryPersister::default();
         let res = monitor
-            .check_for_broadcast(|_| Ok(Some(payjoin_tx.clone())))
+            .check_for_transaction(|_| Ok(Some(payjoin_tx.clone())))
             .save(&persister)
             .expect("InMemoryPersister shouldn't fail");
 
@@ -1727,7 +1725,7 @@ pub mod test {
         // Fallback was broadcasted, should progress to success
         let persister = InMemoryPersister::default();
         let res = monitor
-            .check_for_broadcast(|txid| {
+            .check_for_transaction(|txid| {
                 // Emulate if one of the fallback outpoints was double spent
                 if txid == original_tx.compute_txid() {
                     Ok(Some(original_tx.clone()))
@@ -1764,8 +1762,8 @@ pub mod test {
 
         let persister = InMemoryPersister::default();
         let res = monitor
-            .check_for_broadcast(|_| {
-                panic!("check_for_broadcast should return before this closure is called")
+            .check_for_transaction(|_| {
+                panic!("check_for_transaction should return before this closure is called")
             })
             .save(&persister)
             .expect("InMemoryPersister shouldn't fail");

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -557,8 +557,8 @@ mod integration {
             // The sender is using a non-SegWit address, so their signature is going to change the TXID. So we test whether the
             // function exists early and does not call the closure.
             monitoring_payment
-                .check_for_broadcast(|_| {
-                    panic!("when the sender is using a non-SegWit address type, the check_for_broadcast function should skip the check and return success")
+                .check_for_transaction(|_| {
+                    panic!("when the sender is using a non-SegWit address type, the check_for_transaction function should skip the check and return success")
                 })
                 .save(&recv_persister)
                 .expect("receiver should successfully monitor for the payment");
@@ -612,7 +612,7 @@ mod integration {
 
             // Receiver should be able to validate that the sender has broadcasted the Payjoin proposal.
             monitoring_payment
-                .check_for_broadcast(|txid| {
+                .check_for_transaction(|txid| {
                     let get_tx_result = receiver.get_raw_transaction(txid);
                     match get_tx_result {
                         Ok(tx) =>
@@ -694,7 +694,7 @@ mod integration {
 
             // Receiver should be able to validate that the sender has broadcasted the Payjoin proposal.
             monitoring_payment
-                .check_for_broadcast(|txid| {
+                .check_for_transaction(|txid| {
                     let get_tx_result = receiver.get_raw_transaction(txid);
                     match get_tx_result {
                         Ok(tx) =>
@@ -770,10 +770,10 @@ mod integration {
             );
 
             // Receiver should be able to validate that the sender has broadcasted the fallback transaction.
-            // The check_for_broadcast closure should be called twice: first for the Payjoin proposal, which will not be found,
+            // The check_for_transaction closure should be called twice: first for the Payjoin proposal, which will not be found,
             // and then for the fallback transaction, which will be found..
             monitoring_payment
-                .check_for_broadcast(|txid| {
+                .check_for_transaction(|txid| {
                     let get_tx_result = receiver.get_raw_transaction(txid);
                     match get_tx_result {
                         Ok(tx) =>


### PR DESCRIPTION
close #1656

& rename the predicate `transaction_exists` to `find_transaction`, because it's not returning a bool it's returning a TxID.

This change is done because broadcast is one possible interpretation of the success condition. Really, it's up to the wallet to determine at what point a transaction = a success for Payjoin, so the name reflects that.

But thinking about this revealed deeper problems (and some solutions to past problems) about the state machine design here which is that we're even making the check based on `TxId` in the first place because it limits detection to segwit transactions and we're just skipping detection otherwise (see #1214 , #1218). I don't see a good reason to force that disability to fit a particular monitor shape. There's another problem with this which is that our design treats detection from this method as the final verdict when even after broadcast detection of a payjoin it's still possible the fallback or another transaction double-spends the same outpoint used as receiver input.

The non-segwit detection issue can be solved by monitoring sender and receiver input outpoints as well as the fallback & payjoin Txids (if predictable via segwit). The monitor would then return `SettlementStatus`. See details below. This would let the wallet deal with reorgs and consistently return the correct SettlementStatus computed according to the wallet state, and wouldn't go stale by serializing event that's the result of a wallet snapshot as the permanent status of a particular payjoin, which is where this stands even after my proposal here.

<details>
<summary>A proposal for payjoin-2.0 monitor design</summary>

```rs
impl Receiver<Monitor> {
    fn payjoin_txid(&self) -> Txid;             // the payjoin tx
    fn fallback_txid(&self) -> Option<Txid>;         // None when non-segwit (txid unpredictable)

    // or for simplicity, do we JUST provide the OutPoints @ monitor and always ingest the Txid with whatever we detect to come up with the status?

    fn contested_outpoints(&self) -> Vec<OutPoint>; // sender inputs BOTH txs spend — the battleground
    fn receiver_input(&self) -> OutPoint;       // our contributed input — the payjoin "fingerprint"

}
```

The wallet reports raw facts; the payjoin library classifies

```rs
struct ChainView { spends: Vec<OutpointSpend> }
struct OutpointSpend { outpoint: OutPoint, spent_by: Option<Txid>, tx: Option<Transaction>, confirmations: u32 }

enum SettlementStatus {
    Pending,                                              // contested outpoints unspent
    Detected { outcome: Outcome, confirmations: u32 },    // confirmations == 0 means mempool
}
enum Outcome {
    Payjoin { sender_witnesses: Vec<(ScriptBuf, Witness)> }, // privacy achieved + the proof
    Fallback,                                                // original won; no privacy
    Other(Txid),                                             // outpoints spent by an unrecognized tx
}

impl Receiver<Monitor> {
    // Pure: maps observed cs/outpoints. No I/O.
    fn classify(&self, view: &ChainView) -> SettlementStatus;
}

```
</details>


I doubt that this updated follow-up `Receiver<Monitor>` change is critically necessary for 1.0. What we've shipped seems good enough for mobile wallets to get status. it seems like a critical necessity for automated exchange/service use cases to be robust enough to go prod, but ultimately I think it depends on how much bikeshedding the correct monitor requires and how much we're willing to push back an already long-passed deadline.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

Yes indeed this was co-authored by Claude Code
