### PR TITLE
Apply 1.0 freeze-required API fixes (non_exhaustive, ShortIdError, OutputSubstitution, must_use)

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -127,6 +127,7 @@ impl Config {
                     "BIP77 (v2) selected but v2 feature not enabled".to_string(),
                 ));
             }
+            _ => return Err(ConfigError::Message("Unsupported payjoin version".to_string())),
         }
 
         config = handle_subcommands(config, cli)?;
@@ -235,6 +236,7 @@ impl Config {
                     "BIP77 (v2) selected but v2 feature not enabled".to_string(),
                 ));
             }
+            _ => return Err(ConfigError::Message("Unsupported payjoin version".to_string())),
         }
 
         if config.version.is_none() {

--- a/payjoin/src/core/into_url.rs
+++ b/payjoin/src/core/into_url.rs
@@ -1,6 +1,7 @@
 use crate::core::{Url, UrlParseError};
 
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     BadScheme,
     ParseError(UrlParseError),

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -25,7 +25,6 @@ pub use uri::{PjParam, PjParseError, PjUri, Uri, UriExt};
 pub(crate) mod error_codes;
 
 pub(crate) mod output_substitution;
-#[cfg(feature = "v1")]
 pub use output_substitution::OutputSubstitution;
 
 #[cfg(feature = "v2")]

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -69,6 +69,7 @@ impl<Event> PersistActions<Event> {
 
 /// Handles cases where the transition either succeeds with a final result that ends the session, or hits a static condition and stays in the same state.
 /// State transition may also be a fatal error or transient error.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct MaybeSuccessTransitionWithNoResults<Event, SuccessValue, CurrentState, Err>(
     Result<AcceptOptionalTransition<Event, SuccessValue, CurrentState>, Rejection<Event, Err>>,
 );
@@ -156,6 +157,7 @@ where
 }
 
 /// A transition that can result in a state transition, fatal error, or successfully have no results.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct MaybeFatalTransitionWithNoResults<Event, NextState, CurrentState, Err>(
     Result<AcceptOptionalTransition<Event, NextState, CurrentState>, Rejection<Event, Err>>,
 );
@@ -240,6 +242,7 @@ where
 }
 
 /// A transition that can be either fatal, transient, or a state transition.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct MaybeFatalTransition<Event, NextState, Err, ErrorState = ()>(
     pub(crate) Result<AcceptNextState<Event, NextState>, Rejection<Event, Err, ErrorState>>,
 );
@@ -310,6 +313,7 @@ where
 
 /// A transition that can result in a state transition or a transient error.
 /// Fatal errors cannot occur in this transition.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct MaybeTransientTransition<Event, NextState, Err>(
     Result<AcceptNextState<Event, NextState>, RejectTransient<Err>>,
 );
@@ -362,6 +366,7 @@ where
 }
 
 /// A transition that always results in a state transition.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct NextStateTransition<Event, NextState>(AcceptNextState<Event, NextState>);
 
 impl<Event, NextState> NextStateTransition<Event, NextState> {
@@ -400,6 +405,7 @@ impl<Event, NextState> NextStateTransition<Event, NextState> {
 /// No error path exists. Both outcomes are successful from the protocol's point
 /// of view. The choice is determined by the source typestate's internal data,
 /// not by the caller.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct MaybeTerminalTransition<Event, NextState>(MaybeTerminalOutcome<Event, NextState>);
 
 impl<Event, NextState> MaybeTerminalTransition<Event, NextState> {
@@ -446,6 +452,7 @@ impl<Event, NextState> MaybeTerminalTransition<Event, NextState> {
 /// Fatal outcomes still persist an event. When the fatal outcome advances, the
 /// saved event keeps the session live for replay while the caller receives the
 /// fatal protocol error.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct MaybeTerminalSuccessTransition<Event, NextState, Err>(
     MaybeTerminalSuccessOutcome<Event, NextState, Err>,
 );
@@ -531,6 +538,7 @@ where
 /// being persisted. This lets callers receive derived data (e.g. a fallback
 /// transaction) through the same `.save()` call pattern used by every other
 /// transition type.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub struct TerminalTransition<Event, T>(Event, T);
 
 impl<Event, T> TerminalTransition<Event, T> {
@@ -557,6 +565,7 @@ impl<Event, T> TerminalTransition<Event, T> {
 
 /// A transition that can result in a succession completion, fatal error, or transient error.
 /// The transition can also result in no state change.
+#[must_use = "a transition must be persisted with .save() to advance the session"]
 pub enum MaybeFatalOrSuccessTransition<Event, CurrentState, Err> {
     Success(Event),
     NoResults(CurrentState),

--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -57,6 +57,7 @@ impl error::Error for Error {
 /// 4. Provide errors according to BIP-78 JSON error specifications for return
 ///    after conversion into [`JsonReply`]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ProtocolError {
     /// Error arising from validation of the original PSBT payload
     OriginalPayload(PayloadError),

--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -180,6 +180,7 @@ impl SessionHistory {
 // Represents the status of a session that can be inferred from the information in the session
 // event log.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SessionStatus {
     Active,
     Expired,

--- a/payjoin/src/core/send/v2/session.rs
+++ b/payjoin/src/core/send/v2/session.rs
@@ -143,6 +143,7 @@ impl SessionHistory {
 /// Represents the status of a session that can be inferred from the information in the session
 /// event log.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SessionStatus {
     Expired,
     Active,

--- a/payjoin/src/core/url.rs
+++ b/payjoin/src/core/url.rs
@@ -143,6 +143,7 @@ impl<'a> UrlQueryPairs<'a> {
 ///
 /// Re-exported at the crate root as `UrlParseError`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ParseError {
     /// The authority section had no host between `://` and the path.
     EmptyHost,

--- a/payjoin/src/core/version.rs
+++ b/payjoin/src/core/version.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///   and to match the expected wire format.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Version {
     /// BIP 78 Payjoin
     One = 1,

--- a/payjoin/src/directory.rs
+++ b/payjoin/src/directory.rs
@@ -48,6 +48,24 @@ pub enum ShortIdError {
     IncorrectLength(std::array::TryFromSliceError),
 }
 
+impl std::fmt::Display for ShortIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShortIdError::DecodeBech32(e) => write!(f, "Failed to decode short ID: {e}"),
+            ShortIdError::IncorrectLength(e) => write!(f, "Short ID has an incorrect length: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ShortIdError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ShortIdError::DecodeBech32(e) => Some(e),
+            ShortIdError::IncorrectLength(e) => Some(e),
+        }
+    }
+}
+
 impl std::convert::From<bitcoin::hashes::sha256::Hash> for ShortId {
     fn from(h: bitcoin::hashes::sha256::Hash) -> Self {
         bitcoin::hashes::Hash::as_byte_array(&h)[..8]

--- a/payjoin/src/directory.rs
+++ b/payjoin/src/directory.rs
@@ -42,6 +42,7 @@ impl std::fmt::Display for ShortId {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ShortIdError {
     DecodeBech32(bitcoin::bech32::primitives::decode::CheckedHrpstringError),
     IncorrectLength(std::array::TryFromSliceError),


### PR DESCRIPTION
## Summary

I ran a 1.0 API audit with Claude that surfaced these relatively low-hanging fruit issues that are best addressed before a 1.0 freeze.

Each commit is standalone:

1. **Mark public enums non-exhaustive** — the receive/send session
   state/event/status/outcome enums, `ReceiveSession`/`SendSession`,
   `ProtocolError`, `IntoUrlError`, `UrlParseError`, `ShortIdError`, `Version`,
   `MaybePayjoinExtras`, and the persist transition/outcome enums. Adds the
   required wildcard arms in `payjoin-cli` (graceful "unknown" fallbacks in
   display and dispatch) and `payjoin-ffi` (`unreachable!()` in the infallible
   mirror-conversion `From` impls, which are version-locked to `payjoin`).
2. **Implement `Error` + `Display` for `ShortIdError`** so it can be
   `?`-propagated — it is the `Err` type of `ShortId`'s `TryFrom`/`FromStr` but
   derived only `Debug`.
3. **Export `OutputSubstitution` under v2** — it was gated on the `v1` feature,
   but v2 methods return it and v2 does not enable v1, so default (v2-only)
   builds could not name the type.
4. **Mark the persist transition types `#[must_use]`** so dropping a transition
   without `.save()` is a compiler warning instead of a silently lost step.

Follows #1702 (bitcoin-ohttp / bitcoin-hpke insulation). Tracking: #976.

Disclosure: co-authored by Claude Code (Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
