### PR TITLE
Correct `create_error_request` return type

### DIFF
--- a/payjoin-ffi/src/receive/error.rs
+++ b/payjoin-ffi/src/receive/error.rs
@@ -191,12 +191,6 @@ impl From<ProtocolError> for JsonReply {
 #[error(transparent)]
 pub struct SessionError(#[from] receive::v2::SessionError);
 
-#[uniffi::export]
-impl SessionError {
-    /// Returns `true` if the session has expired.
-    pub fn is_expired(&self) -> bool { self.0.is_expired() }
-}
-
 /// Protocol error raised during output substitution.
 #[derive(Debug, thiserror::Error, uniffi::Object)]
 #[uniffi::export(Debug, Display)]
@@ -286,7 +280,6 @@ mod tests {
     #[test]
     fn session_and_replay_errors_expose_is_expired() {
         // uniffi Objects expose the core predicate to bindings.
-        let _: fn(&SessionError) -> bool = SessionError::is_expired;
         let _: fn(&ReceiverReplayError) -> bool = ReceiverReplayError::is_expired;
     }
 

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1422,7 +1422,7 @@ impl HasReplyableError {
     pub fn create_error_request(
         &self,
         ohttp_relay: String,
-    ) -> Result<RequestResponse, SessionError> {
+    ) -> Result<RequestResponse, ReceiverCreateRequestError> {
         self.0.clone().create_error_request(ohttp_relay).map_err(Into::into).map(|(req, ctx)| {
             RequestResponse { request: req.into(), client_response: Arc::new(ctx.into()) }
         })

--- a/payjoin/src/core/receive/v2/error.rs
+++ b/payjoin/src/core/receive/v2/error.rs
@@ -16,11 +16,6 @@ impl From<InternalSessionError> for SessionError {
     fn from(value: InternalSessionError) -> Self { SessionError(value) }
 }
 
-impl SessionError {
-    /// Returns `true` if the session has expired.
-    pub fn is_expired(&self) -> bool { matches!(self.0, InternalSessionError::Expired(_)) }
-}
-
 impl From<crate::into_url::Error> for SessionError {
     fn from(e: crate::into_url::Error) -> Self { SessionError(InternalSessionError::ParseUrl(e)) }
 }
@@ -29,10 +24,6 @@ impl From<crate::into_url::Error> for SessionError {
 pub(crate) enum InternalSessionError {
     /// Url parsing failed
     ParseUrl(crate::into_url::Error),
-    /// The session has expired
-    Expired(Time),
-    /// OHTTP Encapsulation failed
-    OhttpEncapsulation(OhttpEncapsulationError),
     /// Hybrid Public Key Encryption failed
     Hpke(HpkeError),
     /// The directory returned a bad response
@@ -45,8 +36,6 @@ impl fmt::Display for SessionError {
 
         match &self.0 {
             ParseUrl(e) => write!(f, "URL parsing failed: {e}"),
-            Expired(expiration) => write!(f, "Session expired at {expiration:?}"),
-            OhttpEncapsulation(e) => write!(f, "OHTTP Encapsulation Error: {e}"),
             Hpke(e) => write!(f, "Hpke decryption failed: {e}"),
             DirectoryResponse(e) => write!(f, "Directory response error: {e}"),
         }
@@ -59,8 +48,6 @@ impl error::Error for SessionError {
 
         match &self.0 {
             ParseUrl(e) => Some(e),
-            Expired(_) => None,
-            OhttpEncapsulation(e) => Some(e),
             Hpke(e) => Some(e),
             DirectoryResponse(e) => Some(e),
         }
@@ -143,15 +130,6 @@ impl From<OhttpEncapsulationError> for CreateRequestError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn session_error_is_expired() {
-        let expired = SessionError(InternalSessionError::Expired(Time::now()));
-        assert!(expired.is_expired());
-
-        let other = SessionError(InternalSessionError::ParseUrl(crate::into_url::Error::BadScheme));
-        assert!(!other.is_expired());
-    }
 
     #[test]
     fn create_request_error_is_expired() {

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1397,10 +1397,10 @@ impl Receiver<HasReplyableError> {
     pub fn create_error_request(
         &self,
         ohttp_relay: impl IntoUrl,
-    ) -> Result<(Request, OhttpResponse), SessionError> {
+    ) -> Result<(Request, OhttpResponse), CreateRequestError> {
         let session_context = &self.session_context;
         if session_context.expiration.elapsed() {
-            return Err(InternalSessionError::Expired(session_context.expiration).into());
+            return Err(InternalCreateRequestError::Expired(self.session_context.expiration).into());
         }
         let mailbox =
             mailbox_endpoint(&session_context.directory, &session_context.reply_mailbox_id());
@@ -1410,8 +1410,7 @@ impl Receiver<HasReplyableError> {
                     self.error_reply.to_json().to_string().into_bytes(),
                     &session_context.receiver_key,
                     reply_key,
-                )
-                .map_err(InternalSessionError::Hpke)?
+                )?
             } else {
                 // Post a generic unavailable error message in the case where we don't have a reply key
                 let err =
@@ -1421,7 +1420,7 @@ impl Receiver<HasReplyableError> {
         };
         let (body, ohttp_ctx) =
             ohttp_encapsulate(&session_context.ohttp_keys, "POST", mailbox.as_str(), Some(&body))
-                .map_err(InternalSessionError::OhttpEncapsulation)?;
+                .map_err(InternalCreateRequestError::OhttpEncapsulation)?;
         let req = Request::new_v2(&session_context.full_relay_url(ohttp_relay)?, &body);
         Ok((req, OhttpResponse::new(ohttp_ctx)))
     }
@@ -1995,7 +1994,7 @@ pub mod test {
         match expiration {
             Err(error) => assert_eq!(
                 error.to_string(),
-                SessionError::from(InternalSessionError::Expired(now)).to_string()
+                CreateRequestError::from(InternalCreateRequestError::Expired(now)).to_string()
             ),
             Ok(_) => panic!("Expected session expiration error, got success"),
         }


### PR DESCRIPTION
### Summary

Resolves https://github.com/payjoin/rust-payjoin/issues/1714. `Receiver<HasReplyableError>::create_error_request` is currently employing a `SessionError` error type when it should be using `CreateRequestError` error type instead, just like all the create request methods. This PR makes that correction.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
