### PR TITLE
Bound nix cache size in FFI CI workflows

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -9,6 +9,12 @@ runs:
     - name: Install nix
       uses: DeterminateSystems/determinate-nix-action@main
     - name: Use nix cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
+      uses: nix-community/cache-nix-action@v7
       with:
-        use-flakehub: false
+        primary-key: nix-${{ runner.os }}-${{ github.job }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ github.job }}-
+        gc-max-store-size: 1G
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-${{ github.job }}-
+        purge-created: 0
+        purge-primary-key: never

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,12 +27,8 @@ jobs:
           # The toolchain must be specified manually, as this action ignores the rust-toolchain override
           # https://github.com/dtolnay/rust-toolchain?tab=readme-ov-file#inputs
           toolchain: ${{ matrix.rust }}
-      - name: "Install nix"
-        uses: DeterminateSystems/determinate-nix-action@main
-      - name: "Use nix cache"
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          use-flakehub: false
+      - name: Set up nix
+        uses: ./.github/actions/setup-nix
       - name: "Add nginxWithStream to PATH"
         run: |
           # This is necessary for payjoin-mailroom integration tests
@@ -49,12 +45,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
-      - name: "Install nix"
-        uses: DeterminateSystems/determinate-nix-action@main
-      - name: "Use nix cache"
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          use-flakehub: false
+      - name: Set up nix
+        uses: ./.github/actions/setup-nix
       - name: "Run code linting"
         run: nix develop -c ./contrib/lint.sh
       - name: "Run documentation linting"
@@ -77,12 +69,8 @@ jobs:
       - name: "Install toolchain"
         # rust-cache usage with stable Rust is most effective, as a cache is tied to the Rust version
         uses: dtolnay/rust-toolchain@stable
-      - name: "Install nix"
-        uses: DeterminateSystems/determinate-nix-action@main
-      - name: "Use nix cache"
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          use-flakehub: false
+      - name: Set up nix
+        uses: ./.github/actions/setup-nix
       - name: "Add nginxWithStream to PATH"
         run: |
           # This is necessary for payjoin-mailroom integration tests


### PR DESCRIPTION
Follow-up to #1131, with the measurements in
https://github.com/payjoin/rust-payjoin/issues/1131#issuecomment-5302104007.

`magic-nix-cache-action` writes one GitHub cache entry per nix store path. Upstream
currently holds 1031 entries totalling 10.46 GiB against a 10 GB quota, of which only 15
are the `Swatinem/rust-cache` entries the jobs actually reuse. GitHub then evicts
least-recently-used entries, so identical keys hit or miss depending on which PR ran last.

This swaps the four FFI workflows to
[`nix-community/cache-nix-action`](https://github.com/nix-community/cache-nix-action),
which stores the nix store as one bounded entry per workflow per runner OS, with
`purge` on so only the newest survives per key.

I tested it on my fork before opening this. All three testable FFI workflows passed
(csharp is excluded from the fork test only because its unrelated `build-nuget-native`
cross-compile matrix would have run too):

| | entries | size |
|---|---:|---:|
| fork before | 298 | 11.29 GiB |
| fork after | 14 | 9.09 GiB |

The 6 entries this action created, one per workflow per OS:

```
1.16 GiB  nix-Linux-dart-3a4d0953...
0.26 GiB  nix-Linux-javascript-3a4d0953...
0.26 GiB  nix-Linux-python-3a4d0953...
0.41 GiB  nix-macOS-dart-3a4d0953...
0.26 GiB  nix-macOS-javascript-3a4d0953...
0.26 GiB  nix-macOS-python-3a4d0953...
                                   total 2.61 GiB
```

With csharp included that is 8 entries rather than the thousands magic-nix-cache
produces, and CI runs were green so `gc-max-store-size: 1G` is not too tight for these
devshells. The number is easy to tune if you'd rather trade quota for fewer GC passes.

Fork runs: https://github.com/emmanuelist/rust-payjoin/actions?query=branch%3Aci-bounded-nix-cache

I left `rust.yml`, `format.yml` and `crates-release.yml` on `magic-nix-cache-action` so
this can be judged on the FFI workflows first. Happy to convert those too, or to close
this if you'd rather go a different way (dropping nix caching from the FFI jobs entirely,
or moving it off the GitHub quota to FlakeHub or Cachix were the other options I listed
in #1131).

Disclosure: co-authored by Claude Code.
