### PR TITLE
Use a single release environment for publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -57,7 +57,7 @@ If any issues need to be fixed before the _MAJOR.MINOR+1.0_ version is released:
   - In the body of the tag message put a copy of the **Summary** and **Changelog** for the release.
   - Sign with a key committed under `contrib/release/keys/`, using the explicit `--sign` flag.
 - [ ] Push the new tag to the `payjoin/rust-payjoin` repo.
-- [ ] Approve the `crates-release` environment when it requests a reviewer.
+- [ ] Approve the `release` environment when it requests a reviewer.
 - [ ] Announce the release, using the **Summary**, on Discord, Twitter, Nostr, and stacker.news.
 - [ ] Celebrate 🎉
 

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -3,7 +3,7 @@ name: Release
 # A pull request that bumps a release crate's version is checked for
 # consistency and publishability. Pushing a `<crate>-<version>` tag verifies
 # the tag, waits for CI at that commit, then publishes to crates.io through
-# the `crates-release` environment (required reviewer) with keyless OIDC,
+# the `release` environment (required reviewer) with keyless OIDC,
 # cuts the GitHub release, and confirms the upload.
 
 on:
@@ -101,7 +101,7 @@ jobs:
     if: github.event_name == 'push'
     needs: [verify-tag, wait-for-ci]
     runs-on: ubuntu-26.04
-    environment: crates-release
+    environment: release
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -267,10 +267,10 @@ jobs:
     needs: [pack-nuget, smoke-nuget]
     if: startsWith(github.ref, 'refs/tags/payjoin-csharp-')
     # Optional but recommended: a GitHub Actions environment lets you bind the
-    # nuget.org policy to `nuget-release` AND add required reviewers, turning
+    # nuget.org policy to `release` AND add required reviewers, turning
     # publish into a manual-approval gate. Create the environment first, or
     # remove this line to publish without an approval gate. See README.
-    environment: nuget-release
+    environment: release
     permissions:
       id-token: write # OIDC: used by BOTH NuGet/login and attest-build-provenance
       attestations: write # actions/attest-build-provenance writes the attestation

--- a/payjoin-ffi/csharp/RELEASING.md
+++ b/payjoin-ffi/csharp/RELEASING.md
@@ -116,7 +116,7 @@ is ever stored. The workflow is
    `publish-nuget` verifies the tag matches the packed
    `Payjoin.<version>.nupkg`, attests build provenance, exchanges the GitHub
    OIDC token for a short-lived nuget.org key via [`NuGet/login`], and pushes.
-   The job runs in the `nuget-release` environment: if it has required
+   The job runs in the `release` environment: if it has required
    reviewers, approve the paused run before anything reaches nuget.org.
 
 3. `github-release` attaches the `.nupkg` and a generated `SHA256SUMS` to the
@@ -128,7 +128,7 @@ is ever stored. The workflow is
 
 One-time setup — the nuget.org Trusted Publishing policy (bound to
 `payjoin/rust-payjoin`, workflow file `csharp.yml`, environment
-`nuget-release`), the `nuget-release` GitHub Actions environment with required
+`release`), the `release` GitHub Actions environment with required
 reviewers, and the `NUGET_USER` secret (the publishing member's nuget.org
 profile name) — is a one-time account and repository configuration, not part
 of the per-release flow.


### PR DESCRIPTION
The crates.io and nuget.org publish jobs each gated on their own GitHub Actions environment, crates-release and nuget-release, with the same purpose: a required-reviewer approval before anything reaches a registry. Before we start adding trusted publishing for more languages/package managers, unify the environment so that this configuration lives in one place.

Co-authored-by: Claude Fable 5

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
