### PR TITLE
Update setuptools to 83.0.0

### DIFF
--- a/payjoin-ffi/python/pyproject.toml
+++ b/payjoin-ffi/python/pyproject.toml
@@ -1,18 +1,18 @@
 [build-system]
-requires = ["setuptools>=62", "wheel", "toml"]
+requires = ["setuptools>=83", "wheel", "toml"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "payjoin"
 description = "The Python language bindings for the Payjoin Dev Kit"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 dynamic = ["version"]
 dependencies = [
   "build==1.3.0",
   "semantic-version==2.9.0",
-  "setuptools==78.1.1",
+  "setuptools==83.0.0",
   "typing-extensions==4.0.1",
   "wheel==0.46.3",
   "httpx==0.28.1",

--- a/payjoin-ffi/python/uv.lock
+++ b/payjoin-ffi/python/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [[package]]
 name = "anyio"
@@ -149,7 +149,7 @@ requires-dist = [
     { name = "build", specifier = "==1.3.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "semantic-version", specifier = "==2.9.0" },
-    { name = "setuptools", specifier = "==78.1.1" },
+    { name = "setuptools", specifier = "==83.0.0" },
     { name = "typing-extensions", specifier = "==4.0.1" },
     { name = "wheel", specifier = "==0.46.3" },
 ]
@@ -189,11 +189,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "78.1.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/9c/42314ee079a3e9c24b27515f9fbc7a3c1d29992c33451779011c74488375/setuptools-78.1.1.tar.gz", hash = "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d", size = 1368163, upload-time = "2025-04-19T18:23:36.68Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl", hash = "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561", size = 1256462, upload-time = "2025-04-19T18:23:34.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This updates setuptools to the latest 83.0.0 to address the CWE-176 and CWE-697 which are both vulnerabilities addressed in this same version.

The python minimum version bump was needed as `setuptools-83.0.0` does not support `python-3.9`

These seem to be packaging vulnerabilities according to their descriptions.
https://cwe.mitre.org/data/definitions/176.html
https://cwe.mitre.org/data/definitions/697.html

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
