### PR TITLE
Bump payjoin to version 1.0.0-rc.8

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2567,7 +2567,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2698,7 +2698,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6.0.0"
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.8.0", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1.18", optional = true }
-payjoin = { version = "1.0.0-rc.7", default-features = false }
+payjoin = { version = "1.0.0-rc.8", default-features = false }
 pest_derive = "2.7.0"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -27,7 +27,7 @@ getrandom = "0.2.10"
 icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 lazy_static = "1.5.0"
-payjoin = { version = "1.0.0-rc.7", features = ["v1", "v2"] }
+payjoin = { version = "1.0.0-rc.8", features = ["v1", "v2"] }
 payjoin-test-utils = { version = "0.0.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry-otlp = { version = "0.32", optional = true, default-features = fal
   "http-proto",
 ] }
 opentelemetry_sdk = "0.32"
-payjoin = { version = "1.0.0-rc.7", features = [
+payjoin = { version = "1.0.0-rc.8", features = [
   "directory",
 ], default-features = false }
 rand = "0.8"

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,7 +32,7 @@ futures = { version = "0.3.21", default-features = false, features = ["std"] }
 http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "1.0.0-rc.7", default-features = false }
+payjoin = { version = "1.0.0-rc.8", default-features = false }
 payjoin-mailroom = { version = "0.1.2", features = ["_manual-tls"] }
 tar = "0.4.20"
 # Pin to 0.14.7 (last version to support our MSRV 1.85)

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Payjoin Changelog
 
+## 1.0.0-rc.8
+
+This release tightens the sender's validation of the sighash types declared on
+its own inputs.
+
+Selected Improvements:
+
+### Bug Fixes
+
+- Require sender inputs to declare a sighash type that commits to all inputs
+  and outputs. Only ECDSA `SIGHASH_ALL`, taproot
+  `SIGHASHDEFAULT`/`SIGHASH_ALL`, and an unset type are accepted, both when
+  building the sender context and when validating the receiver's proposal
+  (#1790, #1793)
+
 ## 1.0.0-rc.7
 
 This release changes how the receiver's ownership guard identifies a coin, so

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
Prepare the `payjoin-1.0.0-rc.8` release per #1794. Bumps the crate version
and every workspace member's requirement on it, refreshes both lock files,
and adds the changelog section for the changes merged since rc.7.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

Disclosure: co-authored by Claude Opus 5
