### PR TITLE
Bump payjoin to version 1.0.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2567,7 +2567,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.8"
+version = "1.0.0"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -2698,7 +2698,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.8"
+version = "1.0.0"
 dependencies = [
  "bhttp",
  "bitcoin",

--- a/payjoin-cli/Cargo.toml
+++ b/payjoin-cli/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6.0.0"
 http-body-util = { version = "0.1.3", optional = true }
 hyper = { version = "1.8.0", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1.18", optional = true }
-payjoin = { version = "1.0.0-rc.8", default-features = false }
+payjoin = { version = "1.0.0", default-features = false }
 pest_derive = "2.7.0"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -27,7 +27,7 @@ getrandom = "0.2.10"
 icu_locale_core = "=2.0.1"
 icu_provider = "=2.0.0"
 lazy_static = "1.5.0"
-payjoin = { version = "1.0.0-rc.8", features = ["v1", "v2"] }
+payjoin = { version = "1.0.0", features = ["v1", "v2"] }
 payjoin-test-utils = { version = "0.0.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/payjoin-mailroom/Cargo.toml
+++ b/payjoin-mailroom/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry-otlp = { version = "0.32", optional = true, default-features = fal
   "http-proto",
 ] }
 opentelemetry_sdk = "0.32"
-payjoin = { version = "1.0.0-rc.8", features = [
+payjoin = { version = "1.0.0", features = [
   "directory",
 ], default-features = false }
 rand = "0.8"

--- a/payjoin-test-utils/Cargo.toml
+++ b/payjoin-test-utils/Cargo.toml
@@ -32,7 +32,7 @@ futures = { version = "0.3.21", default-features = false, features = ["std"] }
 http = { version = "1.3.1", optional = true }
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0", optional = true }
 once_cell = "1.21.3"
-payjoin = { version = "1.0.0-rc.8", default-features = false }
+payjoin = { version = "1.0.0", default-features = false }
 payjoin-mailroom = { version = "0.1.2", features = ["_manual-tls"] }
 tar = "0.4.20"
 # Pin to 0.14.7 (last version to support our MSRV 1.85)

--- a/payjoin/CHANGELOG.md
+++ b/payjoin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Payjoin Changelog
 
+## 1.0.0
+
+The first stable release of the payjoin library supports both synchronous
+BIP 78 payjoins and asynchronous BIP 77 payjoins. The BIP 77 sender and
+receiver APIs use typestate-driven session workflows, event-log persistence,
+and explicit monitoring, cancellation, and fallback paths so interrupted
+sessions can be safely resumed.
+
+This release stabilizes the public API and persisted session format developed
+through the 0.24, 0.25, and 1.0 release candidates.
+
 ## 1.0.0-rc.8
 
 This release tightens the sender's validation of the sighash types declared on

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin"
-version = "1.0.0-rc.8"
+version = "1.0.0"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Payjoin Library implementing BIP 78 and BIP 77 batching protocols."
 repository = "https://github.com/payjoin/rust-payjoin"


### PR DESCRIPTION
Before merging I have some questions about how we should structure the changelog.

Should we be comparing this against the `payjoin-0.25` tag or `rc-8` If we are comparing against the last non release candidate should we include changes in the changelog from each rc?

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
