### PR TITLE
Bump payjoin to version 1.0.0-rc.6

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2567,7 +2567,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2698,7 +2698,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6.0.0"
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.8.0", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1.18", optional = true }
-payjoin = { version = "1.0.0-rc.5", default-features = false }
+payjoin = { version = "1.0.0-rc.6", default-features = false }
 pest_derive = "2.7.0"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -27,7 +27,7 @@ getrandom = "0.2.10"
 icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 lazy_static = "1.5.0"
-payjoin = { version = "1.0.0-rc.5", features = ["v1", "v2"] }
+payjoin = { version = "1.0.0-rc.6", features = ["v1", "v2"] }
 payjoin-test-utils = { version = "0.0.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry-otlp = { version = "0.32", optional = true, default-features = fal
   "http-proto",
 ] }
 opentelemetry_sdk = "0.32"
-payjoin = { version = "1.0.0-rc.5", features = [
+payjoin = { version = "1.0.0-rc.6", features = [
   "directory",
 ], default-features = false }
 rand = "0.8"

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,7 +32,7 @@ futures = { version = "0.3.21", default-features = false, features = ["std"] }
 http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "1.0.0-rc.5", default-features = false }
+payjoin = { version = "1.0.0-rc.6", default-features = false }
 payjoin-mailroom = { version = "0.1.1", features = ["_manual-tls"] }
 tar = "0.4.20"
 # Pin to 0.14.7 (last version to support our MSRV 1.85)

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Payjoin Changelog
 
+## 1.0.0-rc.6
+
+This release insulates the `bitcoin_uri` crate from payjoin's public API so
+that a breaking release of `bitcoin_uri` no longer forces a breaking release of
+payjoin. `Uri` and `PjUri` are now owned newtypes read through accessor methods
+instead of public fields, parsing returns payjoin's own `UriParseError`, and the
+`UriExt` trait is replaced by inherent methods. It also seals the persisted
+`SessionOutcome` ahead of the 1.0 database-compatibility freeze and exposes
+proposal transaction ID stability on receiver states.
+
+Selected Improvements:
+
+### API Changes
+
+- Insulate `bitcoin_uri` from the public API: `Uri` and `PjUri` become owned
+  newtypes with accessor methods (`address()`, `amount()`, `set_amount()`,
+  `label()`, `message()`, `extras()`), parsing returns the payjoin-owned
+  `UriParseError`, and the `UriExt` trait is removed in favor of inherent
+  `check_pj_supported`, `assume_checked`, and `require_network` methods (#1756)
+- `SessionOutcome` drops the unused witness payload on a `Success` outcome and
+  instead encapsulates a `bitcoin::Txid` instead. Also fully seal the enum by
+  fully handling remaining cases with a new `Unrecognized(Txid)` arm ahead of
+  the 1.0 database-compatibility freeze. (#1747)
+- Expose `proposal_txid_is_stable()` on the receiver states that hold the
+  fallback transaction, mirrored in payjoin-ffi (#1718)
+
+### Bug Fixes
+
+- Fix the proposal transaction ID stability check for nested SegWit inputs
+  (#1718)
+
 ## 1.0.0-rc.5
 
 This release renames `PersistedError::error_state` to `fatal_state`, makes

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
Release the bitcoin_uri public-API insulation along with the pre-1.0
SessionOutcome seal and the proposal txid stability accessor. Bump the
payjoin dependency requirement in the workspace crates and refresh the
minimal and recent lock files. See CHANGELOG.md for the full notice.

(cherry picked from commit 69e5dad4ea3edd985d5b3548b795198c7d68b796)

Disclosure: Co-authored by Claude Code
