### PR TITLE
Disable flakehub API call in dart CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -29,5 +29,7 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
       - name: "Build and test"
         run: nix develop .#dart -c bash ./payjoin-ffi/dart/contrib/test.sh


### PR DESCRIPTION
`dart.yml` is the only workflow still calling `magic-nix-cache-action` without
`use-flakehub: false`.

#1798 added the flag to `crates-release.yml` (4 call sites), `csharp.yml`,
`format.yml`, `javascript.yml`, `python.yml` and `rust.yml`, but `dart.yml` got
missed, so it's still hitting the FlakeHub API on every run even though we
don't have an account. Same behaviour #1798 was removing everywhere else.

I went through every `magic-nix-cache-action` call site under
`.github/workflows/` and this was the only one left without the flag.

Worth flagging: the dart workflow won't actually run on this PR. Its
`pull_request` filter is `payjoin-ffi/**`, `flake.nix` and `flake.lock`, so
editing `.github/workflows/dart.yml` doesn't match and the job stays skipped.
The change is unexercised until something under `payjoin-ffi/` next touches it.
I left the filter alone rather than widen it here, but happy to if you'd
rather workflow edits triggered their own job.

Disclosure: co-authored by Claude Code. It found the gap, wrote the patch and
drafted this description. I reviewed and verified it.
