### PR TITLE
Prepare dart payjoin 0.1.2 for pub.dev

### DIFF
--- a/payjoin-ffi/dart/CHANGELOG.md
+++ b/payjoin-ffi/dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.2]
+
+- Bindings for payjoin-1.0.0-rc.4
+
 ## [0.1.1]
 
 - Initial functional release published to pub.dev.

--- a/payjoin-ffi/dart/native/Cargo.toml
+++ b/payjoin-ffi/dart/native/Cargo.toml
@@ -16,6 +16,6 @@ name = "payjoin_ffi_wrapper"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "dc287ea4992e94b0c1194bab8dcc998ec321cbb2", features = [
+payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "c52bac921731f7d1a08bd2901499027fb1360ee2", features = [
   "dart",
 ] }

--- a/payjoin-ffi/dart/pubspec.yaml
+++ b/payjoin-ffi/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: payjoin
 description: Dart bindings for payjoin (EXPERIMENTAL)
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/payjoin/rust-payjoin
 repository: https://github.com/payjoin/rust-payjoin
 


### PR DESCRIPTION
Bumps the Dart `payjoin` bindings to 0.1.2, targeting payjoin 1.0.0-rc.4.

## Changes

- Bump `pubspec.yaml` version from 0.1.1 to 0.1.2
- Pin the `payjoin-ffi` wrapper dependency in `native/Cargo.toml` to master commit `c52bac92`, whose FFI surface is identical to the `payjoin-1.0.0-rc.4` tag
- Add the 0.1.2 changelog entry

Bindings were regenerated from master and validated: `contrib/test.sh` passes all 24 Dart tests (including the bitcoind v2-to-v2 integration test), and `dart pub publish --dry-run` packages cleanly at 47 KB. The remaining dry-run lints are pre-existing uniffi-dart generator warnings in the generated `lib/payjoin.dart`.

The live `dart pub publish` will be run manually after review.

Disclosure: co-authored by Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
