### PR TITLE
Restore ScriptBuf and Witness test imports

### DIFF
--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1652,7 +1652,7 @@ pub(crate) fn pj_uri<'a>(
 pub mod test {
     use std::str::FromStr;
 
-    use bitcoin::{Amount, FeeRate};
+    use bitcoin::{Amount, FeeRate, ScriptBuf, Witness};
     use once_cell::sync::Lazy;
     use payjoin_test_utils::{
         BoxError, EXAMPLE_URL, ORIGINAL_PSBT, PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL,


### PR DESCRIPTION
The v2 receive test module lost `ScriptBuf` and `Witness` from its bitcoin import after two branches merged with a silent semantic conflict. Commit 4548e25f shrank the import to `{Amount, FeeRate}` because it deleted the code that used them, while PR #1718 (merged against a stale base) added new test code that uses `ScriptBuf` and `Witness`. The 3-way merge kept master's shrunken import alongside the PR's new usages, breaking `cargo test` compilation on master.

Re-add both types to the import so the lib test build compiles.

Authored by Claude Opus 4.8

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
