### PR TITLE
Add --session-id to resume command to allow resuming single sessions

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -382,7 +382,7 @@ fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError
             Ok(config)
         }
         #[cfg(feature = "v2")]
-        Commands::Resume => Ok(config),
+        Commands::Resume { .. } => Ok(config),
         #[cfg(feature = "v2")]
         Commands::History => Ok(config),
         #[cfg(feature = "v2")]

--- a/payjoin-cli/src/app/mod.rs
+++ b/payjoin-cli/src/app/mod.rs
@@ -29,7 +29,7 @@ pub trait App: Send + Sync {
     async fn send_payjoin(&self, bip21: &str, fee_rate: FeeRate) -> Result<()>;
     async fn receive_payjoin(&self, amount: Amount) -> Result<()>;
     #[cfg(feature = "v2")]
-    async fn resume_payjoins(&self) -> Result<()>;
+    async fn resume_payjoins(&self, session_id: Option<SessionId>) -> Result<()>;
     #[cfg(feature = "v2")]
     async fn history(&self) -> Result<()>;
     #[cfg(feature = "v2")]

--- a/payjoin-cli/src/app/v1.rs
+++ b/payjoin-cli/src/app/v1.rs
@@ -119,7 +119,7 @@ impl AppTrait for App {
     }
 
     #[cfg(feature = "v2")]
-    async fn resume_payjoins(&self) -> Result<()> {
+    async fn resume_payjoins(&self, _session_id: Option<crate::db::v2::SessionId>) -> Result<()> {
         unimplemented!("resume_payjoins not implemented for v1");
     }
 

--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -301,9 +301,17 @@ impl AppTrait for App {
         Ok(())
     }
 
-    async fn resume_payjoins(&self) -> Result<()> {
-        let recv_session_ids = self.db.get_recv_session_ids()?;
-        let send_session_ids = self.db.get_send_session_ids()?;
+    async fn resume_payjoins(&self, session_id: Option<SessionId>) -> Result<()> {
+        let mut recv_session_ids = self.db.get_recv_session_ids()?;
+        let mut send_session_ids = self.db.get_send_session_ids()?;
+
+        if let Some(ref target_id) = session_id {
+            recv_session_ids.retain(|id| id == target_id);
+            send_session_ids.retain(|id| id == target_id);
+            if recv_session_ids.is_empty() && send_session_ids.is_empty() {
+                anyhow::bail!("Session {target_id} not found or already completed");
+            }
+        }
 
         if recv_session_ids.is_empty() && send_session_ids.is_empty() {
             println!("No sessions to resume.");

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -128,7 +128,11 @@ pub enum Commands {
     },
     /// Resume pending payjoins (BIP77/v2 only)
     #[cfg(feature = "v2")]
-    Resume,
+    Resume {
+        /// Only resume a specific session
+        #[arg(long = "session-id")]
+        session_id: Option<String>,
+    },
     #[cfg(feature = "v2")]
     /// Show payjoin session history
     History,

--- a/payjoin-cli/src/main.rs
+++ b/payjoin-cli/src/main.rs
@@ -71,8 +71,14 @@ async fn main() -> Result<()> {
             app.receive_payjoin(*amount).await?;
         }
         #[cfg(feature = "v2")]
-        Commands::Resume => {
-            app.resume_payjoins().await?;
+        Commands::Resume { session_id } => {
+            let session_id = match session_id {
+                Some(s) => Some(SessionId(
+                    s.parse().map_err(|e| anyhow::anyhow!("Invalid session ID UUID: {e}"))?,
+                )),
+                None => None,
+            };
+            app.resume_payjoins(session_id).await?;
         }
         #[cfg(feature = "v2")]
         Commands::History => {


### PR DESCRIPTION
Adds the ability to resume single sessions instead of all sessions at once.

usage --session-id {session_id} to only resume that individual session. will fail if the session is already closed or not existent.

Coded with Deepseek v4

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
