### PR TITLE
Pin bindings CI to the maintained lockfile

### DIFF
--- a/contrib/lockfile.sh
+++ b/contrib/lockfile.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOCKFILE="Cargo.lock"
-LOCKDIR=".bak"
-LOCKFILE_BAK="${LOCKDIR}/${LOCKFILE}"
+# Absolute paths so the EXIT trap restores the lockfile even if the sourcing
+# script changes directory after calling use_lockfile.
+LOCKFILE="${PWD}/Cargo.lock"
+LOCKDIR="${PWD}/.bak"
+LOCKFILE_BAK="${LOCKDIR}/Cargo.lock"
 
 _cleanup_lockfile() {
     if [ -f "$LOCKFILE_BAK" ]; then

--- a/payjoin-ffi/csharp/contrib/test.sh
+++ b/payjoin-ffi/csharp/contrib/test.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Build against the maintained lockfile instead of resolving the dependency
+# graph fresh on every run. use_lockfile copies Cargo-recent.lock into place
+# and restores the previous state when this script exits.
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+source contrib/lockfile.sh
+use_lockfile Cargo-recent.lock
+
+cd "$REPO_ROOT/payjoin-ffi/csharp"
 
 echo "==> Generating FFI bindings..."
 bash ./scripts/generate_bindings.sh

--- a/payjoin-ffi/csharp/scripts/generate_bindings.ps1
+++ b/payjoin-ffi/csharp/scripts/generate_bindings.ps1
@@ -36,6 +36,20 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $payjoinFfiDir = Resolve-Path (Join-Path $scriptDir "..\..")
 Set-Location $payjoinFfiDir
 
+# Build against the maintained lockfile instead of resolving the dependency
+# graph fresh on every run; mirrors contrib/lockfile.sh for this Windows entry
+# point. The previous lockfile state is restored before the script exits.
+$repoRoot = Resolve-Path (Join-Path $payjoinFfiDir "..")
+$lockFile = Join-Path $repoRoot "Cargo.lock"
+$lockBackup = $null
+if (Test-Path $lockFile) {
+    $lockBackup = "$lockFile.bak"
+    Move-Item $lockFile $lockBackup -Force
+}
+Copy-Item (Join-Path $repoRoot "Cargo-recent.lock") $lockFile -Force
+
+try {
+
 Write-Host "Generating payjoin C#..."
 if ($null -ne $env:PAYJOIN_FFI_FEATURES) {
     $payjoinFfiFeatures = $env:PAYJOIN_FFI_FEATURES
@@ -72,5 +86,13 @@ finally {
 Write-Host "Copying native library..."
 New-Item -ItemType Directory -Force -Path "csharp/lib" | Out-Null
 Copy-Item "../target/debug/$libName" "csharp/lib/$libName" -Force
+
+}
+finally {
+    Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
+    if ($null -ne $lockBackup) {
+        Move-Item $lockBackup $lockFile -Force
+    }
+}
 
 Write-Host "All done!"

--- a/payjoin-ffi/dart/contrib/test.sh
+++ b/payjoin-ffi/dart/contrib/test.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Build against the maintained lockfile instead of resolving the dependency
+# graph fresh on every run. use_lockfile copies Cargo-recent.lock into place
+# and restores the previous state when this script exits.
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+source contrib/lockfile.sh
+use_lockfile Cargo-recent.lock
+
+cd "$REPO_ROOT/payjoin-ffi/dart"
 
 echo "==> Cleaning nested Cargo.lock..."
 rm -f native/Cargo.lock

--- a/payjoin-ffi/javascript/contrib/test.sh
+++ b/payjoin-ffi/javascript/contrib/test.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Build against the maintained lockfile instead of resolving the dependency
+# graph fresh on every run. use_lockfile copies Cargo-recent.lock into place
+# and restores the previous state when this script exits.
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+source contrib/lockfile.sh
+use_lockfile Cargo-recent.lock
+
+cd "$REPO_ROOT/payjoin-ffi/javascript"
 
 echo "==> Installing JavaScript dependencies..."
 npm ci

--- a/payjoin-ffi/python/contrib/test.sh
+++ b/payjoin-ffi/python/contrib/test.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Build against the maintained lockfile instead of resolving the dependency
+# graph fresh on every run. use_lockfile copies Cargo-recent.lock into place
+# and restores the previous state when this script exits.
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+source contrib/lockfile.sh
+use_lockfile Cargo-recent.lock
+
+cd "$REPO_ROOT/payjoin-ffi/python"
 
 echo "==> Syncing Python dependencies with uv..."
 uv sync --all-extras


### PR DESCRIPTION
The bindings workflows (csharp, dart, python, javascript) never use the repository's lockfile mechanism, so every CI run resolves the full dependency graph fresh, and today that broke every PR's Windows csharp job: tokio 1.53.0 resolves as 1.85-compatible but uses `Once::wait` (stabilized in 1.86) in its Windows-only signal code. This wires the same `contrib/lockfile.sh` + `Cargo-recent.lock` mechanism the Rust jobs already use into the four bindings test entry points, with a PowerShell mirror for the Windows csharp entry, restoring the previous lockfile state on exit. The detached `payjoin-ffi/dart/native` wrapper workspace still resolves fresh and is left for a separate change.

Disclosure: co-authored by Claude Code.