### PR TITLE
Bump payjoin to version 1.0.0-rc.5

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2568,7 +2568,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2699,7 +2699,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6.0.0"
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.8.0", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1.18", optional = true }
-payjoin = { version = "1.0.0-rc.4", default-features = false }
+payjoin = { version = "1.0.0-rc.5", default-features = false }
 pest_derive = "2.7.0"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -27,7 +27,7 @@ getrandom = "0.2.10"
 icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 lazy_static = "1.5.0"
-payjoin = { version = "1.0.0-rc.4", features = ["v1", "v2"] }
+payjoin = { version = "1.0.0-rc.5", features = ["v1", "v2"] }
 payjoin-test-utils = { version = "0.0.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -61,7 +61,7 @@ opentelemetry-otlp = { version = "0.31", optional = true, features = [
   "reqwest-rustls",
 ] }
 opentelemetry_sdk = "0.31"
-payjoin = { version = "1.0.0-rc.4", features = [
+payjoin = { version = "1.0.0-rc.5", features = [
   "directory",
 ], default-features = false }
 rand = "0.8"

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,7 +32,7 @@ futures = { version = "0.3.21", default-features = false, features = ["std"] }
 http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "1.0.0-rc.4", default-features = false }
+payjoin = { version = "1.0.0-rc.5", default-features = false }
 payjoin-mailroom = { version = "0.1.1", features = ["_manual-tls"] }
 tar = "0.4.20"
 # Pin to 0.14.7 (last version to support our MSRV 1.85)

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Payjoin Changelog
 
+## 1.0.0-rc.5
+
+This release renames `PersistedError::error_state` to `fatal_state`, makes
+`Monitor::check_for_transaction` consume `self`, and adds
+`ReplayError::expiry_fallback_tx` for recovering the fallback transaction from
+an expired session.
+
+Selected Improvements:
+
+### API Changes
+
+- Rename `PersistedError::error_state()` to `fatal_state()` (#1728)
+- `Monitor::check_for_transaction()` now consumes `self` (#1729)
+- `ReplayError::expiry_fallback_tx()` returns the fallback transaction from an
+  expired session's event log, if available (#1700)
+
+### Dependencies
+
+- Update deps to patch cargo audit vulnerabilities (#1735)
+
 ## 1.0.0-rc.4
 
 This release locks down the public API ahead of the 1.0 freeze. It insulates the bitcoin-ohttp and bitcoin-hpke types from the public interface, marks public enums non_exhaustive and persistence transition types must_use, exposes transient versus fatal classification on PersistedError, corrects the create_error_request return type, renames the Receiver<Monitor> check methods, and removes utxos_to_be_locked. It also hardens the receiver against panic paths and fixes bugs in output substitution change handling, session replay, and coin selection.

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
Prepare the `payjoin-cli-1.0.0-rc.5` release. Part of #1740 

### Changelog

## 1.0.0-rc.5

This release renames `PersistedError::error_state` to `fatal_state`, makes
`Monitor::check_for_transaction` consume `self`, and adds
`ReplayError::expiry_fallback_tx` for recovering the fallback transaction from
an expired session. These are hopefully the final breaking changes before 1.0 stable. :crossed_fingers: 

Selected Improvements:

### API Changes

- Rename `PersistedError::error_state()` to `fatal_state()` (#1728)
- `Monitor::check_for_transaction()` now consumes `self` (#1729)
- `ReplayError::expiry_fallback_tx()` returns the fallback transaction from an
  expired session's event log, if available (#1700)

### Dependencies

- Update deps to patch cargo audit vulnerabilities (#1735)

Co-authored by deepseek v4 flash

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
