### PR TITLE
Bump payjoin version to 1.0.0-rc.4

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2754,7 +2754,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "bhttp",
  "bitcoin 0.32.9",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2879,7 +2879,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "bhttp",
  "bitcoin 0.32.101",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6.0.0"
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.8.0", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1.18", optional = true }
-payjoin = { version = "1.0.0-rc.3", default-features = false }
+payjoin = { version = "1.0.0-rc.4", default-features = false }
 pest_derive = "2.7.0"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -27,7 +27,7 @@ getrandom = "0.2.10"
 icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 lazy_static = "1.5.0"
-payjoin = { version = "1.0.0-rc.3", features = ["v1", "v2"] }
+payjoin = { version = "1.0.0-rc.4", features = ["v1", "v2"] }
 payjoin-test-utils = { version = "0.0.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -61,7 +61,7 @@ opentelemetry-otlp = { version = "0.31", optional = true, features = [
   "reqwest-rustls",
 ] }
 opentelemetry_sdk = "0.31"
-payjoin = { version = "1.0.0-rc.3", features = [
+payjoin = { version = "1.0.0-rc.4", features = [
   "directory",
 ], default-features = false }
 rand = "0.8"

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,7 +32,7 @@ futures = { version = "0.3.21", default-features = false, features = ["std"] }
 http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "1.0.0-rc.3", default-features = false }
+payjoin = { version = "1.0.0-rc.4", default-features = false }
 payjoin-mailroom = { version = "0.1.1", features = ["_manual-tls"] }
 tar = "0.4.20"
 # Pin to 0.14.7 (last version to support our MSRV 1.85)

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Payjoin Changelog
 
+## 1.0.0-rc.4
+
+This release locks down the public API ahead of the 1.0 freeze. It insulates the bitcoin-ohttp and bitcoin-hpke types from the public interface, marks public enums non_exhaustive and persistence transition types must_use, exposes transient versus fatal classification on PersistedError, corrects the create_error_request return type, renames the Receiver<Monitor> check methods, and removes utxos_to_be_locked. It also hardens the receiver against panic paths and fixes bugs in output substitution change handling, session replay, and coin selection.
+
+Selected Improvements:
+
+### API Stabilization
+
+- Insulate `bitcoin-ohttp` and `bitcoin-hpke` from the public API (#1702)
+- Apply 1.0 freeze-required API fixes: `#[non_exhaustive]` enums, `ShortIdError`, `OutputSubstitution` export, and `#[must_use]` transition types (#1703)
+- Expose transient versus fatal classification on `PersistedError` and return current state in transient errors (#1724)
+- Correct `create_error_request` return type (#1715)
+- Rename `Receiver<Monitor>` check methods (`check_for_broadcast` to `check_for_transaction`) (#1661, #1684)
+- Remove `utxos_to_be_locked` (#1719)
+- Add `InputPair::outpoint()` accessor (#1654)
+
+### Bug Fixes and Hardening
+
+- Prevent receiver panic paths (#1704)
+- Fix output substitution change misdirect (#1685)
+- Fix session replay reporting closed sessions as expired (#1672)
+- Fix `try_preserving_privacy` returning `Empty` when candidates exist (#1629)
+- Assert bech32 encoding is uppercase (#1666)
+
+### Dependencies
+
+- Update to bitcoind async client 0.14 (#1646)
+- Downgrade transitive dependencies to match minimal direct dependencies (#1640)
+
+### Testing and Documentation
+
+- Add tests to catch mutants (#1622)
+- Add spec-related consts for readability in tests (#1699)
+- Employ new `fallback_tx` method (#1625)
+- Fix `check_payment` docstring (#1626)
+- Fix commented test assert (#1624)
+- Attach `--no-run` to feature-gated test runs to ensure compilation (#1621)
+
 ## 1.0.0-rc.3
 
 This release introduces sender and receiver cancel() APIs, fallback typestates for both sender and receiver, merges Cancel/Failure error variants and carves out dedicated errors (CoinSelectionError, DecapsulationError, dedicated create-request error), promotes InMemoryTestPersister to InMemoryPersister while removing NoopSessionPersister, replaces the url crate dependency with an internal Url type, adds is_expired and ErrorCode/WellKnownError::code to the error hierarchy, and removes sender sigs from receiver psbt_to_sign.

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
Prepares the `payjoin-1.0.0-rc.4` release. Part of #1720.

### Changelog

## 1.0.0-rc.4

This release locks down the public API ahead of the 1.0 freeze. It insulates the bitcoin-ohttp and bitcoin-hpke types from the public interface, marks public enums non_exhaustive and persistence transition types must_use, exposes transient versus fatal classification on PersistedError, corrects the create_error_request return type, renames the Receiver<Monitor> check methods, and removes utxos_to_be_locked. It also hardens the receiver against panic paths and fixes bugs in output substitution change handling, session replay, and coin selection.

Selected Improvements:

#### API Stabilization

- Insulate `bitcoin-ohttp` and `bitcoin-hpke` from the public API (#1702)
- Apply 1.0 freeze-required API fixes: `#[non_exhaustive]` enums, `ShortIdError`, `OutputSubstitution` export, and `#[must_use]` transition types (#1703)
- Expose transient versus fatal classification on `PersistedError` and return current state in transient errors (#1724)
- Correct `create_error_request` return type (#1715)
- Rename `Receiver<Monitor>` check methods (`check_for_broadcast` to `check_for_transaction`) (#1661, #1684)
- Remove `utxos_to_be_locked` (#1719)
- Add `InputPair::outpoint()` accessor (#1654)

#### Bug Fixes and Hardening

- Prevent receiver panic paths (#1704)
- Fix output substitution change misdirect (#1685)
- Fix session replay reporting closed sessions as expired (#1672)
- Fix `try_preserving_privacy` returning `Empty` when candidates exist (#1629)
- Assert bech32 encoding is uppercase (#1666)

#### Dependencies

- Update to bitcoind async client 0.14 (#1646)
- Downgrade transitive dependencies to match minimal direct dependencies (#1640)

#### Testing and Documentation

- Add tests to catch mutants (#1622)
- Add spec-related consts for readability in tests (#1699)
- Employ new `fallback_tx` method (#1625)
- Fix `check_payment` docstring (#1626)
- Fix commented test assert (#1624)
- Attach `--no-run` to feature-gated test runs to ensure compilation (#1621)

---

Disclosure: co-authored by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
