### PR TITLE
Expose PjParam::receiver_pubkey() over FFI

### DIFF
--- a/payjoin-ffi/src/send/mod.rs
+++ b/payjoin-ffi/src/send/mod.rs
@@ -252,6 +252,18 @@ impl From<PjParam> for payjoin::uri::v2::PjParam {
     fn from(value: PjParam) -> Self { value.0 }
 }
 
+#[uniffi::export]
+impl PjParam {
+    /// The receiver's ephemeral HPKE public key, as 33 compressed bytes.
+    ///
+    /// Stable for the lifetime of a receive session. Consumers use it to
+    /// deduplicate and resume sender sessions and to ensure a receiver key
+    /// is not reused across sessions, without parsing the endpoint fragment.
+    pub fn receiver_pubkey(&self) -> Vec<u8> {
+        self.0.receiver_pubkey().to_compressed_bytes().to_vec()
+    }
+}
+
 #[derive(uniffi::Object, Clone)]
 pub struct SenderSessionHistory(pub payjoin::send::v2::SessionHistory);
 


### PR DESCRIPTION
FFI consumers need the receiver's ephemeral HPKE public key as the
key for deduplicating and resuming sender sessions, matching what
the `payjoin-cli` reference already does. Until now the FFI PjParam was an
opaque object with no exported methods, forcing wallets to scrape the
compressed key out of the endpoint fragment and reimplement URI-format
knowledge that belongs in the library.

Add a `#[uniffi::export]` getter returning the 33-byte compressed key,
mirroring the existing `SenderSessionHistory::fallback_tx()` pattern. This
only bridges to FFI what core already exposes as pub for exactly this
purpose; the genuinely-internal fields stay pub(crate).

Uniffi has no fixed-size-array type, so we return a vec rather than `[u8; 33]`

I found this while hacking on WasabiWallet and realizing it needed to index on the pk as the reference payjoin-cli does.

Disclosure: Co-authored by: Claude Code

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
