### PR TITLE
Look up RK instead of looping

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -206,23 +206,16 @@ impl AppTrait for App {
             }
             PjParam::V2(pj_param) => {
                 let receiver_pubkey = pj_param.receiver_pubkey();
-                let sender_state =
-                    self.db.get_send_session_ids()?.into_iter().find_map(|session_id| {
-                        let session_receiver_pubkey = self
-                            .db
-                            .get_send_session_receiver_pk(&session_id)
-                            .expect("Receiver pubkey should exist if session id exists");
-                        if session_receiver_pubkey == *receiver_pubkey {
-                            let sender_persister =
-                                SenderPersister::from_id(self.db.clone(), session_id);
-                            let (send_session, _) = replay_sender_event_log(&sender_persister)
-                                .map_err(|e| anyhow!("Failed to replay sender event log: {:?}", e))
-                                .ok()?;
-
-                            Some((send_session, sender_persister))
-                        } else {
-                            None
-                        }
+                let sender_state = self
+                    .db
+                    .get_send_session_id_by_receiver_pk(receiver_pubkey)?
+                    .and_then(|session_id| {
+                        let sender_persister =
+                            SenderPersister::from_id(self.db.clone(), session_id);
+                        let (send_session, _) = replay_sender_event_log(&sender_persister)
+                            .map_err(|e| anyhow!("Failed to replay sender event log: {:?}", e))
+                            .ok()?;
+                        Some((send_session, sender_persister))
                     });
 
                 let (sender_state, persister) = match sender_state {

--- a/payjoin-cli/src/db/v2.rs
+++ b/payjoin-cli/src/db/v2.rs
@@ -4,7 +4,7 @@ use payjoin::persist::SessionPersister;
 use payjoin::receive::v2::SessionEvent as ReceiverSessionEvent;
 use payjoin::send::v2::SessionEvent as SenderSessionEvent;
 use payjoin::HpkePublicKey;
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use super::*;
 
@@ -239,16 +239,22 @@ impl Database {
         Ok(session_ids)
     }
 
-    pub(crate) fn get_send_session_receiver_pk(
+    pub(crate) fn get_send_session_id_by_receiver_pk(
         &self,
-        session_id: &SessionId,
-    ) -> Result<HpkePublicKey> {
+        receiver_pubkey: &HpkePublicKey,
+    ) -> Result<Option<SessionId>> {
         let conn = self.get_connection()?;
-        let mut stmt =
-            conn.prepare("SELECT receiver_pubkey FROM send_sessions WHERE session_id = ?1")?;
-        let receiver_pubkey: Vec<u8> =
-            stmt.query_row(params![session_id.0.to_string()], |row| row.get(0))?;
-        Ok(HpkePublicKey::from_compressed_bytes(&receiver_pubkey).expect("Valid receiver pubkey"))
+        let receiver_pubkey_bytes = receiver_pubkey.to_compressed_bytes();
+        let mut stmt = conn.prepare(
+            "SELECT session_id FROM send_sessions WHERE receiver_pubkey = ?1 AND completed_at IS NULL",
+        )?;
+        let result = stmt.query_row(params![&receiver_pubkey_bytes], |row| {
+            let session_id: String = row.get(0)?;
+            let session_id = uuid::Uuid::parse_str(&session_id)
+                .expect("Database corruption: invalid session_id UUID");
+            Ok(SessionId(session_id))
+        });
+        Ok(result.optional()?)
     }
 
     pub(crate) fn get_inactive_send_session_ids(&self) -> Result<Vec<(SessionId, u64)>> {


### PR DESCRIPTION
Follow up from https://github.com/payjoin/rust-payjoin/pull/995. We can replace a loop over all active session ids with a WHERE clause.

Supersedes #1013 

since this helper function returns a `Result<Option<SessionId>>` I opted to move some match error handing within the function itself instead of matching at the `send_payjoin` level

Additionally adds some enhacements suggested from the original PR like adding `"completed_at IS NULL"`

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
