### PR TITLE
Only save rust cache on master

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -113,6 +113,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Use cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Prepare lockfile
         run: cp Cargo-recent.lock Cargo.lock
       - name: Package the crate

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"
@@ -56,6 +58,8 @@ jobs:
 
       - name: Use cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v4
@@ -119,6 +123,8 @@ jobs:
 
       - name: Use cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install cross toolchain
         # Version- and hash-pinned: these tools produce the shipped binaries.
@@ -179,6 +185,8 @@ jobs:
 
       - name: Use cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install .NET 10 SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,8 @@ jobs:
           echo "$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin" >> $GITHUB_PATH
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Run tests
         run: RUST_LOG=debug bash contrib/test.sh
 
@@ -49,6 +51,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: "Install nix"
         uses: DeterminateSystems/determinate-nix-action@main
       - name: "Use nix cache"
@@ -89,6 +93,8 @@ jobs:
           echo "$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin" >> $GITHUB_PATH
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: "Install cargo-llvm-cov"
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: "Generate code coverage for tests"
@@ -128,6 +134,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Run cargo-mutants on diff
         run: >
           cargo mutants --no-shuffle --in-diff git.diff
@@ -149,5 +157,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: "Build fuzz targets"
         run: cd fuzz && cargo build


### PR DESCRIPTION
Follow-up to the numbers in #1131.

`Swatinem/rust-cache` saves on every run, so each PR writes its own copy of the build
cache. Those entries are large, and they are what actually fills the quota. Upstream
right now:

| | entries | size |
|---|---:|---:|
| Swatinem/rust-cache | 7 | 9.32 GiB |
| cache-nix-action | 2 | 0.59 GiB |
| total | 9 | 9.91 GiB (quota is 10 GB) |

So rust-cache is sitting at about 94% of the quota on its own, and 4 of those 7
entries are scoped to PR refs. A PR can only restore from its own ref or from the
default branch, never from another PR, so those 4 are doing nothing for anyone else
while pushing everything else out. That is what makes identical cache keys hit or
miss depending on which PR ran last.

This gates saving on master, so PRs restore but do not write.

I tested it on my fork. The branch without this change accumulated 7 rust-cache
entries from its runs. The branch with it, after a full green run of the same
workflows, wrote **0**, and CI came back green:

```
entries on save-if branch: 0
Formatting -> success
Continuous integration -> success
Flake Check -> success
```

Two things worth knowing.

@benalleng you already said on #1131 that "for any PR that changes the dep tree it is
ok to not get the full benefit of caching", which is the main trade-off here, so I
went ahead on that basis. Shout if you meant something narrower.

There is a small transition cost. master currently holds 3 rust-cache entries, so
most PRs will still restore something straight away, but the jobs master has not run
recently will be cold until it does. rust.yml runs on push to master so that sorts
itself out on the first merge.

Happy to narrow this to rust.yml alone if you would rather keep the blast radius
small. Those 5 jobs are where the 1.4 to 1.5 GiB entries live, so they are most of
the benefit, and the FFI and release sites are much smaller.

Disclosure: co-authored by Claude Code.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
