### PR TITLE
Enable external-sources for shellcheck formatting.

### DIFF
--- a/treefmt.nix
+++ b/treefmt.nix
@@ -11,7 +11,10 @@
       package = pkgs.rustToolchains.nightly;
       edition = "2021";
     };
-    shellcheck.enable = true;
+    shellcheck = {
+      enable = true;
+      external-sources = true;
+    };
     shfmt = {
       enable = true;
       indent_size = 4;


### PR DESCRIPTION
Following a merge from #1770 I came across a nix fmt error whereby the shellcheck formatter needs external-sources enabled to be able to verify the formatting properly.

https://www.shellcheck.net/wiki/SC1091

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
