### PR TITLE
update runners to Ubuntu 26.04

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -25,7 +25,7 @@ jobs:
   check-bump:
     name: Check release version bump
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -43,7 +43,7 @@ jobs:
   verify-tag:
     name: Verify release tag
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       crate: ${{ steps.meta.outputs.crate }}
       version: ${{ steps.meta.outputs.version }}
@@ -80,7 +80,7 @@ jobs:
     name: Wait for CI
     if: github.event_name == 'push'
     needs: verify-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       checks: read
       contents: read
@@ -100,7 +100,7 @@ jobs:
     name: Publish to crates.io
     if: github.event_name == 'push'
     needs: [verify-tag, wait-for-ci]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: crates-release
     permissions:
       id-token: write
@@ -142,7 +142,7 @@ jobs:
     name: Create GitHub release
     if: github.event_name == 'push'
     needs: [verify-tag, publish]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     env:
@@ -187,7 +187,7 @@ jobs:
     name: Verify publication
     if: github.event_name == 'push'
     needs: [verify-tag, publish]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     env:
       CRATE: ${{ needs.verify-tag.outputs.crate }}
       VERSION: ${{ needs.verify-tag.outputs.version }}

--- a/.github/workflows/cron-directory-monitor.yml
+++ b/.github/workflows/cron-directory-monitor.yml
@@ -4,7 +4,7 @@ on:
     - cron: "9,23,38,53 * * * *" # Runs 4 times per hour offset from the high traffic quarters that may delay or cancel a run from occuring
 jobs:
   health-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
       - name: Check /health endpoint

--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # allows manual triggering
 jobs:
   cargo-mutants:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-26.04, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -73,7 +73,7 @@ jobs:
     # Microsoft CRT/SDK. The per-RID smoke jobs verify each produced asset on
     # real hardware.
     name: "Build NuGet native asset"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     env:
       # Must match the dtolnay/rust-toolchain version exactly: the cross-target
       # std components are installed for that toolchain, and a partial version
@@ -153,7 +153,7 @@ jobs:
 
   pack-nuget:
     name: "Pack C# NuGet package"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     needs: build-nuget-native
     env:
       # Exact version so the packaged bindings build with the toolchain the
@@ -215,7 +215,7 @@ jobs:
         include:
           - os: ubuntu-26.04-arm
             rid: linux-arm64
-          - os: ubuntu-latest
+          - os: ubuntu-26.04
             rid: linux-x64
           - os: macos-latest
             rid: osx-arm64

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -213,7 +213,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-26.04-arm
             rid: linux-arm64
           - os: ubuntu-latest
             rid: linux-x64

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-26.04, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   flake-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         checks:

--- a/.github/workflows/flake-maintenance.yml
+++ b/.github/workflows/flake-maintenance.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate-lock-file:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         checks:
@@ -26,7 +26,7 @@ jobs:
 
   update-lock-file:
     needs: validate-lock-file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v6

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-26.04, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/lock-maintenance.yml
+++ b/.github/workflows/lock-maintenance.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-lock-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     env:
       UPDATE_DEPS: true
     permissions:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-26.04, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       packages: write
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +41,7 @@ jobs:
         run: RUST_LOG=debug bash contrib/test.sh
 
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v6
@@ -58,7 +58,7 @@ jobs:
 
   Coverage:
     name: Code coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     env:
@@ -94,14 +94,14 @@ jobs:
 
   CodeSpell:
     name: Code spell check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
       - uses: codespell-project/actions-codespell@v2
 
   DiffMutants:
     name: Diff cargo-mutants
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -135,7 +135,7 @@ jobs:
 
   Fuzz:
     name: Fuzz build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v6

--- a/.github/workflows/standup-compile.yml
+++ b/.github/workflows/standup-compile.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5

--- a/.github/workflows/standup-on-comment.yml
+++ b/.github/workflows/standup-on-comment.yml
@@ -12,7 +12,7 @@ jobs:
       github.event.comment.parent_id == null &&
       github.event.comment.user.login != 'payjoin-bot' &&
       contains(github.event.comment.body, '/check-in')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5

--- a/.github/workflows/standup-prompt.yml
+++ b/.github/workflows/standup-prompt.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   create-discussion:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Updates every workflow from the floating `ubuntu-latest` label to the explicit `ubuntu-26.04` image, including the linux-arm64 smoke job in `csharp.yml` which moves from `ubuntu-24.04-arm` to `ubuntu-26.04-arm`.

`ubuntu-latest` still resolves to Ubuntu 24.04 with no announced migration date, so pinning explicitly keeps every runner aligned on the same image and future bumps become an intentional PR instead of a silent drift.

Closes #1783

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [X] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [X] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
