### PR TITLE
fix(payjoin-ffi): validate brew and llvm on macOS

### DIFF
--- a/payjoin-ffi/javascript/scripts/generate_bindings.sh
+++ b/payjoin-ffi/javascript/scripts/generate_bindings.sh
@@ -7,7 +7,10 @@ echo "Running on $OS"
 npm --version
 
 if [[ $OS == "Darwin" && -z ${IN_NIX_SHELL:-} ]]; then
-    # TODO: check if brew & llvm are installed
+    if ! command -v brew >/dev/null 2>&1 || [[ ! -d "$(brew --prefix llvm 2>/dev/null)" ]]; then
+        echo "Error: both brew and llvm must be installed." >&2
+        exit 1
+    fi
     LLVM_PREFIX=$(brew --prefix llvm)
     export AR="$LLVM_PREFIX/bin/llvm-ar"
     export CC="$LLVM_PREFIX/bin/clang"


### PR DESCRIPTION
## Summary

- commit - d33bc3c4fa31847e2fbe860ab8ecc6cb0c5e6aeb
  - the commit adds an early guard inside the `Darwin` + `non-Nix-shell` if block with a descriptive error message when brew or llvm are not installed

Closes #1773 

hey @xstoicunicornx when you've got some time i'd appreciate that review. Thank you.

## AI assistance disclosure
I consulted GitHub copilot to understand the codebase and most of the code was then generated using copilot inline completion


<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
