### PR TITLE
Prefer MSRV-compatible deps in the ubrn build

### DIFF
--- a/payjoin-ffi/javascript/scripts/generate_bindings.sh
+++ b/payjoin-ffi/javascript/scripts/generate_bindings.sh
@@ -14,10 +14,12 @@ if [[ $OS == "Darwin" && -z ${IN_NIX_SHELL:-} ]]; then
     echo "LLVM flags set: AR=$AR, CC=$CC"
 fi
 
-# Heinous hack to pin a transitive dependency to be MSRV compatible on 1.85
-cd node_modules/uniffi-bindgen-react-native
-cargo add home@=0.5.11 --package uniffi-bindgen-react-native
-cd ../..
+# The ubrn command is compiled from source during the build below, from a
+# workspace that ships no lock file, so cargo resolves it fresh every run and
+# picks up crates whose MSRV has moved past this shell's toolchain. Ask cargo
+# to prefer versions compatible with the rustc in use instead of pinning each
+# drifting crate by hand.
+export CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback
 
 # rustup target add is a no-op against a nix-provided toolchain
 # (no rustup home, targets baked into the nix derivation instead).


### PR DESCRIPTION
Fixes the javascript CI job, which has been broken since 2026-08-04 on every
PR that touches `payjoin-ffi/**`.

`ubrn` is compiled from source during binding generation, out of a workspace
that ships no lock file, so cargo resolves it fresh on every run and takes the
newest semver-compatible release of each crate. `globset 0.4.20` raised its
MSRV to 1.88, so that resolution now yields a crate the javascript dev shell's
pinned 1.85.0 toolchain refuses to build:

```
error: rustc 1.85.0 is not supported by the following package:
  globset@0.4.20 requires rustc 1.88
```

Rather than extend the existing `cargo add` pin list with a second entry, this
sets `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback` and drops the list
entirely. Cargo's MSRV-aware resolver prefers versions compatible with the
rustc in use, and derives `globset 0.4.19` and `home 0.5.11` on its own, the
same two versions the manual pins named. Future MSRV drift resolves the same
way with no further edits.

It also stops the build mutating `node_modules`. `cargo add` was writing pins
into `node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/Cargo.toml`;
that manifest now stays pristine.

Verified locally on macOS with `nix develop .#javascript -c
./payjoin-ffi/javascript/contrib/test.sh` against a clean `npm ci`: 31 tests
pass, and the generated lock records globset 0.4.19 / home 0.5.11.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

Disclosure: co-authored by Claude Opus 5
