### PR TITLE
Add service.instance.id to mailroom telemetry resource

### DIFF
--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -21,7 +21,7 @@ ws-bootstrap = ["dep:tokio-tungstenite", "dep:rustls"]
 _manual-tls = ["dep:axum-server", "dep:rustls"]
 acme = ["dep:tokio-rustls-acme", "dep:axum-server", "dep:rustls"]
 access-control = ["dep:flate2", "dep:ipnet", "dep:maxminddb", "dep:reqwest"]
-telemetry = ["dep:opentelemetry-otlp"]
+telemetry = ["dep:opentelemetry-otlp", "dep:uuid"]
 
 [dependencies]
 anyhow = "1.0.99"
@@ -82,6 +82,7 @@ tower-http = { version = "0.6.11", features = ["trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 unicode-segmentation = "=1.12.0"
+uuid = { version = "1.18.0", features = ["v4"], optional = true }
 
 # Pinned transitive dependencies that appear unused to cargo-machete
 [package.metadata.cargo-machete]

--- a/payjoin-mailroom/src/main.rs
+++ b/payjoin-mailroom/src/main.rs
@@ -36,14 +36,10 @@ fn init_tracing() -> Option<SdkMeterProvider> {
 
 #[cfg(feature = "telemetry")]
 fn init_tracing_with_telemetry(telemetry: &config::TelemetryConfig) -> SdkMeterProvider {
-    use opentelemetry::KeyValue;
     use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-    use opentelemetry_sdk::Resource;
+    use payjoin_mailroom::metrics::build_telemetry_resource;
 
-    let resource = Resource::builder()
-        .with_service_name("payjoin-mailroom")
-        .with_attribute(KeyValue::new("operator.domain", telemetry.operator_domain.clone()))
-        .build();
+    let resource = build_telemetry_resource(&telemetry.operator_domain);
 
     let headers: std::collections::HashMap<String, String> =
         [("Authorization".to_string(), format!("Basic {}", telemetry.auth_token))].into();

--- a/payjoin-mailroom/src/metrics.rs
+++ b/payjoin-mailroom/src/metrics.rs
@@ -10,6 +10,7 @@ pub fn build_telemetry_resource(operator_domain: &str) -> opentelemetry_sdk::Res
     opentelemetry_sdk::Resource::builder()
         .with_service_name("payjoin-mailroom")
         .with_attribute(KeyValue::new("operator.domain", operator_domain.to_string()))
+        .with_attribute(KeyValue::new("service.instance.id", uuid::Uuid::new_v4().to_string()))
         .build()
 }
 
@@ -349,23 +350,37 @@ mod tests {
 
     #[cfg(feature = "telemetry")]
     #[test]
-    fn telemetry_resource_has_service_name_and_operator_domain() {
+    fn telemetry_resource_attributes() {
         use opentelemetry::Key;
 
         use super::build_telemetry_resource;
 
-        let resource = build_telemetry_resource("example.com");
+        let r1 = build_telemetry_resource("example.com");
 
         assert_eq!(
-            resource.get(&Key::from("service.name")),
+            r1.get(&Key::from("service.name")),
             Some(opentelemetry::Value::String("payjoin-mailroom".into())),
             "service.name must be payjoin-mailroom"
         );
         assert_eq!(
-            resource.get(&Key::from("operator.domain")),
+            r1.get(&Key::from("operator.domain")),
             Some(opentelemetry::Value::String("example.com".into())),
             "operator.domain must match configured value"
         );
+
+        let id1 = r1
+            .get(&Key::from("service.instance.id"))
+            .expect("service.instance.id must be present")
+            .to_string();
+        assert!(!id1.is_empty(), "service.instance.id must not be empty");
+        uuid::Uuid::parse_str(&id1).expect("service.instance.id must parse as a UUID");
+
+        let r2 = build_telemetry_resource("example.com");
+        let id2 = r2
+            .get(&Key::from("service.instance.id"))
+            .expect("service.instance.id must be present in second resource")
+            .to_string();
+        assert_ne!(id1, id2, "service.instance.id must differ across constructions");
     }
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
 

--- a/payjoin-mailroom/src/metrics.rs
+++ b/payjoin-mailroom/src/metrics.rs
@@ -4,6 +4,15 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "telemetry")]
+pub fn build_telemetry_resource(operator_domain: &str) -> opentelemetry_sdk::Resource {
+    use opentelemetry::KeyValue;
+    opentelemetry_sdk::Resource::builder()
+        .with_service_name("payjoin-mailroom")
+        .with_attribute(KeyValue::new("operator.domain", operator_domain.to_string()))
+        .build()
+}
+
 use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
 use opentelemetry::metrics::{Counter, MeterProvider, ObservableGauge, UpDownCounter};
 use opentelemetry::KeyValue;
@@ -337,6 +346,27 @@ impl Drop for InFlightGuard {
 #[cfg(test)]
 mod tests {
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+
+    #[cfg(feature = "telemetry")]
+    #[test]
+    fn telemetry_resource_has_service_name_and_operator_domain() {
+        use opentelemetry::Key;
+
+        use super::build_telemetry_resource;
+
+        let resource = build_telemetry_resource("example.com");
+
+        assert_eq!(
+            resource.get(&Key::from("service.name")),
+            Some(opentelemetry::Value::String("payjoin-mailroom".into())),
+            "service.name must be payjoin-mailroom"
+        );
+        assert_eq!(
+            resource.get(&Key::from("operator.domain")),
+            Some(opentelemetry::Value::String("example.com".into())),
+            "operator.domain must match configured value"
+        );
+    }
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
 
     use super::*;


### PR DESCRIPTION
# PR body draft — agent/mailroom-otel-instance-id

Title: Add service.instance.id to mailroom telemetry resource

---

Every mailroom node pushes OTLP metrics with a resource of only
`service.name` + `operator.domain`. Grafana Cloud maps `service.name`to `job`
and `service.instance.id` to `instance`. Other resource attributes land only in
`target_info`. With no `service.instance.id`, every node shares identical
series identity, so cumulative counters from N processes interleave inside
ONE stored series per metric. Prometheus `rate()` reads each backward jump as
a counter reset and re-adds roughly the full counter value.

Observed in production: 5 nodes reporting (`count(target_info)` = 5) but a
single series for the label-less `http_requests_started_total`. The dashboard
rendered a climbing ~100k req/s sawtooth from a service doing ~5 req/s (the
counter never exceeded ~5.5M — a genuine 100k/s over a 4-minute rate window
would require 24M of increase).

Fix: attach a per-boot `service.instance.id` (UUID v4) so each process gets
its own series.

- Commit 1 extracts the `Resource` construction out of `main.rs` into the
  library so it is testable — `contrib/test.sh` only runs `--lib` and
  `--test integration` targets, so a test in the binary would never run in CI.
- Commit 2 adds the attribute. `uuid` is promoted from dev-dependency to an
  optional dependency of the `telemetry` feature; both lockfiles already
  pinned uuid 1.18.0, so there is no lockfile change.

Tests assert `service.name`, `operator.domain`, and that
`service.instance.id` is present, non-empty, parses as a UUID, and differs
across constructions. Local gates green: fmt, codespell, clippy
(`--all-features` and `--no-default-features`), 65 lib + 3 integration tests,
`contrib/lint.sh`, doc lint (`-D warnings`), `nix fmt -- --ci`.

Nodes must redeploy to benefit; until all operators update, non-upgraded
senders continue to collide with each other (mitigable stack-side by
promoting the `operator.domain` resource attribute onto metrics).

Disclosure: co-authored by Claude Code
