### PR TITLE
Rename FFI builder errors to match payjoin crate

### DIFF
--- a/payjoin-ffi/csharp/UnitTests.cs
+++ b/payjoin-ffi/csharp/UnitTests.cs
@@ -283,7 +283,7 @@ public class ValidationTests
     {
         var ohttpKeys = OhttpKeys.Decode(OhttpKeysData);
         
-        Assert.Throws<ReceiverBuilderException.InvalidAddress>(() =>
+        Assert.Throws<BuildReceiverException.InvalidAddress>(() =>
         {
             new ReceiverBuilder("not-an-address", "https://example.com", ohttpKeys);
         });

--- a/payjoin-ffi/python/test/test_payjoin_unit_test.py
+++ b/payjoin-ffi/python/test/test_payjoin_unit_test.py
@@ -269,7 +269,7 @@ class TestSenderCancelAsync(unittest.TestCase):
 
 class TestValidation(unittest.TestCase):
     def test_receiver_builder_rejects_bad_address(self):
-        with self.assertRaises(cast(type[Exception], payjoin.ReceiverBuilderError)):
+        with self.assertRaises(cast(type[Exception], payjoin.BuildReceiverError)):
             payjoin.ReceiverBuilder(
                 "not-an-address",
                 "https://example.com",

--- a/payjoin-ffi/src/receive/error.rs
+++ b/payjoin-ffi/src/receive/error.rs
@@ -122,7 +122,7 @@ impl_persisted_error_from!(payjoin::IntoUrlError, |api_err: payjoin::IntoUrlErro
 /// Error that may occur when building a receiver session.
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[non_exhaustive]
-pub enum ReceiverBuilderError {
+pub enum BuildReceiverError {
     /// The provided Bitcoin address is invalid.
     #[error("Invalid Bitcoin address: {0}")]
     InvalidAddress(Arc<AddressParseError>),
@@ -131,15 +131,15 @@ pub enum ReceiverBuilderError {
     IntoUrl(Arc<IntoUrlError>),
 }
 
-impl From<payjoin::IntoUrlError> for ReceiverBuilderError {
+impl From<payjoin::IntoUrlError> for BuildReceiverError {
     fn from(value: payjoin::IntoUrlError) -> Self {
-        ReceiverBuilderError::IntoUrl(Arc::new(value.into()))
+        BuildReceiverError::IntoUrl(Arc::new(value.into()))
     }
 }
 
-impl From<payjoin::bitcoin::address::ParseError> for ReceiverBuilderError {
+impl From<payjoin::bitcoin::address::ParseError> for BuildReceiverError {
     fn from(value: payjoin::bitcoin::address::ParseError) -> Self {
-        ReceiverBuilderError::InvalidAddress(Arc::new(value.into()))
+        BuildReceiverError::InvalidAddress(Arc::new(value.into()))
     }
 }
 

--- a/payjoin-ffi/src/receive/mod.rs
+++ b/payjoin-ffi/src/receive/mod.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 pub use error::{
-    AddressParseError, CoinSelectionError, InputContributionError, InputPairError, JsonReply,
-    OutputSubstitutionError, ProtocolError, PsbtInputError, ReceiverBuilderError,
+    AddressParseError, BuildReceiverError, CoinSelectionError, InputContributionError,
+    InputPairError, JsonReply, OutputSubstitutionError, ProtocolError, PsbtInputError,
     ReceiverCreateRequestError, ReceiverError, SessionError,
 };
 use payjoin::bitcoin::consensus::Decodable;
@@ -541,9 +541,9 @@ impl ReceiverBuilder {
         address: String,
         directory: String,
         ohttp_keys: Arc<OhttpKeys>,
-    ) -> Result<Self, ReceiverBuilderError> {
+    ) -> Result<Self, BuildReceiverError> {
         let parsed_address = payjoin::bitcoin::Address::from_str(address.as_str())
-            .map_err(ReceiverBuilderError::from)?
+            .map_err(BuildReceiverError::from)?
             .assume_checked();
         Ok(Self(
             payjoin::receive::v2::ReceiverBuilder::new(
@@ -551,7 +551,7 @@ impl ReceiverBuilder {
                 directory,
                 Arc::unwrap_or_clone(ohttp_keys).into(),
             )
-            .map_err(ReceiverBuilderError::from)?,
+            .map_err(BuildReceiverError::from)?,
         ))
     }
 

--- a/payjoin-ffi/src/send/error.rs
+++ b/payjoin-ffi/src/send/error.rs
@@ -11,16 +11,16 @@ use crate::error::{FfiValidationError, ImplementationError};
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Object)]
 #[uniffi::export(Debug, Display, Eq)]
 #[error("Error initializing the sender: {msg}")]
-pub struct SenderBuilderError {
+pub struct BuildSenderError {
     msg: String,
 }
 
-impl From<PsbtParseError> for SenderBuilderError {
-    fn from(value: PsbtParseError) -> Self { SenderBuilderError { msg: value.to_string() } }
+impl From<PsbtParseError> for BuildSenderError {
+    fn from(value: PsbtParseError) -> Self { BuildSenderError { msg: value.to_string() } }
 }
 
-impl From<send::BuildSenderError> for SenderBuilderError {
-    fn from(value: send::BuildSenderError) -> Self { SenderBuilderError { msg: value.to_string() } }
+impl From<send::BuildSenderError> for BuildSenderError {
+    fn from(value: send::BuildSenderError) -> Self { BuildSenderError { msg: value.to_string() } }
 }
 
 /// FFI-visible PSBT parsing error surfaced at the sender boundary.
@@ -41,7 +41,7 @@ pub enum SenderInputError {
     #[error(transparent)]
     Psbt(PsbtParseError),
     #[error(transparent)]
-    Build(Arc<SenderBuilderError>),
+    Build(Arc<BuildSenderError>),
     #[error(transparent)]
     FfiValidation(FfiValidationError),
 }
@@ -189,7 +189,7 @@ pub enum SenderError {
     Response(ResponseError),
     /// Sender Build error
     #[error(transparent)]
-    Build(Arc<SenderBuilderError>),
+    BuildSender(Arc<BuildSenderError>),
     /// Unexpected error
     #[error("An unexpected error occurred")]
     Unexpected,
@@ -258,7 +258,7 @@ impl_sender_persisted_error_from!(send::ResponseError, |api_err: send::ResponseE
 });
 
 impl_sender_persisted_error_from!(send::BuildSenderError, |api_err: send::BuildSenderError| {
-    SenderError::Build(Arc::new(api_err.into()))
+    SenderError::BuildSender(Arc::new(api_err.into()))
 });
 
 #[cfg(test)]

--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 pub use error::{
-    CreateRequestError, DecapsulationError, PsbtParseError, ResponseError, SenderBuilderError,
+    BuildSenderError, CreateRequestError, DecapsulationError, PsbtParseError, ResponseError,
     SenderInputError,
 };
 


### PR DESCRIPTION
Rename SenderBuilderError to BuildSenderError and
ReceiverBuilderError to BuildReceiverError in payjoin-ffi so the FFI error names mirror the core payjoin crate's naming convention (e.g. payjoin::send::BuildSenderError).

This is a follow up from suggestion made in https://github.com/payjoin/rust-payjoin/pull/1724#discussion_r3561858787.

Claude Fable was used to make these code updates.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
