### PR TITLE
Rename PersistedError::error_state to fatal_state

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -1073,7 +1073,7 @@ impl App {
                     if let Some(api_err) = e.api_error_ref() {
                         tracing::warn!("Failed to confirm error response delivery: {api_err}");
                     }
-                    match e.error_state() {
+                    match e.fatal_state() {
                         Some(_) => {
                             let id = persister.session_id();
                             println!(

--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -824,7 +824,7 @@ where
         }
     }
 
-    pub fn error_state(self) -> Option<ErrorState> {
+    pub fn fatal_state(self) -> Option<ErrorState> {
         match self.0 {
             InternalPersistedError::Api(ApiError::FatalWithState(_, state)) => Some(state),
             _ => None,
@@ -854,7 +854,7 @@ where
 
     /// True if the transition failed fatally: an event was persisted, and
     /// the session is closed or has moved to an error state (see
-    /// [`Self::error_state`]).
+    /// [`Self::fatal_state`]).
     ///
     /// Storage errors are neither transient nor fatal. They mean the
     /// transition outcome is unknown, and recovery is replaying the event
@@ -1830,7 +1830,7 @@ mod tests {
         assert!(fatal_with_state_error.api_error_ref().is_some());
         assert!(!fatal_with_state_error.is_transient());
         assert!(fatal_with_state_error.is_fatal());
-        assert_eq!(fatal_with_state_error.error_state(), Some("Error state".to_string()));
+        assert_eq!(fatal_with_state_error.fatal_state(), Some("Error state".to_string()));
 
         let transient_error = PersistedError::<InMemoryTestError, InMemoryTestError, (), String>(
             InternalPersistedError::Api(ApiError::Transient(

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1914,7 +1914,7 @@ pub mod test {
             .check_broadcast_suitability(Some(FeeRate::MIN), |_| Ok(false))
             .save(&persister)
             .expect_err("should have replyable error");
-        let has_error = unchecked_proposal_err.error_state().expect("should have state");
+        let has_error = unchecked_proposal_err.fatal_state().expect("should have state");
 
         let _err_req = has_error.create_error_request(EXAMPLE_URL)?;
         Ok(())
@@ -2182,7 +2182,7 @@ pub mod test {
             .expect_err("fatal response should error");
 
         assert!(err.api_error_ref().is_some());
-        let pending_fallback = err.error_state().expect("pending fallback should be carried");
+        let pending_fallback = err.fatal_state().expect("pending fallback should be carried");
         assert_eq!(pending_fallback.fallback_tx(), &expected_tx);
         assert_events(&persister, &[SessionEvent::ProtocolFailed], false);
         Ok(())
@@ -2241,7 +2241,7 @@ pub mod test {
             .process_response(&response, ctx)
             .save(&persister)
             .expect_err("fatal response should error");
-        let pending_fallback = err.error_state().expect("pending fallback should be carried");
+        let pending_fallback = err.fatal_state().expect("pending fallback should be carried");
 
         assert_eq!(pending_fallback.fallback_tx(), &expected_tx);
         assert_events(&persister, &[SessionEvent::ProtocolFailed], false);


### PR DESCRIPTION
The method returns the state carried by a fatal rejection, mirroring transient_state for transient ones. Name it after the error class it applies to so the pairing is clear at the call site.

This is a follow up I suggested from https://github.com/payjoin/rust-payjoin/pull/1724#discussion_r3561659935, feel free to close if not taking.

Claude Fable was used to generate these updates.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
