### PR TITLE
Disable docs build verification in CI for non-lib crates

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Use nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Download packaged crate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: crate
           path: dist

--- a/contrib/release/verify-published.sh
+++ b/contrib/release/verify-published.sh
@@ -45,8 +45,17 @@ published_sha="$(poll "${CRATES_IO_ATTEMPTS:-30}" \
     die "checksum mismatch: crates.io $published_sha vs local $local_sha"
 echo "crates.io checksum matches the attested .crate ($local_sha)"
 
-echo "Waiting for docs.rs to build $crate $version (${DOCS_RS_ATTEMPTS:-60} checks, ${interval}s apart)"
-poll "${DOCS_RS_ATTEMPTS:-60}" \
-    "https://docs.rs/crate/$crate/$version/status.json" 'select(.doc_status == true) | "built"' >/dev/null ||
-    die "docs.rs did not build $crate $version"
-echo "docs.rs built $crate $version"
+# docs.rs builds documentation only for crates with a library target;
+# binary-only crates (e.g. payjoin-cli) never reach doc_status == true.
+if cargo metadata --format-version 1 --no-deps 2>/dev/null |
+    jq -e --arg c "$crate" \
+        'any(.packages[] | select(.name == $c) | .targets[].kind[]; . | test("^(lib|rlib|dylib|cdylib|staticlib|proc-macro)$"))' \
+        >/dev/null; then
+    echo "Waiting for docs.rs to build $crate $version (${DOCS_RS_ATTEMPTS:-60} checks, ${interval}s apart)"
+    poll "${DOCS_RS_ATTEMPTS:-60}" \
+        "https://docs.rs/crate/$crate/$version/status.json" 'select(.doc_status == true) | "built"' >/dev/null ||
+        die "docs.rs did not build $crate $version"
+    echo "docs.rs built $crate $version"
+else
+    echo "Skipping docs.rs check for $crate (no library target)"
+fi


### PR DESCRIPTION
This skips docs builds to prevent failures on crates that will not ever successfully build docs, i.e. binary crates like payjoin-cli.

https://github.com/payjoin/rust-payjoin/actions/runs/31037558465/job/92423224391z

also updates the download package action to bring it inline with our recent update away from node 20

script edit written by glm-5.2

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
