### PR TITLE
Cli cancel UX

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -61,6 +61,9 @@ pub struct Config {
     pub root_certificate: Option<PathBuf>,
     #[cfg(feature = "_manual-tls")]
     pub certificate_key: Option<PathBuf>,
+    #[cfg(feature = "v2")]
+    #[serde(skip)]
+    pub expire_in_secs: Option<u64>,
 }
 
 impl Config {
@@ -157,6 +160,8 @@ impl Config {
             max_fee_rate: built_config.get("max_fee_rate").ok(),
             bitcoind: built_config.get("bitcoind")?,
             version: None,
+            #[cfg(feature = "v2")]
+            expire_in_secs: None,
             #[cfg(feature = "_manual-tls")]
             root_certificate: built_config.get("root_certificate").ok(),
             #[cfg(feature = "_manual-tls")]
@@ -243,6 +248,11 @@ impl Config {
             return Err(ConfigError::Message(
                 "No valid version configuration found for the specified mode".to_string(),
             ));
+        }
+
+        #[cfg(feature = "v2")]
+        if let Commands::Receive { expire_in, .. } = &cli.command {
+            config.expire_in_secs = *expire_in;
         }
 
         tracing::trace!("App config: {config:?}");

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -39,6 +39,30 @@ const W_STATUS: usize = 15;
 /// misbehaving directory or relay is not hammered in a tight loop.
 const TRANSIENT_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// A request-construction error that can report whether it was caused by
+/// session expiry. Implemented by the sender/receiver request-building error
+/// types so `post_via_relay` can hand expiry back to the caller (which owns the
+/// typestate needed to react) instead of flattening it into `anyhow::Error`.
+trait RequestExpiry {
+    fn expired(&self) -> bool;
+}
+
+impl RequestExpiry for payjoin::send::v2::CreateRequestError {
+    fn expired(&self) -> bool { self.is_expired() }
+}
+
+impl RequestExpiry for payjoin::receive::v2::CreateRequestError {
+    fn expired(&self) -> bool { self.is_expired() }
+}
+
+/// Outcome of building and posting a request via `post_via_relay`. HTTP
+/// failures are retried against other relays inside the helper; only session
+/// expiry and fatal build errors escape to the caller.
+enum RelayPost<T> {
+    Posted(reqwest::Response, T),
+    Expired,
+}
+
 #[derive(Clone)]
 pub(crate) struct App {
     config: Config,
@@ -293,6 +317,10 @@ impl AppTrait for App {
         if let Some(max_fee_rate) = self.config.max_fee_rate {
             receiver_builder = receiver_builder.with_max_fee_rate(max_fee_rate);
         }
+        if let Some(expire_in_secs) = self.config.expire_in_secs {
+            let expiration = std::time::Duration::from_secs(expire_in_secs);
+            receiver_builder = receiver_builder.with_expiration(expiration);
+        }
         let session = receiver_builder.build().save(&persister)?;
         println!("Receive session established: {}", persister.session_id());
 
@@ -341,13 +369,21 @@ impl AppTrait for App {
                 }
                 Err(e) => {
                     if e.is_expired() {
-                        println!("Session {session_id} receiver expired.");
+                        match e.expiry_fallback_tx() {
+                            Some(tx) => println!(
+                                "Session {session_id} receiver expired. Broadcast the original transaction manually:\n{}",
+                                serialize_hex(tx)
+                            ),
+                            None => println!(
+                                "No fallback transaction available for expired receiver session {session_id}."
+                            ),
+                        }
                     } else {
                         tracing::error!(
                             "An error {:?} occurred while replaying receiver session",
                             e
                         );
-                        println!("Session {session_id} receiver failed to replay -  {e}");
+                        println!("Session {session_id} receiver failed to replay - {e}");
                     }
                     Self::close_failed_session(&recv_persister, &session_id, "receiver");
                 }
@@ -369,7 +405,15 @@ impl AppTrait for App {
                 }
                 Err(e) => {
                     if e.is_expired() {
-                        println!("Session {session_id} sender expired.");
+                        match e.expiry_fallback_tx() {
+                            Some(tx) => println!(
+                                "Session {session_id} sender expired. Broadcast the original transaction manually:\n{}",
+                                serialize_hex(tx)
+                            ),
+                            None => println!(
+                                "No fallback transaction available for expired sender session {session_id}."
+                            ),
+                        }
                     } else {
                         tracing::error!("An error {:?} occurred while replaying Sender session", e);
                         println!("Session {session_id} sender failed to replay -  {e}");
@@ -574,7 +618,21 @@ impl AppTrait for App {
 impl App {
     fn cancel_sender_session(&self, session_id: SessionId, no_broadcast: bool) -> Result<()> {
         let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
-        let (session, history) = replay_sender_event_log(&persister)?;
+        let (session, history) = match replay_sender_event_log(&persister) {
+            Ok((session, history)) => (session, history),
+            Err(e) if e.is_expired() => {
+                let tx = e.expiry_fallback_tx().cloned().ok_or_else(|| {
+                    anyhow!("Expired sender session {session_id} has no fallback transaction")
+                })?;
+                println!(
+                    "Session {session_id} expired. Broadcast the original transaction manually:\n{}",
+                    serialize_hex(&tx)
+                );
+                Self::close_failed_session(&persister, &session_id, "sender");
+                return Ok(());
+            }
+            Err(e) => return Err(anyhow!("Failed to replay sender session {session_id}: {:?}", e)),
+        };
 
         let pending: Sender<SenderPendingFallback> = match session {
             SendSession::WithReplyKey(sender) => sender.cancel().save(&persister)?,
@@ -615,7 +673,21 @@ impl App {
 
     fn cancel_receiver_session(&self, session_id: SessionId, no_broadcast: bool) -> Result<()> {
         let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
-        let (session, history) = replay_receiver_event_log(&persister)?;
+        let (session, history) = match replay_receiver_event_log(&persister) {
+            Ok((session, history)) => (session, history),
+            Err(e) if e.is_expired() => {
+                let tx = e.expiry_fallback_tx().cloned().ok_or_else(|| {
+                    anyhow!("Expired receiver session {session_id} has no fallback transaction")
+                })?;
+                println!(
+                    "Session {session_id} expired. Broadcast the original transaction manually:\n{}",
+                    serialize_hex(&tx)
+                );
+                Self::close_failed_session(&persister, &session_id, "sender");
+                return Ok(());
+            }
+            Err(e) => return Err(anyhow!("Failed to replay sender session {session_id}: {:?}", e)),
+        };
 
         let pending: Receiver<ReceiverPendingFallback> = match session {
             ReceiveSession::Initialized(receiver) => {
@@ -693,8 +765,40 @@ impl App {
         if let Err(close_err) = SessionPersister::close(persister) {
             tracing::error!("Failed to close {} session {}: {:?}", role, session_id, close_err);
         } else {
-            tracing::error!("Closed failed {} session: {}", role, session_id);
+            tracing::debug!("Closed failed {} session: {}", role, session_id);
         }
+    }
+
+    fn finalize_expired_sender(
+        &self,
+        pending: Sender<SenderPendingFallback>,
+        persister: &SenderPersister,
+    ) -> Result<()> {
+        let tx = pending.fallback_tx();
+        let session_id = persister.session_id();
+        println!(
+            "Session {} expired. Broadcast the original transaction manually:\n{}",
+            session_id,
+            serialize_hex(tx)
+        );
+        Self::close_failed_session(persister, &session_id, "sender");
+        Ok(())
+    }
+
+    fn finalize_expired_receiver(
+        &self,
+        pending: Receiver<ReceiverPendingFallback>,
+        persister: &ReceiverPersister,
+    ) -> Result<()> {
+        let tx = pending.fallback_tx();
+        let session_id = persister.session_id();
+        println!(
+            "Session {} expired. Broadcast the original transaction manually:\n{}",
+            session_id,
+            serialize_hex(tx)
+        );
+        Self::close_failed_session(persister, &session_id, "receiver");
+        Ok(())
     }
 
     async fn process_sender_session(
@@ -733,7 +837,12 @@ impl App {
     ) -> Result<()> {
         loop {
             let (response, ctx) =
-                self.post_via_relay(|relay| sender.create_v2_post_request(relay)).await?;
+                match self.post_via_relay(|relay| sender.create_v2_post_request(relay)).await? {
+                    RelayPost::Posted(resp, ctx) => (resp, ctx),
+                    RelayPost::Expired =>
+                        return self
+                            .finalize_expired_sender(sender.cancel().save(persister)?, persister),
+                };
             match sender.process_response(&response.bytes().await?, ctx).save(persister) {
                 Ok(sender) => {
                     println!("Posted Original PSBT...");
@@ -757,8 +866,14 @@ impl App {
         // Long poll until we get a response
         loop {
             let (response, ctx) =
-                self.post_via_relay(|relay| sender.create_poll_request(relay)).await?;
-            let res = sender.process_response(&response.bytes().await?, ctx).save(persister);
+                match self.post_via_relay(|relay| sender.create_poll_request(relay)).await? {
+                    RelayPost::Posted(resp, ctx) => (resp, ctx),
+                    RelayPost::Expired =>
+                        return self
+                            .finalize_expired_sender(sender.cancel().save(persister)?, persister),
+                };
+            let res =
+                sender.clone().process_response(&response.bytes().await?, ctx).save(persister);
             match res {
                 Ok(OptionalTransitionOutcome::Progress(psbt)) => {
                     println!("Proposal received. Processing...");
@@ -791,7 +906,14 @@ impl App {
         loop {
             println!("Polling receive request...");
             let (ohttp_response, context) =
-                self.post_via_relay(|relay| session.create_poll_request(relay)).await?;
+                match self.post_via_relay(|relay| session.create_poll_request(relay)).await? {
+                    RelayPost::Posted(resp, ctx) => (resp, ctx),
+                    RelayPost::Expired => {
+                        let session_id = persister.session_id();
+                        Self::close_failed_session(persister, &session_id, "receiver");
+                        return Err(anyhow!("Receiver session expired: {session_id}"));
+                    }
+                };
             let state_transition = session
                 .process_response(ohttp_response.bytes().await?.to_vec().as_slice(), context)
                 .save(persister);
@@ -998,13 +1120,15 @@ impl App {
         persister: &ReceiverPersister,
     ) -> Result<()> {
         loop {
-            let (res, ohttp_ctx) = self
-                .post_via_relay(|relay| {
-                    proposal
-                        .create_post_request(relay)
-                        .map_err(|e| anyhow!("v2 req extraction failed {}", e))
-                })
-                .await?;
+            let (res, ohttp_ctx) = match self
+                .post_via_relay(|relay| proposal.create_post_request(relay))
+                .await?
+            {
+                RelayPost::Posted(resp, ctx) => (resp, ctx),
+                RelayPost::Expired =>
+                    return self
+                        .finalize_expired_receiver(proposal.cancel().save(persister)?, persister),
+            };
             let payjoin_psbt = proposal.psbt().clone();
             match proposal.process_response(&res.bytes().await?, ohttp_ctx).save(persister) {
                 Ok(session) => {
@@ -1085,21 +1209,38 @@ impl App {
         persister: &ReceiverPersister,
     ) -> Result<()> {
         loop {
-            let (err_response, err_ctx) = self
-                .post_via_relay(|relay| {
-                    session
-                        .create_error_request(relay)
-                        .map_err(|e| anyhow!("Failed to post error request: {}", e))
-                })
-                .await?;
-
+            let (err_response, err_ctx) = match self
+                .post_via_relay(|relay| session.create_error_request(relay))
+                .await?
+            {
+                RelayPost::Posted(resp, ctx) => (resp, ctx),
+                RelayPost::Expired => match session.cancel().save(persister)? {
+                    Some(pending) => return self.finalize_expired_receiver(pending, persister),
+                    None => {
+                        let session_id = persister.session_id();
+                        println!(
+                            "Session {session_id} expired before the error reply could be sent. No fallback transaction available."
+                        );
+                        Self::close_failed_session(persister, &session_id, "receiver");
+                        return Ok(());
+                    }
+                },
+            };
             let err_bytes = match err_response.bytes().await {
                 Ok(bytes) => bytes,
                 Err(e) => return Err(anyhow!("Failed to get error response bytes: {}", e)),
             };
 
             match session.process_error_response(&err_bytes, err_ctx).save(persister) {
-                Ok(_) => return Ok(()),
+                Ok(Some(pending)) => {
+                    let session_id = persister.session_id();
+                    println!(
+                                "Session {session_id} delivered error reply. Broadcast the fallback transaction manually:\n{}",
+                                serialize_hex(pending.fallback_tx())
+                            );
+                    return Ok(());
+                }
+                Ok(None) => return Ok(()),
                 Err(e) if e.is_transient() => {
                     tracing::debug!("Transient error posting error response, retrying: {e:?}");
                     session = e.transient_state().expect("transient error carries current state");
@@ -1110,10 +1251,11 @@ impl App {
                         tracing::warn!("Failed to confirm error response delivery: {api_err}");
                     }
                     match e.fatal_state() {
-                        Some(_) => {
-                            let id = persister.session_id();
+                        Some(pending) => {
+                            let session_id = persister.session_id();
                             println!(
-                                "Session {id} failed. Run `payjoin-cli cancel {id}` to cancel and broadcast the fallback transaction."
+                                "Session {session_id} failed to deliver error reply. Broadcast the fallback transaction manually:\n{}",
+                                serialize_hex(pending.fallback_tx())
                             );
                             return Ok(());
                         }
@@ -1135,16 +1277,20 @@ impl App {
             .context("HTTP request failed")
     }
 
-    async fn post_via_relay<F, T, E>(&self, mut build: F) -> Result<(reqwest::Response, T)>
+    async fn post_via_relay<F, T, E>(&self, mut build: F) -> Result<RelayPost<T>>
     where
         F: FnMut(&str) -> std::result::Result<(payjoin::Request, T), E>,
-        E: Into<anyhow::Error>,
+        E: RequestExpiry + Into<anyhow::Error>,
     {
         loop {
             let relay = self.mailroom_manager.choose_relay()?;
-            let (req, ctx) = build(relay.as_str()).map_err(Into::into)?;
+            let (req, ctx) = match build(relay.as_str()) {
+                Ok(r) => r,
+                Err(e) if e.expired() => return Ok(RelayPost::Expired),
+                Err(e) => return Err(e.into()),
+            };
             match self.post_request(req).await {
-                Ok(resp) => return Ok((resp, ctx)),
+                Ok(resp) => return Ok(RelayPost::Posted(resp, ctx)),
                 Err(e) => {
                     tracing::debug!("Request to relay {relay} failed: {e:?}");
                     self.mailroom_manager.add_failed_relay(relay);

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -235,6 +235,7 @@ impl AppTrait for App {
                         let psbt = self.create_original_psbt(&address, amount, fee_rate)?;
                         let persister =
                             SenderPersister::new(self.db.clone(), bip21, receiver_pubkey)?;
+                        println!("Send session established: {}", persister.session_id());
                         let sender =
                             SenderBuilder::from_parts(psbt, pj_param, &address, Some(amount))
                                 .build_recommended(fee_rate)?
@@ -243,7 +244,6 @@ impl AppTrait for App {
                         (SendSession::WithReplyKey(sender), persister)
                     }
                 };
-                println!("Send session established: {}", persister.session_id());
                 let mut interrupt = self.interrupt.clone();
                 tokio::select! {
                     res = self.process_sender_session(sender_state, &persister) => {
@@ -294,8 +294,8 @@ impl AppTrait for App {
             receiver_builder = receiver_builder.with_max_fee_rate(max_fee_rate);
         }
         let session = receiver_builder.build().save(&persister)?;
-
         println!("Receive session established: {}", persister.session_id());
+
         let pj_uri = session.pj_uri();
         println!("Request Payjoin by sharing this Payjoin Uri:");
         println!("{pj_uri}");

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -116,16 +116,23 @@ struct SessionHistoryRow<Status> {
     role: Role,
     status: Status,
     error_message: Option<String>,
+    fallback_available: bool,
 }
 
 impl<Status: StatusText> fmt::Display for SessionHistoryRow<Status> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let status_text = match (self.error_message.as_deref(), self.fallback_available) {
+            (Some(err), _) => err.to_string(),
+            (None, true) =>
+                format!("{}, Fallback transaction available", self.status.status_text()),
+            (None, false) => self.status.status_text().to_string(),
+        };
         write!(
             f,
             "{:<W_ID$} {:<W_ROLE$} {:<W_STATUS$}",
             self.session_id.to_string(),
             self.role.as_str(),
-            self.error_message.as_deref().unwrap_or(self.status.status_text())
+            status_text
         )
     }
 }
@@ -405,12 +412,15 @@ impl AppTrait for App {
         self.db.get_send_session_ids()?.into_iter().for_each(|session_id| {
             let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
             match replay_sender_event_log(&persister) {
-                Ok((sender_state, _)) => {
+                Ok((sender_state, _session_history)) => {
+                    let fallback_available =
+                        matches!(sender_state, SendSession::Closed(SenderSessionOutcome::Aborted));
                     let row = SessionHistoryRow {
                         session_id,
                         role: Role::Sender,
                         status: sender_state.clone(),
                         error_message: None,
+                        fallback_available,
                     };
                     send_rows.push(row);
                 }
@@ -420,6 +430,7 @@ impl AppTrait for App {
                         role: Role::Sender,
                         status: SendSession::Closed(SenderSessionOutcome::Aborted),
                         error_message: Some(e.to_string()),
+                        fallback_available: false,
                     };
                     send_rows.push(row);
                 }
@@ -429,12 +440,17 @@ impl AppTrait for App {
         self.db.get_recv_session_ids()?.into_iter().for_each(|session_id| {
             let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
             match replay_receiver_event_log(&persister) {
-                Ok((receiver_state, _)) => {
+                Ok((receiver_state, session_history)) => {
+                    let fallback_available = matches!(
+                        receiver_state,
+                        ReceiveSession::Closed(ReceiverSessionOutcome::Aborted)
+                    ) && session_history.fallback_tx().is_some();
                     let row = SessionHistoryRow {
                         session_id,
                         role: Role::Receiver,
                         status: receiver_state.clone(),
                         error_message: None,
+                        fallback_available,
                     };
                     recv_rows.push(row);
                 }
@@ -444,6 +460,7 @@ impl AppTrait for App {
                         role: Role::Receiver,
                         status: ReceiveSession::Closed(ReceiverSessionOutcome::Aborted),
                         error_message: Some(e.to_string()),
+                        fallback_available: false,
                     };
                     recv_rows.push(row);
                 }
@@ -454,11 +471,14 @@ impl AppTrait for App {
             let persister = SenderPersister::from_id(self.db.clone(), session_id.clone());
             match replay_sender_event_log(&persister) {
                 Ok((sender_state, _)) => {
+                    let fallback_available =
+                        matches!(sender_state, SendSession::Closed(SenderSessionOutcome::Aborted));
                     let row = SessionHistoryRow {
                         session_id,
                         role: Role::Sender,
                         status: sender_state.clone(),
                         error_message: None,
+                        fallback_available,
                     };
                     send_rows.push(row);
                 }
@@ -468,6 +488,7 @@ impl AppTrait for App {
                         role: Role::Sender,
                         status: SendSession::Closed(SenderSessionOutcome::Aborted),
                         error_message: Some(e.to_string()),
+                        fallback_available: false,
                     };
                     send_rows.push(row);
                 }
@@ -477,12 +498,17 @@ impl AppTrait for App {
         self.db.get_inactive_recv_session_ids()?.into_iter().for_each(|(session_id, _)| {
             let persister = ReceiverPersister::from_id(self.db.clone(), session_id.clone());
             match replay_receiver_event_log(&persister) {
-                Ok((receiver_state, _)) => {
+                Ok((receiver_state, session_history)) => {
+                    let fallback_available = matches!(
+                        receiver_state,
+                        ReceiveSession::Closed(ReceiverSessionOutcome::Aborted)
+                    ) && session_history.fallback_tx().is_some();
                     let row = SessionHistoryRow {
                         session_id,
                         role: Role::Receiver,
                         status: receiver_state.clone(),
                         error_message: None,
+                        fallback_available,
                     };
                     recv_rows.push(row);
                 }
@@ -492,6 +518,7 @@ impl AppTrait for App {
                         role: Role::Receiver,
                         status: ReceiveSession::Closed(ReceiverSessionOutcome::Aborted),
                         error_message: Some(e.to_string()),
+                        fallback_available: false,
                     };
                     recv_rows.push(row);
                 }

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -32,7 +32,7 @@ use crate::db::Database;
 mod ohttp;
 
 const W_ID: usize = 36;
-const W_ROLE: usize = 25;
+const W_ROLE: usize = 15;
 const W_STATUS: usize = 15;
 
 /// Delay before retrying a transiently failed state transition, so a
@@ -281,9 +281,9 @@ impl AppTrait for App {
                         }
                     },
                     _ = interrupt.changed() => {
-                        let id = persister.session_id();
+                        let session_id = persister.session_id();
                         println!(
-                            "Session {id} interrupted. Call `send` again to resume, `resume` to resume all sessions, or `payjoin-cli cancel {id}` to cancel and broadcast the original transaction."
+                            "Session {session_id} interrupted. Call `payjoin-cli resume --session-id {session_id}` again to resume, `payjoin-cli resume` to resume all sessions, or `payjoin-cli cancel {session_id}` to cancel and broadcast the original transaction."
                         );
                         return Err(anyhow!("Interrupted"))
                     }
@@ -369,21 +369,19 @@ impl AppTrait for App {
                 }
                 Err(e) => {
                     if e.is_expired() {
+                        println!("Receiver session expired: {session_id}");
                         match e.expiry_fallback_tx() {
                             Some(tx) => println!(
-                                "Session {session_id} receiver expired. Broadcast the original transaction manually:\n{}",
+                                "Broadcast the original transaction manually:\n{}",
                                 serialize_hex(tx)
                             ),
                             None => println!(
-                                "No fallback transaction available for expired receiver session {session_id}."
+                                "No fallback transaction available for expired receiver session: {session_id}"
                             ),
                         }
                     } else {
-                        tracing::error!(
-                            "An error {:?} occurred while replaying receiver session",
-                            e
-                        );
-                        println!("Session {session_id} receiver failed to replay - {e}");
+                        tracing::error!("An error {:?} occurred while replaying session", e);
+                        println!("Session failed to replay: {session_id} - {e}");
                     }
                     Self::close_failed_session(&recv_persister, &session_id, "receiver");
                 }
@@ -405,18 +403,19 @@ impl AppTrait for App {
                 }
                 Err(e) => {
                     if e.is_expired() {
+                        println!("Sender session expired: {session_id}");
                         match e.expiry_fallback_tx() {
                             Some(tx) => println!(
-                                "Session {session_id} sender expired. Broadcast the original transaction manually:\n{}",
+                                "Broadcast the original transaction manually:\n{}",
                                 serialize_hex(tx)
                             ),
                             None => println!(
-                                "No fallback transaction available for expired sender session {session_id}."
+                                "No fallback transaction available for expired sender session: {session_id}"
                             ),
                         }
                     } else {
-                        tracing::error!("An error {:?} occurred while replaying Sender session", e);
-                        println!("Session {session_id} sender failed to replay -  {e}");
+                        tracing::error!("An error {:?} occurred while replaying session", e);
+                        println!("Session failed to replay: {session_id} -  {e}");
                     }
                     Self::close_failed_session(&sender_persister, &session_id, "sender");
                 }

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -125,6 +125,11 @@ pub enum Commands {
         /// The path to the ohttp keys file
         #[arg(long = "ohttp-keys", value_parser = value_parser!(PathBuf))]
         ohttp_keys: Option<PathBuf>,
+
+        #[cfg(feature = "v2")]
+        /// Session expiration in seconds from now
+        #[arg(long = "expire-in")]
+        expire_in: Option<u64>,
     },
     /// Resume pending payjoins (BIP77/v2 only)
     #[cfg(feature = "v2")]

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -52,6 +52,37 @@ mod e2e {
         session_id
     }
 
+    /// Read lines from `child_stderr` until `match_pattern` is found and the corresponding
+    /// line is returned.
+    /// Also writes every read line to tokio::io::stdout();
+    async fn wait_for_stderr_match<F>(
+        child_stderr: &mut tokio::process::ChildStderr,
+        match_pattern: F,
+    ) -> Option<String>
+    where
+        F: Fn(&str) -> bool,
+    {
+        let reader = BufReader::new(child_stderr);
+        let mut lines = reader.lines();
+        let mut res = None;
+
+        let mut stderr = tokio::io::stderr();
+        while let Some(line) = lines.next_line().await.expect("Failed to read line from stdout") {
+            // Write all output to tests stdout
+            stderr
+                .write_all(format!("{line}\n").as_bytes())
+                .await
+                .expect("Failed to write to stderr");
+
+            if match_pattern(&line) {
+                res = Some(line);
+                break;
+            }
+        }
+
+        res
+    }
+
     /// Read lines from `child_stdout` until `match_pattern` is found and the corresponding
     /// line is returned.
     /// Also writes every read line to tokio::io::stdout();
@@ -1009,6 +1040,198 @@ mod e2e {
                 cancel_again_output.contains(&format!("Session {session_id} is already closed")),
                 "cancel on closed session should reference the session id and report it is already closed"
             );
+
+            Ok(())
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "v2")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sender_expire_v2() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use payjoin_test_utils::{init_tracing, TestServices};
+        use tempfile::TempDir;
+
+        type Result<T> = std::result::Result<T, BoxError>;
+
+        init_tracing();
+        let mut services = TestServices::initialize_with_relays(3).await?;
+        let temp_dir = tempdir()?;
+
+        let result = tokio::select! {
+            res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {res:?}").into()),
+            res = services.take_directory_handle() => Err(format!("Directory server is long running: {res:?}").into()),
+            res = expire_sender_async(&services, &temp_dir) => res,
+        };
+
+        assert!(result.is_ok(), "sender_expire_v2 failed: {:#?}", result.unwrap_err());
+
+        async fn expire_sender_async(services: &TestServices, temp_dir: &TempDir) -> Result<()> {
+            let sender_db_path = temp_dir.path().join("sender_db");
+            let (bitcoind, _sender, _receiver) = init_bitcoind_sender_receiver(None, None)?;
+            let cert_path = &temp_dir.path().join("localhost.der");
+            tokio::fs::write(cert_path, services.cert()).await?;
+            services.wait_for_services_ready().await?;
+            let ohttp_keys = services.fetch_ohttp_keys().await?;
+            let ohttp_keys_path = temp_dir.path().join("ohttp_keys");
+            tokio::fs::write(&ohttp_keys_path, ohttp_keys.encode()?).await?;
+
+            let receiver_db_path = temp_dir.path().join("receiver_db");
+            let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
+            let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
+            let cookie_file = &bitcoind.params.cookie_file;
+            let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
+            let directory = &services.directory_url();
+            let ohttp_relays = &services.ohttp_relay_urls();
+
+            // Start receiver with short 15s expiry, get BIP21, kill receiver
+            let cli_receiver = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("receive")
+                .arg(RECEIVE_SATS)
+                .arg("--pj-directories")
+                .arg(directory)
+                .arg("--ohttp-keys")
+                .arg(&ohttp_keys_path)
+                .arg("--expire-in")
+                .arg("5")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli receiver");
+            let bip21 = get_bip21_from_receiver(cli_receiver).await;
+
+            // Start sender with the BIP21 (15s expiry embedded from receiver)
+            // Sender posts original proposal, polls until expiry, auto-cancels
+            let mut cli_sender = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&sender_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&sender_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("send")
+                .arg(&bip21)
+                .arg("--fee-rate")
+                .arg("1")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli sender");
+
+            let mut sender_stdout =
+                cli_sender.stdout.take().expect("failed to take stdout of sender");
+            let timeout = tokio::time::Duration::from_secs(60);
+            let expire_line = tokio::time::timeout(
+                timeout,
+                wait_for_stdout_match(&mut sender_stdout, |l| {
+                    l.contains("Broadcast the original transaction manually")
+                }),
+            )
+            .await?;
+
+            // Process should exit on its own after handling expiry
+            let _ = cli_sender.wait().await;
+
+            assert!(expire_line.is_some(), "sender should print fallback tx hex on expiry");
+
+            Ok(())
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "v2")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn receiver_expire_v2() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use payjoin_test_utils::{init_tracing, TestServices};
+        use tempfile::TempDir;
+
+        type Result<T> = std::result::Result<T, BoxError>;
+
+        init_tracing();
+        let mut services = TestServices::initialize_with_relays(3).await?;
+        let temp_dir = tempdir()?;
+
+        let result = tokio::select! {
+            res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {res:?}").into()),
+            res = services.take_directory_handle() => Err(format!("Directory server is long running: {res:?}").into()),
+            res = expire_receiver_async(&services, &temp_dir) => res,
+        };
+
+        assert!(result.is_ok(), "receiver_expire_v2 failed: {:#?}", result.unwrap_err());
+
+        async fn expire_receiver_async(services: &TestServices, temp_dir: &TempDir) -> Result<()> {
+            let receiver_db_path = temp_dir.path().join("receiver_db");
+            let (bitcoind, _sender, _receiver) = init_bitcoind_sender_receiver(None, None)?;
+            let cert_path = &temp_dir.path().join("localhost.der");
+            tokio::fs::write(cert_path, services.cert()).await?;
+            services.wait_for_services_ready().await?;
+            let ohttp_keys = services.fetch_ohttp_keys().await?;
+            let ohttp_keys_path = temp_dir.path().join("ohttp_keys");
+            tokio::fs::write(&ohttp_keys_path, ohttp_keys.encode()?).await?;
+
+            let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
+            let cookie_file = &bitcoind.params.cookie_file;
+            let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
+            let directory = &services.directory_url();
+            let ohttp_relays = &services.ohttp_relay_urls();
+
+            // Start receiver with short 15s expiry
+            // It will post to directory, poll, detect expiry, auto-cancel
+            let mut cli_receiver = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("receive")
+                .arg(RECEIVE_SATS)
+                .arg("--pj-directories")
+                .arg(directory)
+                .arg("--ohttp-keys")
+                .arg(&ohttp_keys_path)
+                .arg("--expire-in")
+                .arg("5")
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("Failed to execute payjoin-cli receiver");
+
+            let mut receiver_stderr =
+                cli_receiver.stderr.take().expect("failed to take stderr of receiver");
+            let timeout = tokio::time::Duration::from_secs(60);
+            let expired_line = tokio::time::timeout(
+                timeout,
+                wait_for_stderr_match(&mut receiver_stderr, |l| {
+                    l.contains("Error: Receiver session expired:")
+                }),
+            )
+            .await?;
+
+            // Process should exit on its own after handling expiry
+            let _ = cli_receiver.wait().await;
+
+            assert!(expired_line.is_some(), "receiver should print expiry message before exit");
 
             Ok(())
         }

--- a/payjoin/src/core/error.rs
+++ b/payjoin/src/core/error.rs
@@ -53,7 +53,7 @@ impl<SessionState: Debug, SessionEvent: Debug> std::fmt::Display
             },
             InvalidEventPayload(event, reason) =>
                 write!(f, "Invalid event payload ({event:?}): {reason}"),
-            Expired(time) => write!(f, "Session expired at {time:?}"),
+            Expired(time, _) => write!(f, "Session expired at {time:?}"),
             PersistenceFailure(e) => write!(f, "Persistence failure: {e}"),
         }
     }
@@ -75,7 +75,20 @@ impl<SessionState: Debug, SessionEvent: Debug> From<InternalReplayError<SessionS
 impl<SessionState, SessionEvent> ReplayError<SessionState, SessionEvent> {
     /// Returns `true` if the event log could not be replayed because the
     /// session has expired.
-    pub fn is_expired(&self) -> bool { matches!(self.0, InternalReplayError::Expired(_)) }
+    pub fn is_expired(&self) -> bool { matches!(self.0, InternalReplayError::Expired(..)) }
+
+    /// Returns the fallback transaction that should be broadcast when the
+    /// session has expired, if one is recoverable from the event log.
+    ///
+    /// Returns `None` for non-expired errors, or for an expired session that
+    /// never produced a fallback transaction (e.g. a receiver that expired
+    /// before receiving the sender's original proposal).
+    pub fn expiry_fallback_tx(&self) -> Option<&bitcoin::Transaction> {
+        match &self.0 {
+            InternalReplayError::Expired(_, tx) => tx.as_ref(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(feature = "v2")]
@@ -87,8 +100,8 @@ pub(crate) enum InternalReplayError<SessionState, SessionEvent> {
     InvalidEvent(Box<SessionEvent>, Option<Box<SessionState>>),
     /// Event payload failed validation
     InvalidEventPayload(Box<SessionEvent>, String),
-    /// Session is expired
-    Expired(crate::time::Time),
+    /// Session is expired. Carries the recoverable fallback transaction, if any.
+    Expired(crate::time::Time, Option<bitcoin::Transaction>),
     /// Application storage error
     PersistenceFailure(ImplementationError),
 }
@@ -100,8 +113,10 @@ mod tests {
 
     #[test]
     fn replay_error_is_expired() {
-        let expired: ReplayError<(), ()> = ReplayError(InternalReplayError::Expired(Time::now()));
+        let expired: ReplayError<(), ()> =
+            ReplayError(InternalReplayError::Expired(Time::now(), None));
         assert!(expired.is_expired());
+        assert!(expired.expiry_fallback_tx().is_none());
 
         let other: ReplayError<(), ()> = ReplayError(InternalReplayError::NoEvents);
         assert!(!other.is_expired());

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -33,7 +33,7 @@ fn construct_history(
     if !matches!(receiver, ReceiveSession::Closed(_)) {
         let ctx = history.session_context();
         if ctx.expiration.elapsed() {
-            return Err(InternalReplayError::Expired(ctx.expiration).into());
+            return Err(InternalReplayError::Expired(ctx.expiration, history.fallback_tx()).into());
         }
     }
     Ok(history)
@@ -650,7 +650,7 @@ mod tests {
             .expect("in memory persister save should not fail");
         let err = replay_event_log(&persister).expect_err("session should be expired");
         let expected_err: ReplayError<ReceiveSession, SessionEvent> =
-            InternalReplayError::Expired(expiration).into();
+            InternalReplayError::Expired(expiration, None).into();
         assert_eq!(err.to_string(), expected_err.to_string());
 
         let persister = InMemoryAsyncPersister::<SessionEvent>::default();
@@ -660,7 +660,7 @@ mod tests {
             .expect("in memory async persister save should not fail");
         let err = replay_event_log_async(&persister).await.expect_err("session should be expired");
         let expected_err: ReplayError<ReceiveSession, SessionEvent> =
-            InternalReplayError::Expired(expiration).into();
+            InternalReplayError::Expired(expiration, None).into();
         assert_eq!(err.to_string(), expected_err.to_string());
     }
 

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -30,7 +30,11 @@ fn construct_history(
     if !matches!(sender, SendSession::Closed(_)) {
         let pj_param = history.pj_param();
         if pj_param.expiration().elapsed() {
-            return Err(InternalReplayError::Expired(pj_param.expiration()).into());
+            return Err(InternalReplayError::Expired(
+                pj_param.expiration(),
+                Some(history.fallback_tx()),
+            )
+            .into());
         }
     }
     Ok(history)


### PR DESCRIPTION
This PR builds on #1688 but reverts the `completed_at` DB column removal.

- Add an auto-cancel mid loop when passing the expiry instead of only on process start.
- print the session ID at the start of the session to better keep track if the user want to immediately cancel.
- Show what sessions have a fallback transaction available from `payjoin-cli history` for rebroadcasting.

example output. _custom timeout of 20s to demonstrate automatic cancel logic_
<img width="899" height="321" alt="image" src="https://github.com/user-attachments/assets/e802060d-95c0-4d3d-bdf6-f2a864c46ae2" />


Coded with help from GLM-5.2

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
