### PR TITLE
Use the binary dotnet SDK in Darwin dev shells

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
+      # The unix jobs run inside the flake's csharp dev shell, so changes to
+      # the flake change this workflow's environment.
+      - flake.nix
+      - flake.lock
 
 jobs:
   build-csharp-and-test-unix:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
+      # The jobs run inside the flake's dev shell, so changes to the flake
+      # change this workflow's environment.
+      - flake.nix
+      - flake.lock
 
 jobs:
   build-dart-and-test:

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
+      # The jobs run inside the flake's dev shell, so changes to the flake
+      # change this workflow's environment.
+      - flake.nix
+      - flake.lock
 
 jobs:
   build-js-and-test:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
       - payjoin-ffi/**
+      # The jobs run inside the flake's dev shell, so changes to the flake
+      # change this workflow's environment.
+      - flake.nix
+      - flake.lock
 
 jobs:
   build-python-and-test:

--- a/flake.nix
+++ b/flake.nix
@@ -259,7 +259,16 @@
             "payjoin-mailroom-image" = mkContainerImage "payjoin-mailroom" packages.payjoin-mailroom tag;
           };
 
-        dotnetSdk = pkgs.dotnetCorePackages.sdk_10_0;
+        # On Darwin the default sdk_10_0 resolves to the source-built VMR, which has
+        # no binaries in the public nix cache: every uncached realization compiles
+        # the entire .NET SDK from source (hours on CI runners and contributor
+        # machines). Use the Microsoft-binary SDK there; Linux keeps the
+        # source-built SDK, which hydra serves from cache.
+        dotnetSdk =
+          if pkgs.stdenv.isDarwin then
+            pkgs.dotnetCorePackages.sdk_10_0_1xx-bin
+          else
+            pkgs.dotnetCorePackages.sdk_10_0;
 
         devShells = builtins.mapAttrs (
           _name: craneLib:


### PR DESCRIPTION
The "Build and test csharp (macos-latest)" job takes 2.5–3 hours on every run (2h51m, 2h53m, 2h29m on the three most recent PRs, and the same ~150–170 min on every earlier `csharp.yml` run sampled back through July 4). The job log shows where the time goes: of a 2h29m run, the script itself, cargo build, bindings generation, `dotnet test`, finishes in under five minutes (4m09s + 2s + 8s); the remaining ~2h24m is `nix develop .#csharp` building `dotnet-vmr` derivations before the command even starts.

`dotnetCorePackages.sdk_10_0` resolves to the source-built VMR SDK, and the public nix cache has no Darwin binaries for it, so every macOS CI run, and every macOS contributor's first `nix develop .#csharp`, compiles the entire .NET SDK from source.

This switches the Darwin dev shells to the Microsoft-binary SDK, `sdk_10_0_1xx-bin`: the same `10.0.1xx` feature band that `global.json` requires (`10.0.100`, `rollForward: latestFeature`), and the same `share/dotnet` layout that `DOTNET_ROOT` expects. Linux keeps the source-built SDK, which hydra serves from cache. After the change, the Darwin csharp shell's closure contains the `dotnet-sdk-10.0.109-osx-arm64` binary tarball and no VMR derivations.

Disclosure: co-authored by Claude Code

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
