### PR TITLE
Keep receiver input failures recoverable

### DIFF
--- a/payjoin-cli/src/app/v2/mod.rs
+++ b/payjoin-cli/src/app/v2/mod.rs
@@ -1099,8 +1099,9 @@ impl App {
         let candidate_inputs = wallet.list_unspent()?;
 
         if candidate_inputs.is_empty() {
+            let id = persister.session_id();
             return Err(anyhow::anyhow!(
-                "No spendable UTXOs available in wallet. Cannot contribute inputs to payjoin."
+                "No spendable UTXOs available in wallet. Please fund your wallet before resuming this session, or run `payjoin-cli cancel {id}` to cancel and broadcast the original transaction."
             ));
         }
 

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -5,7 +5,7 @@ mod e2e {
 
     use nix::sys::signal::{kill, Signal};
     use nix::unistd::Pid;
-    use payjoin::bitcoin::Txid;
+    use payjoin::bitcoin::{Amount, Txid};
     use payjoin_test_utils::{init_bitcoind_sender_receiver, BoxError};
     use tempfile::tempdir;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -527,6 +527,225 @@ mod e2e {
             .await?;
             terminate(cli_resumer).await.expect("Failed to kill payjoin-cli");
             assert!(res.is_none(), "Expected resumed sessions not yet completed");
+            Ok(())
+        }
+        Ok(())
+    }
+
+    /// A receiver with no spendable inputs can fund its wallet and resume the
+    /// same session to complete the Payjoin.
+    #[cfg(feature = "v2")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn receiver_reports_input_contribution_recovery_v2(
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use payjoin_test_utils::{init_tracing, TestServices};
+        use tempfile::TempDir;
+
+        type Result<T> = std::result::Result<T, BoxError>;
+
+        /// How long to wait for a payjoin-cli subprocess to print an expected line.
+        const STDOUT_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(10);
+
+        init_tracing();
+        let mut services = TestServices::initialize_with_relays(3).await?;
+        let temp_dir = tempdir()?;
+
+        let result = tokio::select! {
+            res = services.take_ohttp_relay_handle() => Err(format!("Ohttp relay is long running: {res:?}").into()),
+            res = services.take_directory_handle() => Err(format!("Directory server is long running: {res:?}").into()),
+            res = recovery_cli_async(&services, &temp_dir) => res,
+        };
+
+        assert!(result.is_ok(), "receiver recovery test failed: {:#?}", result.unwrap_err());
+
+        /// Read lines until the receiver reports how to recover.
+        async fn wait_for_recovery_guidance(mut cli_receive_resumer: Child) -> Result<()> {
+            let mut stdout =
+                cli_receive_resumer.stdout.take().expect("Failed to take stdout of child process");
+            let res = tokio::time::timeout(
+                STDOUT_TIMEOUT,
+                wait_for_stdout_match(&mut stdout, |line| {
+                    line.contains("No spendable UTXOs available in wallet")
+                        && line.contains("Please fund your wallet before resuming this session")
+                        && line.contains("payjoin-cli cancel")
+                        && line.contains("broadcast the original transaction")
+                }),
+            )
+            .await?;
+
+            terminate(cli_receive_resumer).await.expect("Failed to kill payjoin-cli");
+            res.ok_or_else(|| "receiver did not report input contribution recovery options".into())
+                .map(|_| ())
+        }
+
+        async fn wait_for_output(mut child: Child, expected: &str) -> Result<()> {
+            let mut stdout = child.stdout.take().expect("Failed to take child stdout");
+            let res = tokio::time::timeout(
+                STDOUT_TIMEOUT,
+                wait_for_stdout_match(&mut stdout, |line| line.contains(expected)),
+            )
+            .await?;
+
+            terminate(child).await.expect("Failed to kill payjoin-cli");
+            res.ok_or_else(|| format!("payjoin-cli did not report {expected:?}").into()).map(|_| ())
+        }
+
+        async fn recovery_cli_async(services: &TestServices, temp_dir: &TempDir) -> Result<()> {
+            let receiver_db_path = temp_dir.path().join("receiver_db");
+            let sender_db_path = temp_dir.path().join("sender_db");
+            let (bitcoind, sender, receiver) = init_bitcoind_sender_receiver(None, None)?;
+
+            // Empty the receiver wallet so it has no inputs to contribute.
+            let sweep_address = sender.new_address()?;
+            receiver.send_all(std::slice::from_ref(&sweep_address))?;
+            bitcoind.client.generate_to_address(1, &sweep_address)?;
+
+            let cert_path = &temp_dir.path().join("localhost.der");
+            tokio::fs::write(cert_path, services.cert()).await?;
+            services.wait_for_services_ready().await?;
+            let ohttp_keys = services.fetch_ohttp_keys().await?;
+            let ohttp_keys_path = temp_dir.path().join("ohttp_keys");
+            tokio::fs::write(&ohttp_keys_path, ohttp_keys.encode()?).await?;
+
+            let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);
+            let sender_rpchost = format!("http://{}/wallet/sender", bitcoind.params.rpc_socket);
+            let cookie_file = &bitcoind.params.cookie_file;
+            let payjoin_cli = env!("CARGO_BIN_EXE_payjoin-cli");
+            let directory = &services.directory_url();
+            let ohttp_relays = &services.ohttp_relay_urls();
+
+            // Receiver publishes a BIP21 and then goes offline.
+            let cli_receive_initiator = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("receive")
+                .arg(RECEIVE_SATS)
+                .arg("--pj-directories")
+                .arg(directory)
+                .arg("--ohttp-keys")
+                .arg(&ohttp_keys_path)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli");
+            let bip21 = get_bip21_from_receiver(cli_receive_initiator).await;
+
+            // Sender posts the original proposal and waits for a response.
+            let cli_send_initiator = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&sender_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&sender_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("send")
+                .arg(&bip21)
+                .arg("--fee-rate")
+                .arg("1")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli");
+            send_until_request_timeout(cli_send_initiator).await?;
+
+            // Receiver resumes and reports both recovery options without
+            // automatically cancelling the session.
+            let cli_receive_resumer = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("resume")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to execute payjoin-cli");
+            wait_for_recovery_guidance(cli_receive_resumer).await?;
+
+            // Fund the receiver, then resume the unchanged WantsInputs state.
+            let funding_address = receiver.new_address()?;
+            sender.send_to_address(&funding_address, Amount::from_sat(100_000))?;
+            bitcoind.client.generate_to_address(1, &sweep_address)?;
+
+            let cli_receive_resumer = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("resume")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to resume payjoin-cli receiver");
+            wait_for_output(cli_receive_resumer, "Response successful").await?;
+
+            // The sender receives and broadcasts the Payjoin proposal.
+            let cli_send_resumer = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&sender_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&sender_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("send")
+                .arg(&bip21)
+                .arg("--fee-rate")
+                .arg("1")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to resume payjoin-cli sender");
+            wait_for_output(cli_send_resumer, "Payjoin sent").await?;
+
+            bitcoind.client.generate_to_address(1, &sweep_address)?;
+
+            // Monitoring the same receiver session observes the confirmed
+            // Payjoin and closes the session successfully.
+            let cli_receive_resumer = Command::new(payjoin_cli)
+                .arg("--root-certificate")
+                .arg(cert_path)
+                .arg("--rpchost")
+                .arg(&receiver_rpchost)
+                .arg("--cookie-file")
+                .arg(cookie_file)
+                .arg("--db-path")
+                .arg(&receiver_db_path)
+                .arg("--ohttp-relays")
+                .arg(ohttp_relays)
+                .arg("resume")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("Failed to resume payjoin-cli receiver monitoring");
+            wait_for_output(cli_receive_resumer, "Session completed.").await?;
             Ok(())
         }
         Ok(())


### PR DESCRIPTION
Closes #1213.

## What

When the payjoin-cli receiver has no spendable inputs to contribute, the session remains recoverable instead of being cancelled automatically.

- v1 keeps its existing empty-wallet guard and returns actionable funding guidance to the sender.
- v2 keeps its empty-wallet guard and tells the receiver to either fund the wallet and resume the session or run `payjoin-cli cancel <id>` to cancel and broadcast the original transaction.

## Why

A missing receiver input is recoverable: the receiver can acquire a spendable UTXO and resume the same session. Cancellation remains available when the user prefers to fall back to the original transaction.

## Test

Added an e2e test that empties the receiver wallet, verifies both recovery options are reported, funds the wallet, resumes the same session, and completes the Payjoin successfully.

Disclosure: co-authored by Codex