### PR TITLE
Pin globset for javascript bindings generation

### DIFF
--- a/payjoin-ffi/javascript/scripts/generate_bindings.sh
+++ b/payjoin-ffi/javascript/scripts/generate_bindings.sh
@@ -16,7 +16,7 @@ fi
 
 # Heinous hack to pin a transitive dependency to be MSRV compatible on 1.85
 cd node_modules/uniffi-bindgen-react-native
-cargo add home@=0.5.11 --package uniffi-bindgen-react-native
+cargo add home@=0.5.11 globset@=0.4.19 --package uniffi-bindgen-react-native
 cd ../..
 
 # rustup target add is a no-op against a nix-provided toolchain


### PR DESCRIPTION
Pin the globset dep for the javascript ffi build

`0.4.19` is the latest with 1.85.0 msrv support https://crates.io/crates/globset/versions

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
