### PR TITLE
Remove flakehub api call in nix cache action in CI

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -35,6 +35,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: Use nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: Check the bump is consistent and publishable
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -59,6 +61,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: Use nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: Compute tag metadata
         id: meta
         env:
@@ -155,6 +159,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: Use nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: Download packaged crate
         uses: actions/download-artifact@v4
         with:
@@ -198,6 +204,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: Use nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: Download packaged crate
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -39,6 +39,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Build and test"
         run: nix develop .#csharp -c ./payjoin-ffi/csharp/contrib/test.sh
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: Run treefmt
         run: |
           set -eo pipefail

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Formatting
 
 on: [push, pull_request]
 

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -29,5 +29,7 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Build and test"
         run: nix develop .#javascript -c ./payjoin-ffi/javascript/contrib/test.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,5 +29,7 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Build and test"
         run: nix develop .#python --command bash ./payjoin-ffi/python/contrib/test.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Add nginxWithStream to PATH"
         run: |
           # This is necessary for payjoin-mailroom integration tests
@@ -51,6 +53,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Run code linting"
         run: nix develop -c ./contrib/lint.sh
       - name: "Run documentation linting"
@@ -77,6 +81,8 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Add nginxWithStream to PATH"
         run: |
           # This is necessary for payjoin-mailroom integration tests


### PR DESCRIPTION
The magic-nix-cache-action was calling the flakehub api when we do not have an account for it. This keeps the action and just uses the standard github cache storage space.

As a note the github cache space is limited at our current tier. Perhaps it is worth exploring whether or not this job is totally worth it if our repo immediately fills the cache space.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
