### PR TITLE
Remove output substitution test helper

### DIFF
--- a/payjoin/src/core/send/v1.rs
+++ b/payjoin/src/core/send/v1.rs
@@ -247,18 +247,13 @@ mod test {
     use crate::error_codes::ErrorCode;
     use crate::send::error::{ResponseError, WellKnownError};
     use crate::send::test::create_psbt_context;
+    use crate::uri::pj_uri;
     use crate::{Uri, MAX_CONTENT_LENGTH};
 
     const PJ_URI: &str =
         "bitcoin:2N47mmrWXsNBvQR6k78hWJoTji57zXwNcU7?amount=0.02&pjos=0&pj=HTTPS://EXAMPLE.COM/";
-
-    fn pj_uri() -> PjUri {
-        Uri::try_from(PJ_URI)
-            .expect("uri should succeed")
-            .assume_checked()
-            .check_pj_supported()
-            .expect("uri should support payjoin")
-    }
+    const PJ_URI_OUTPUT_SUBSTITUTION_ENABLED: &str =
+        "bitcoin:2N47mmrWXsNBvQR6k78hWJoTji57zXwNcU7?amount=0.02&pj=HTTPS://EXAMPLE.COM/";
 
     fn create_v1_context() -> super::V1Context {
         let psbt_context = create_psbt_context().expect("failed to create context");
@@ -398,13 +393,13 @@ mod test {
     #[test]
     fn test_build_recommended_max_fee_contribution() {
         let psbt = PARSED_ORIGINAL_PSBT.clone();
-        let sender = SenderBuilder::new(psbt.clone(), pj_uri())
+        let sender = SenderBuilder::new(psbt.clone(), pj_uri(PJ_URI))
             .build_recommended(
                 FeeRate::from_sat_per_vb(2000000).expect("Could not determine feerate"),
             )
             .expect("sender should succeed");
         assert_eq!(sender.psbt_ctx.output_substitution, OutputSubstitution::Disabled);
-        assert_eq!(&sender.psbt_ctx.payee, &pj_uri().address().script_pubkey());
+        assert_eq!(&sender.psbt_ctx.payee, &pj_uri(PJ_URI).address().script_pubkey());
         let fee_contribution =
             sender.psbt_ctx.fee_contribution.expect("sender should contribute fees");
         assert_eq!(fee_contribution.max_amount, psbt.unsigned_tx.output[0].value);
@@ -414,33 +409,35 @@ mod test {
 
     #[test]
     fn test_build_recommended() {
-        let sender = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri())
+        let sender = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri(PJ_URI))
             .build_recommended(FeeRate::BROADCAST_MIN)
             .expect("sender should succeed");
         assert_eq!(sender.psbt_ctx.output_substitution, OutputSubstitution::Disabled);
-        assert_eq!(&sender.psbt_ctx.payee, &pj_uri().address().script_pubkey());
+        assert_eq!(&sender.psbt_ctx.payee, &pj_uri(PJ_URI).address().script_pubkey());
         let fee_contribution =
             sender.psbt_ctx.fee_contribution.expect("sender should contribute fees");
         assert_eq!(fee_contribution.max_amount, Amount::from_sat(91));
         assert_eq!(fee_contribution.vout, 0);
         assert_eq!(sender.psbt_ctx.min_fee_rate, FeeRate::from_sat_per_kwu(250));
         // Ensure the receiver's output substitution preference is respected either way
-        let mut pj_uri = pj_uri();
-        pj_uri.set_output_substitution(OutputSubstitution::Enabled);
-        let sender = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri)
-            .build_recommended(FeeRate::from_sat_per_vb_u32(1))
-            .expect("sender should succeed");
+        let sender = SenderBuilder::new(
+            PARSED_ORIGINAL_PSBT.clone(),
+            pj_uri(PJ_URI_OUTPUT_SUBSTITUTION_ENABLED),
+        )
+        .build_recommended(FeeRate::from_sat_per_vb_u32(1))
+        .expect("sender should succeed");
         assert_eq!(sender.psbt_ctx.output_substitution, OutputSubstitution::Enabled);
     }
 
     #[test]
     fn test_always_disable_output_substitution() {
-        let mut pj_uri = pj_uri();
-        pj_uri.set_output_substitution(OutputSubstitution::Enabled);
-        let sender = SenderBuilder::new(PARSED_ORIGINAL_PSBT.clone(), pj_uri)
-            .always_disable_output_substitution()
-            .build_recommended(FeeRate::BROADCAST_MIN)
-            .expect("sender should succeed");
+        let sender = SenderBuilder::new(
+            PARSED_ORIGINAL_PSBT.clone(),
+            pj_uri(PJ_URI_OUTPUT_SUBSTITUTION_ENABLED),
+        )
+        .always_disable_output_substitution()
+        .build_recommended(FeeRate::BROADCAST_MIN)
+        .expect("sender should succeed");
         assert_eq!(sender.psbt_ctx.output_substitution, OutputSubstitution::Disabled);
     }
 

--- a/payjoin/src/core/uri/mod.rs
+++ b/payjoin/src/core/uri/mod.rs
@@ -19,6 +19,15 @@ pub mod v1;
 #[cfg(feature = "v2")]
 pub mod v2;
 
+#[cfg(all(test, feature = "v1"))]
+pub(crate) fn pj_uri(uri: &str) -> PjUri {
+    Uri::try_from(uri)
+        .expect("uri should parse")
+        .assume_checked()
+        .check_pj_supported()
+        .expect("uri should support payjoin")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 #[cfg_attr(feature = "v2", allow(clippy::large_enum_variant))]
@@ -250,12 +259,6 @@ impl PjUri {
 
     /// The validated payjoin parameters carried by the URI.
     pub fn extras(&self) -> &PayjoinExtras { &self.0.extras.0 }
-
-    /// Overrides the output substitution preference carried by the URI.
-    #[cfg(test)]
-    pub(crate) fn set_output_substitution(&mut self, output_substitution: OutputSubstitution) {
-        self.0.extras.0.output_substitution = output_substitution;
-    }
 }
 
 impl fmt::Display for PjUri {

--- a/payjoin/src/core/uri/mod.rs
+++ b/payjoin/src/core/uri/mod.rs
@@ -19,15 +19,6 @@ pub mod v1;
 #[cfg(feature = "v2")]
 pub mod v2;
 
-#[cfg(all(test, feature = "v1"))]
-pub(crate) fn pj_uri(uri: &str) -> PjUri {
-    Uri::try_from(uri)
-        .expect("uri should parse")
-        .assume_checked()
-        .check_pj_supported()
-        .expect("uri should support payjoin")
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 #[cfg_attr(feature = "v2", allow(clippy::large_enum_variant))]
@@ -370,6 +361,15 @@ impl bitcoin_uri::de::DeserializationState<'_> for DeserializationState {
         };
         Ok(MaybePayjoinExtrasAdapter(extras))
     }
+}
+
+#[cfg(all(test, feature = "v1"))]
+pub(crate) fn pj_uri(uri: &str) -> PjUri {
+    Uri::try_from(uri)
+        .expect("uri should parse")
+        .assume_checked()
+        .check_pj_supported()
+        .expect("uri should support payjoin")
 }
 
 #[cfg(test)]

--- a/payjoin/src/core/uri/v1.rs
+++ b/payjoin/src/core/uri/v1.rs
@@ -38,7 +38,7 @@ mod tests {
     use payjoin_test_utils::BoxError;
 
     use super::*;
-    use crate::uri::MaybePayjoinExtras;
+    use crate::uri::{pj_uri, MaybePayjoinExtras};
     use crate::{OutputSubstitution, PjParam, Uri};
 
     #[test]
@@ -123,25 +123,22 @@ mod tests {
 
     #[test]
     fn test_serialize_pjos() {
-        let uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=HTTPS://EXAMPLE.COM/%23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC";
-        let expected_is_disabled = "pjos=0";
-        let expected_is_enabled = "pjos=1";
-        let mut pjuri = Uri::try_from(uri)
-            .expect("Invalid uri")
-            .assume_checked()
-            .check_pj_supported()
-            .expect("Could not parse pj extras");
-
-        pjuri.set_output_substitution(OutputSubstitution::Disabled);
+        let disabled_uri = pj_uri(
+            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=0&pj=HTTPS://EXAMPLE.COM/\
+             %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC",
+        );
         assert!(
-            pjuri.to_string().contains(expected_is_disabled),
-            "Pj uri should contain param: {expected_is_disabled}, but it did not"
+            disabled_uri.to_string().contains("pjos=0"),
+            "Pj uri should preserve disabled output substitution"
         );
 
-        pjuri.set_output_substitution(OutputSubstitution::Enabled);
+        let enabled_uri = pj_uri(
+            "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pjos=1&pj=HTTPS://EXAMPLE.COM/\
+             %23OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC",
+        );
         assert!(
-            !pjuri.to_string().contains(expected_is_enabled),
-            "Pj uri should elide param: {expected_is_enabled}, but it did not"
+            !enabled_uri.to_string().contains("pjos=1"),
+            "Pj uri should elide enabled output substitution"
         );
     }
 


### PR DESCRIPTION
## Summary

- remove the test-only output substitution setter that is unused in v2-only all-target builds
- construct v1 test cases from explicit BIP21 URI fixtures for enabled and disabled output substitution
- preserve coverage for URI serialization and sender behavior while exercising the public parsing path
- keep the shared URI test helper adjacent to the URI test module

Closes #1774.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p payjoin --lib --no-default-features --features v1` — 243 passed, 1 ignored
- Earlier implementation-head verification also passed v1/v2 Clippy, `contrib/lint.sh`, and `contrib/test_local.sh`; the review-only follow-up only moved the unchanged helper.

## AI assistance disclosure

AI assistance was used to inspect the feature-gated call sites, draft the test refactor and PR description, address review feedback, and run verification. The resulting change was reviewed against the repository contribution requirements and verified with the listed formatting and test workflows.

- [x] I have disclosed my use of AI assistance in this PR body.
- [x] I have read CONTRIBUTING.md and kept each commit hygienic.
