### PR TITLE
[2-week comment period thru 26/08/07] 1.0 CONTRIBUTING.md changes: PR/Issue Scope, SECURITY.md, Licensing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Maintainers. Last matching pattern takes precedence.
+* @benalleng @DanGould @spacebear21

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,9 +16,28 @@ Most discussion about Payjoin research and development happens on [Discord](http
 
 ---
 
+## Scope
+
+Issues and pull requests are for technical substance. Foundation
+governance, personnel, and licensing or IP matters are out of scope. Take
+them to [Foundation leadership](https://payjoin.org/blog/2025/08/08/announcing-payjoin-foundation/)
+directly at [admin@payjoin.org](mailto:admin@payjoin.org). Maintainers may lock or hide
+off-topic threads by pointing to this section, and may temporarily block
+accounts for sustained off-topic participation, with notice.
+
+---
+
 ## Issues
 
 Using and testing Payjoin Dev Kit is an effective way for new contributors to both learn and provide value. If you find a bug, incorrect or unclear documentation, or have any other problem, consider [creating an issue](https://github.com/payjoin/rust-payjoin/issues). Before doing so, please search through [existing issues](https://github.com/payjoin/rust-payjoin/issues) to see if your problem has already been addressed or is actively being discussed. If you can, provide a fully reproducible example or the steps we can use to reproduce the issue to speed up the debugging process.
+
+---
+
+## Security
+
+Do not open public issues or pull requests for vulnerabilities. Report them
+privately to [security@payjoin.org](mailto:security@payjoin.org) as described
+in [SECURITY.md](SECURITY.md).
 
 ---
 
@@ -152,3 +171,30 @@ nix fmt
 ### Linting
 
 We use [`clippy`](https://github.com/rust-lang/rust-clippy) for linting. Please run `contrib/lint.sh` using the nightly toolchain before submitting any changes.
+
+---
+
+## Review and Merging
+
+Pull requests are reviewed on technical merit by the repository
+maintainers listed in [CODEOWNERS](CODEOWNERS). Protocol wire behavior
+follows the BIP process
+([BIP 78](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki),
+[BIP 77](https://github.com/bitcoin/bips/blob/master/bip-0077.md)).
+Observable behavior not yet pinned down by a BIP may merge, but is not
+considered production ready until it is publicly specified. When
+maintainers proceed over a significant technical objection, the rationale
+is written up publicly.
+
+---
+
+## Licensing
+
+Crates in this workspace are licensed as declared in each crate's
+`Cargo.toml`: `MITNFA` for most crates, dual MIT/Apache-2.0 for
+`payjoin-ffi`. Relicensing the workspace to dual MIT/Apache-2.0 is in
+progress in [#1540](https://github.com/payjoin/rust-payjoin/issues/1540).
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be licensed under the license of the crate it modifies and
+dual MIT/Apache-2.0, without any additional terms or conditions.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,9 +16,28 @@ Most discussion about Payjoin research and development happens on [Discord](http
 
 ---
 
+## Scope
+
+Issues and pull requests are for technical substance. Foundation
+governance, personnel, and licensing or IP matters are out of scope. Take
+them to [Foundation leadership](https://payjoin.org/foundation/) directly at
+[hello@payjoin.org](mailto:hello@payjoin.org). Maintainers may lock or hide
+off-topic threads by pointing to this section, and may temporarily block
+accounts for sustained off-topic participation, with notice.
+
+---
+
 ## Issues
 
 Using and testing Payjoin Dev Kit is an effective way for new contributors to both learn and provide value. If you find a bug, incorrect or unclear documentation, or have any other problem, consider [creating an issue](https://github.com/payjoin/rust-payjoin/issues). Before doing so, please search through [existing issues](https://github.com/payjoin/rust-payjoin/issues) to see if your problem has already been addressed or is actively being discussed. If you can, provide a fully reproducible example or the steps we can use to reproduce the issue to speed up the debugging process.
+
+---
+
+## Security
+
+Do not open public issues or pull requests for vulnerabilities. Report them
+privately to [security@payjoin.org](mailto:security@payjoin.org) as described
+in [SECURITY.md](SECURITY.md).
 
 ---
 
@@ -152,3 +171,30 @@ nix fmt
 ### Linting
 
 We use [`clippy`](https://github.com/rust-lang/rust-clippy) for linting. Please run `contrib/lint.sh` using the nightly toolchain before submitting any changes.
+
+---
+
+## Review and Merging
+
+Pull requests are reviewed on technical merit by the repository
+maintainers listed in [CODEOWNERS](CODEOWNERS). Protocol wire behavior
+follows the BIP process
+([BIP 78](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki),
+[BIP 77](https://github.com/bitcoin/bips/blob/master/bip-0077.md)).
+Observable behavior not yet pinned down by a BIP may merge, but is not
+considered production ready until it is publicly specified. When
+maintainers proceed over a significant technical objection, the rationale
+is written up publicly.
+
+---
+
+## Licensing
+
+Crates in this workspace are licensed as declared in each crate's
+`Cargo.toml`: `MITNFA` for most crates, dual MIT/Apache-2.0 for
+`payjoin-ffi`. Relicensing the workspace to dual MIT/Apache-2.0 is in
+progress in [#1540](https://github.com/payjoin/rust-payjoin/issues/1540).
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be licensed under the license of the crate it modifies and
+dual MIT/Apache-2.0, without any additional terms or conditions.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+To report a vulnerability, email
+[security@payjoin.org](mailto:security@payjoin.org). Do not open a public
+issue or pull request for anything security-sensitive.
+
+We follow coordinated disclosure: we will work with you on a fix and agree
+on a disclosure timeline before details are published.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+To report a vulnerability, email
+[security@payjoin.org](mailto:security@payjoin.org). If you wish to encrypt
+your disclosure to you can use one of the maintainer's PGP keys at
+[](https://github.com/payjoin/rust-payjoin/tree/master/contrib/release/keys). Do not open a public issue or pull request for
+anything security-sensitive.
+
+Additionally you can make disclosures via github's [vulnerability reporting](https://github.com/payjoin/rust-payjoin/security/advisories/new).
+
+We follow coordinated disclosure: we will work with you on a fix and agree
+on a disclosure timeline before details are published.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -3,8 +3,8 @@
 To report a vulnerability, email
 [security@payjoin.org](mailto:security@payjoin.org). If you wish to encrypt
 your disclosure to you can use one of the maintainer's PGP keys at
-[](https://github.com/payjoin/rust-payjoin/tree/master/contrib/release/keys). Do not open a public issue or pull request for
-anything security-sensitive.
+[contrib/release/keys/](https://github.com/payjoin/rust-payjoin/tree/master/contrib/release/keys).
+Do not open a public issue or pull request for anything security-sensitive.
 
 Additionally you can make disclosures via github's [vulnerability reporting](https://github.com/payjoin/rust-payjoin/security/advisories/new).
 


### PR DESCRIPTION
As we prepare for rust-payjoin 1.0 maturity and release, I'd like to make some operational policy explicit in CONTRIBUTING.md. Opening the change a 2-week community comment period.

- Include private responsible disclosure path @ security.md
- propose CODEOWNERS (maintainers) who can *merge* (with an ACK), separate from *trusted-contributors* who have write permission and can green-check ACK maintainers' prs
- Make licensing terms more explicit

I commit to responding to any substantial comments during the comment period.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
