### PR TITLE
Remove utxos_to_be_locked

### DIFF
--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -1289,18 +1289,6 @@ impl_save_for_transition!(PayjoinProposalTransition, Monitor);
 
 #[uniffi::export]
 impl PayjoinProposal {
-    pub fn utxos_to_be_locked(&self) -> Vec<OutPoint> {
-        let mut outpoints: Vec<OutPoint> = Vec::new();
-        for o in <PayjoinProposal as Into<
-            payjoin::receive::v2::Receiver<payjoin::receive::v2::PayjoinProposal>,
-        >>::into(self.clone())
-        .utxos_to_be_locked()
-        {
-            outpoints.push(OutPoint::from(*o));
-        }
-        outpoints
-    }
-
     pub fn psbt(&self) -> String {
         <PayjoinProposal as Into<
             payjoin::receive::v2::Receiver<payjoin::receive::v2::PayjoinProposal>,

--- a/payjoin/src/core/receive/v1/mod.rs
+++ b/payjoin/src/core/receive/v1/mod.rs
@@ -313,11 +313,6 @@ pub struct PayjoinProposal {
 }
 
 impl PayjoinProposal {
-    /// The UTXOs that would be spent by this Payjoin transaction.
-    pub fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
-        self.payjoin_psbt.unsigned_tx.input.iter().map(|input| &input.previous_output)
-    }
-
     /// The Payjoin Proposal PSBT.
     pub fn psbt(&self) -> &Psbt { &self.payjoin_psbt }
 }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1258,13 +1258,6 @@ pub struct PayjoinProposal {
 /// A finalized Payjoin proposal, complete with fees and receiver signatures, that the sender
 /// should find acceptable.
 impl Receiver<PayjoinProposal> {
-    /// The UTXOs that would be spent by this Payjoin transaction.
-    pub fn utxos_to_be_locked(&self) -> impl '_ + Iterator<Item = &bitcoin::OutPoint> {
-        // TODO: de-duplicate this with the v1 implementation
-        // It would make more sense if the payjoin proposal was only available after utxos are locked via session persister
-        self.psbt_context.payjoin_psbt.unsigned_tx.input.iter().map(|input| &input.previous_output)
-    }
-
     /// The Payjoin Proposal PSBT.
     pub fn psbt(&self) -> &Psbt { &self.psbt_context.payjoin_psbt }
 


### PR DESCRIPTION
Supersedes #1568

This getter is a vestige of the original bip78 typestate design, in which UnlockedProposal::utxos_to_be_locked() paired with assume_locked() to force integrators to lock the proposal's inputs before a usable Proposal could be obtained. The assume_locked() gate was dropped in 97f0aa2e, leaving an optional getter with no enforcement behind it.

The outpoints it returns are also of no use to the receiver by the time PayjoinProposal is reached. The receiver's own contributed inputs were hand-picked in contribute_inputs, so the caller already knows them, and the sender's inputs are not the receiver's to lock. The probing defense this method was originally tied to is handled by
check_no_inputs_seen_before at the start of the flow.

Co-authored by Claude Opus 4.8

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
