### PR TITLE
Bump dart payjoin 0.2.0 for pub.dev

### DIFF
--- a/payjoin-ffi/dart/CHANGELOG.md
+++ b/payjoin-ffi/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.2.0]
+
+- Bindings for payjoin-1.0.0-rc.7
+- **Breaking:** `checkInputsNotOwned` takes an `IsInputOwned` callback keyed on
+  an `OutPoint` in place of `IsScriptOwned`
+
 ## [0.1.2]
 
 - Bindings for payjoin-1.0.0-rc.4

--- a/payjoin-ffi/dart/native/Cargo.toml
+++ b/payjoin-ffi/dart/native/Cargo.toml
@@ -16,6 +16,6 @@ name = "payjoin_ffi_wrapper"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "c52bac921731f7d1a08bd2901499027fb1360ee2", features = [
+payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "a0eca7e054e035e2b350fd96e244d6b963def343", features = [
   "dart",
 ] }

--- a/payjoin-ffi/dart/pubspec.yaml
+++ b/payjoin-ffi/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: payjoin
 description: Dart bindings for payjoin (EXPERIMENTAL)
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/payjoin/rust-payjoin
 repository: https://github.com/payjoin/rust-payjoin
 


### PR DESCRIPTION
Bump the dart bindings to 0.2.0 to publish updated bindings for payjoin 1.0.0-rc.7. Pin the payjoin-ffi wrapper dependency to a0eca7e0, the payjoin-1.0.0-rc.7 tag commit, and record the release in the changelog.

The minor rather than patch bump reflects a breaking receiver API change: checkInputsNotOwned now takes an IsInputOwned callback keyed on an outpoint in place of IsScriptOwned, so consumers pinning ^0.1.2 do not silently upgrade into it.

The package is already published here https://pub.dev/packages/payjoin

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
