### PR TITLE
Check semver compliance on release bump PRs

### DIFF
--- a/contrib/release/check-bump.sh
+++ b/contrib/release/check-bump.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #
 # Pull request check. For each release crate whose version changed relative
-# to the base commit, confirm the bump is consistent (check-invariants) and
-# the crate still publishes (cargo publish --dry-run). No-ops when no release
-# version changed. A sibling release crate not yet on crates.io is skipped,
-# not failed, since a PR may bump two crates at once.
+# to the base commit, confirm the bump is consistent (check-invariants), the
+# crate still publishes (cargo publish --dry-run), and the bump is large
+# enough for the API changes since the base version (cargo semver-checks).
+# No-ops when no release version changed. A sibling release crate not yet on
+# crates.io is skipped, not failed, since a PR may bump two crates at once.
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=contrib/release/crates.sh
@@ -55,4 +56,24 @@ for crate in "${changed[@]}"; do
     echo "Dry-run publishing $crate"
     cargo publish --dry-run --locked -q -p "$crate"
     echo "$crate packages and publishes cleanly"
+done
+
+# Semver only binds between stable releases: any comparison involving a
+# pre-release is classified as a major bump, which permits everything, so
+# running the tool there proves nothing. Only payjoin is checked for now;
+# payjoin-cli has no library API and payjoin-mailroom's is not yet stable.
+for crate in "${changed[@]}"; do
+    [ "$crate" = "payjoin" ] || continue
+    new_version="$(manifest_version "$crate")"
+    baseline="$(version_at "$base" "$crate")"
+    if is_prerelease "$new_version" || is_prerelease "$baseline"; then
+        echo "Skipping $crate semver check for pre-release ($baseline -> $new_version)"
+        continue
+    fi
+    if ! crate_published "$crate" "$baseline"; then
+        echo "Skipping $crate semver check; baseline $baseline not on crates.io"
+        continue
+    fi
+    echo "Checking $crate $new_version API against $baseline"
+    cargo semver-checks --package "$crate" --baseline-version "$baseline"
 done

--- a/flake.nix
+++ b/flake.nix
@@ -459,6 +459,7 @@
           name = "release";
           packages = with pkgs; [
             rustToolchains.stable
+            cargo-semver-checks
             jq
             gnupg
             curl

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,10 @@
             rust-overlay.overlays.default
             (final: prev: {
               dart = nixpkgs-unstable.legacyPackages.${system}.dart;
+              # From unstable so it keeps pace with the rustdoc JSON format
+              # emitted by rust-overlay's latest stable toolchain; the
+              # release-branch nixpkgs version lags too far behind.
+              cargo-semver-checks = nixpkgs-unstable.legacyPackages.${system}.cargo-semver-checks;
               rustToolchains = {
                 msrv = prev.rust-bin.stable.${msrv-version}.default;
                 stable = prev.rust-bin.stable.latest.default;


### PR DESCRIPTION
Integrates [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) into the release flow. The only API gate at release time today is `cargo publish --dry-run`, which can't tell whether the declared bump is large enough for the API changes it ships.

## Design

- **Runs on bump PRs only**, as part of `check-bump.sh`, which already computes the changed release crates and their base versions. This is how the tool is designed to run: the bump PR declares the actual new version, so the tool compares the required bump against the declared one with no configuration overrides. A continuous per-PR check was considered and rejected: between releases the workspace version equals the published baseline, so the tool would demand a version bump for any public API addition, and bumping `payjoin/Cargo.toml` in a feature PR would itself trigger this release workflow.
- **Explicit baseline**: the crate's version at the PR base SHA is passed as `--baseline-version` instead of relying on the tool's default "latest on crates.io" lookup, so the comparison stays correct even if crates.io carries a newer release (e.g. a bump on a maintenance branch).
- **Pre-release comparisons are skipped**: semver classifies any comparison involving a pre-release as a major bump, which permits every change, so running the tool there proves nothing. Concretely, rc-to-rc bumps (and the rc-to-1.0.0 bump) skip with a log message; enforcement begins with the first stable-to-stable `payjoin` bump after 1.0.0, with no config change needed at that point.
- **Scope is `payjoin` only**: `payjoin-cli` has no library API, and `payjoin-mailroom` can be added by widening the guard once its API stabilizes.
- **Feature coverage**: the tool's default heuristic enables all features except `_`-prefixed ones, so it checks `v1`/`v2`/`io`/`directory` (which transitively enable `_core`, where the public API lives) and correctly excludes the unstable `_manual-tls`. No feature configuration needed.
- The tool comes from the release devshell, sourced from the existing `nixpkgs-unstable` input rather than the 25.11 branch: the release-branch version (0.45.0) predates the rustdoc JSON format (v57) emitted by rust-overlay's current stable toolchain, while unstable's 0.48.0 reads it. If this check ever errors with "unsupported rustdoc format", the fix is a flake input bump.

Verified locally by running `check-bump.sh` against a pre-rc.8 base SHA (detects the bump, takes the pre-release skip path) and by adding a variant to an exhaustive public enum, which the tool correctly rejects as requiring a major bump. Note the tool has known false negatives (some generic/lifetime/type-position changes), so it complements the changelog's `**Breaking:**` markers rather than replacing them.

Disclosure: co-authored by Claude Code