### PR TITLE
Add Spec related consts for better readability in tests

### DIFF
--- a/payjoin-test-utils/src/lib.rs
+++ b/payjoin-test-utils/src/lib.rs
@@ -106,6 +106,10 @@ pub static EXAMPLE_URL: &str = "https://example.com";
 
 pub const QUERY_PARAMS: &str = "maxadditionalfeecontribution=182&additionalfeeoutputindex=0";
 
+pub const MAX_ADDITIONAL_FEE_CONTRIBUTION: Amount = Amount::from_sat(182);
+
+pub const ADDITIONAL_FEE_OUTPUT_INDEX: usize = 0;
+
 /// From the BIP-78 test vector
 pub const ORIGINAL_PSBT: &str = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
 

--- a/payjoin/src/core/receive/mod.rs
+++ b/payjoin/src/core/receive/mod.rs
@@ -484,7 +484,8 @@ pub(crate) mod tests {
         XOnlyPublicKey,
     };
     use payjoin_test_utils::{
-        DUMMY20, DUMMY32, PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL, QUERY_PARAMS,
+        DUMMY20, DUMMY32, MAX_ADDITIONAL_FEE_CONTRIBUTION, PARSED_ORIGINAL_PSBT,
+        PARSED_PAYJOIN_PROPOSAL, QUERY_PARAMS,
     };
 
     use super::*;
@@ -1020,7 +1021,7 @@ pub(crate) mod tests {
         // Fee contribution output belongs to the receiver, it should correctly identify owned
         // vouts and ignore the additional fee contribution param
         let params = Params {
-            additional_fee_contribution: Some((Amount::from_sat(182), 1)),
+            additional_fee_contribution: Some((MAX_ADDITIONAL_FEE_CONTRIBUTION, 1)),
             ..original.params
         };
         let original = OriginalPayload { params, ..original };

--- a/payjoin/src/core/receive/optional_parameters.rs
+++ b/payjoin/src/core/receive/optional_parameters.rs
@@ -155,7 +155,8 @@ impl std::error::Error for Error {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use bitcoin::{Amount, FeeRate};
+    use bitcoin::FeeRate;
+    use payjoin_test_utils::MAX_ADDITIONAL_FEE_CONTRIBUTION;
 
     use super::*;
     use crate::receive::optional_parameters::Params;
@@ -167,7 +168,7 @@ pub(crate) mod test {
             .expect("Could not parse params from query str");
         assert_eq!(params.v, Version::One);
         assert_eq!(params.output_substitution, OutputSubstitution::Disabled);
-        assert_eq!(params.additional_fee_contribution, Some((Amount::from_sat(182), 0)));
+        assert_eq!(params.additional_fee_contribution, Some((MAX_ADDITIONAL_FEE_CONTRIBUTION, 0)));
         assert_eq!(
             params.min_fee_rate,
             FeeRate::from_sat_per_vb(2).expect("Could not calculate feerate")

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -327,9 +327,10 @@ mod tests {
     use std::str::FromStr;
 
     use bitcoin::absolute::{LockTime, Time};
-    use bitcoin::{Address, Amount, Network, Transaction};
+    use bitcoin::{Address, Network, Transaction};
     use payjoin_test_utils::{
-        ORIGINAL_PSBT, PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL, QUERY_PARAMS,
+        MAX_ADDITIONAL_FEE_CONTRIBUTION, ORIGINAL_PSBT, PARSED_ORIGINAL_PSBT,
+        PARSED_PAYJOIN_PROPOSAL, QUERY_PARAMS,
     };
 
     use super::*;
@@ -397,7 +398,7 @@ mod tests {
         assert_eq!(proposal.original.params.v, Version::One);
         assert_eq!(
             proposal.original.params.additional_fee_contribution,
-            Some((Amount::from_sat(182), 0))
+            Some((MAX_ADDITIONAL_FEE_CONTRIBUTION, 0))
         );
         Ok(())
     }

--- a/payjoin/src/core/send/mod.rs
+++ b/payjoin/src/core/send/mod.rs
@@ -682,8 +682,8 @@ mod test {
     use bitcoin::taproot::TaprootBuilder;
     use bitcoin::{Amount, FeeRate, OutPoint, Script, ScriptBuf, Sequence, Witness};
     use payjoin_test_utils::{
-        BoxError, PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL,
-        PARSED_PAYJOIN_PROPOSAL_WITH_SENDER_INFO,
+        BoxError, ADDITIONAL_FEE_OUTPUT_INDEX, MAX_ADDITIONAL_FEE_CONTRIBUTION,
+        PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL, PARSED_PAYJOIN_PROPOSAL_WITH_SENDER_INFO,
     };
 
     use super::*;
@@ -1363,10 +1363,10 @@ mod test {
             assert!(ctx.clone().process_proposal(proposal.clone()).is_ok());
 
             // When output substitution is disabled still allow increasing the output value
-            proposal.unsigned_tx.output[0].value += Amount::from_sat(182);
+            proposal.unsigned_tx.output[0].value += MAX_ADDITIONAL_FEE_CONTRIBUTION;
             assert!(ctx.clone().process_proposal(proposal.clone()).is_ok());
 
-            proposal.unsigned_tx.output[0].value -= Amount::from_sat(182);
+            proposal.unsigned_tx.output[0].value -= MAX_ADDITIONAL_FEE_CONTRIBUTION;
             ctx.original_psbt.unsigned_tx.output.get_mut(0).unwrap().script_pubkey =
                 ctx.payee.clone();
             std::mem::swap(
@@ -1393,7 +1393,7 @@ mod test {
                 ctx.payee.clone();
             assert!(ctx.clone().process_proposal(proposal.clone()).is_ok());
 
-            proposal.unsigned_tx.output[0].value += Amount::from_sat(182);
+            proposal.unsigned_tx.output[0].value += MAX_ADDITIONAL_FEE_CONTRIBUTION;
             assert!(ctx.clone().process_proposal(proposal.clone()).is_ok());
 
             proposal.unsigned_tx.output[0].value -= Amount::from_sat(364);
@@ -1427,7 +1427,8 @@ mod test {
             ctx.output_substitution = OutputSubstitution::Enabled;
 
             let mut proposal = PARSED_PAYJOIN_PROPOSAL.clone();
-            let original_change = &ctx.original_psbt.unsigned_tx.output[0];
+            let original_change =
+                &ctx.original_psbt.unsigned_tx.output[ADDITIONAL_FEE_OUTPUT_INDEX];
             assert_ne!(original_change.script_pubkey, ctx.payee);
 
             let change_pos = proposal


### PR DESCRIPTION
This is a followup on #1622 to add consts for the
MAX_ADDITIONAL_FEE_CONTRIBUTION and ADDITIONAL_FEE_OUTPUT_INDEX to better understand why these values are included in unit tests across the codebase.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
