### PR TITLE
Bump dart payjoin 0.2.1 for pub.dev

### DIFF
--- a/payjoin-ffi/dart/CHANGELOG.md
+++ b/payjoin-ffi/dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.2.1+payjoin-1.0.0-rc.8]
+
+- Sender inputs must declare a sighash type that commits to all inputs and
+  outputs. Only ECDSA `SIGHASH_ALL`, taproot `SIGHASHDEFAULT`/`SIGHASH_ALL`,
+  and an unset type are accepted, both when building the sender context and
+  when validating the receiver's proposal
+- Versions now carry the wrapped payjoin release as build metadata
+
 ## [0.2.0]
 
 - Bindings for payjoin-1.0.0-rc.7

--- a/payjoin-ffi/dart/CONTRIBUTING.md
+++ b/payjoin-ffi/dart/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Instructions for building and testing the Dart bindings locally.
+Instructions for building, testing, and publishing the Dart bindings.
 
 ## Build Bindings
 
@@ -24,3 +24,60 @@ bash ./scripts/generate_bindings.sh
 # Run all tests
 dart test
 ```
+
+## Releasing
+
+Maintainer instructions for publishing to
+[pub.dev](https://pub.dev/packages/payjoin).
+
+### Versioning
+
+Versions take the form `<package version>+payjoin-<crate version>`, for
+example `0.2.1+payjoin-1.0.0-rc.8`. The part before the `+` is the package's
+own semantic version, and is what consumers write version constraints
+against. The build metadata after it records which `payjoin` release the
+bindings wrap, so the pub.dev listing names the supported protocol version
+without a changelog lookup.
+
+Bump the package version for changes to the Dart API or to packaging. Update
+the build metadata whenever the wrapped `payjoin` release changes, which is a
+patch bump at minimum, since the same Dart API gets new behavior.
+
+### Publishing
+
+1. Point the `payjoin-ffi` dependency in `native/Cargo.toml` at the commit
+   tagged for the `payjoin` release being wrapped. Consumers build from that
+   revision. `.cargo/config.toml` redirects it to the local workspace for
+   development only, and `.pubignore` withholds that file from the archive.
+2. Set the version in `pubspec.yaml` and describe the consumer-visible
+   changes under a matching heading in `CHANGELOG.md`.
+3. Run the tests: `bash ./contrib/test.sh`.
+4. Generate the bindings to be shipped and inspect the archive.
+
+   ```shell
+   bash ./scripts/generate_bindings.sh
+   dart pub publish --dry-run
+   ```
+
+   `.pubignore` replaces `.gitignore` for publishing, so a gitignored file is
+   only kept out of the archive if `.pubignore` also lists it. Two build
+   artifacts decide the contents here: `lib/payjoin.dart` has to be present
+   and current, since it is the binding surface consumers import, and
+   `native/Cargo.lock` has to be absent, since publishing one resolved
+   against the `.cargo/config.toml` path overlay would hand consumers a
+   lockfile pinned to a dependency graph they cannot reproduce. Delete it
+   before publishing if a local build left one behind.
+
+5. Publish.
+
+   ```shell
+   dart pub publish
+   ```
+
+Known limitation: `scripts/generate_bindings.sh` always builds with
+`_test-utils`, so the bindings it emits declare test-only APIs such as
+`TestServices` and `BitcoindEnv`. Consumers build the native library without
+that feature, which leaves those declarations backed by symbols that are
+absent at runtime. Every release so far ships them. Giving the script a
+production mode, as `payjoin-ffi/csharp` does with `PAYJOIN_FFI_FEATURES`,
+remains to be done.

--- a/payjoin-ffi/dart/native/Cargo.toml
+++ b/payjoin-ffi/dart/native/Cargo.toml
@@ -16,6 +16,6 @@ name = "payjoin_ffi_wrapper"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "a0eca7e054e035e2b350fd96e244d6b963def343", features = [
+payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "e4f5a0b384462458b3d68aeec042c20ceffb8d80", features = [
   "dart",
 ] }

--- a/payjoin-ffi/dart/pubspec.yaml
+++ b/payjoin-ffi/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: payjoin
 description: Dart bindings for payjoin (EXPERIMENTAL)
-version: 0.2.0
+version: 0.2.1+payjoin-1.0.0-rc.8
 homepage: https://github.com/payjoin/rust-payjoin
 repository: https://github.com/payjoin/rust-payjoin
 


### PR DESCRIPTION
Bumps the Dart bindings to `0.2.1+payjoin-1.0.0-rc.8` and pins the `payjoin-ffi` wrapper dependency to `e4f5a0b3`, the `payjoin-1.0.0-rc.8` tag commit.

The FFI surface is unchanged since rc.7 — `git diff payjoin-1.0.0-rc.7..payjoin-1.0.0-rc.8 -- payjoin-ffi/src` is empty, only the `payjoin` dependency line in `payjoin-ffi/Cargo.toml` moved — so a patch bump covers it. What reaches consumers is rc.8's tightened sender validation: an input must declare a sighash type that commits to all inputs and outputs, so only ECDSA `SIGHASH_ALL`, taproot `SIGHASHDEFAULT`/`SIGHASH_ALL`, and an unset type are accepted.

### Versioning convention

Adopts the pub.dev build-metadata convention that [`bark_bitcoin`](https://pub.dev/packages/bark_bitcoin/versions) uses: `<package version>+payjoin-<crate version>`. The semantic version before the `+` stays what consumers write constraints against, while the metadata after it names the wrapped `payjoin` release directly on the pub.dev listing instead of requiring a changelog lookup. `dart pub publish --dry-run` accepts the string.

### Release documentation

The Dart package carried no publishing instructions, though `payjoin-ffi/README.md` claims each language directory has them, so `CONTRIBUTING.md` gains a `Releasing` section covering the versioning convention and the publish steps.

It documents two archive-content traps, both stemming from `.pubignore` *replacing* `.gitignore` at publish time rather than adding to it:

- `lib/payjoin.dart` is gitignored but must be present and current, since it is the binding surface consumers import.
- `native/Cargo.lock` is gitignored but absent from `.pubignore`, so a local build leaves one behind that would ship a lockfile resolved against the `.cargo/config.toml` path overlay. 0.2.0 happened not to ship one; a dry run from a built tree does include it.

### Known limitation, not addressed here

`scripts/generate_bindings.sh` always builds with `_test-utils`, so the bindings it emits declare test-only APIs such as `TestServices` and `BitcoindEnv` while consumers build the native library without that feature, leaving those declarations backed by symbols absent at runtime. Unpacking the published 0.2.0 archive confirms it already ships them; `@Native` resolves lazily, so this is latent rather than breaking. Recorded as a known limitation in `CONTRIBUTING.md`. Giving the script a production mode, as `payjoin-ffi/csharp` does with `PAYJOIN_FFI_FEATURES`, is left for a follow-up, along with adding `native/Cargo.lock` to `.pubignore`.

Disclosure: co-authored by Claude Code