### PR TITLE
Remove Receiver::SessionEvent enum todo

### DIFF
--- a/payjoin/src/core/receive/v2/session.rs
+++ b/payjoin/src/core/receive/v2/session.rs
@@ -193,7 +193,6 @@ pub enum SessionStatus {
 /// Represents a piece of information that the receiver has obtained from the session
 /// Each event can be used to transition the receiver state machine to a new state
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-// TODO Explore why this lint is not consistent and only fails on 1.85.0 unlike the Sender
 #[allow(clippy::large_enum_variant)]
 pub enum SessionEvent {
     Created(SessionContext),


### PR DESCRIPTION
See #1743 for behavior explanation and reason for no further change

Ai helped me scrape the clippy source code but it made several historical mistakes about the timeline of events resulting in initial misdiagnosis.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
