### PR TITLE
Affix rust nightly version weekly instead of latest

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -44,3 +44,4 @@ jobs:
           branch: chore/nightly-pin-update
           add-paths: |
             rust-toolchain.toml
+            .github/workflows/rust.yml

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -1,0 +1,46 @@
+name: Nightly toolchain maintenance
+
+on:
+  schedule:
+    - cron: "0 11 * * 2" # weekly Tuesday, after Monday's flake maintenance
+  workflow_dispatch:
+
+jobs:
+  validate-toolchain:
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up nix
+        uses: ./.github/actions/setup-nix
+      - name: Update nightly toolchain pin
+        run: ./contrib/bump-nightly.sh
+      - name: Validate pinned toolchain
+        run: nix build .#checks.x86_64-linux.nightly -L --recreate-lock-file --no-write-lock-file
+
+  update-toolchain:
+    needs: validate-toolchain
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Update nightly toolchain pin
+        run: ./contrib/bump-nightly.sh
+      - name: Mint bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "chore: update nightly toolchain pin"
+          commit-message: "chore: update nightly toolchain pin"
+          token: ${{ steps.bot-token.outputs.token }}
+          branch: chore/nightly-pin-update
+          add-paths: |
+            rust-toolchain.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
         rust:
           - 1.85.0 # MSRV
           - stable
-          - nightly
+          - nightly-2026-08-21 # pinned nightly, bumped weekly by contrib/bump-nightly.sh
     env:
       # Override the value from the rust-toolchain file
       # This is necessary because even though the correct toolchain
@@ -134,7 +134,10 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v6
       - name: "Install nightly toolchain"
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          # pinned nightly, bumped weekly by contrib/bump-nightly.sh
+          toolchain: nightly-2026-08-21
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
       - name: "Build fuzz targets"

--- a/contrib/bump-nightly.sh
+++ b/contrib/bump-nightly.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Pin rust-toolchain.toml to the latest available nightly
+
+set -euo pipefail
+
+TOOLCHAIN_FILE="rust-toolchain.toml"
+CHANNEL_URL="https://static.rust-lang.org/dist/channel-rust-nightly.toml"
+
+latest=$(curl -fsSL "$CHANNEL_URL" | sed -n 's/^date = "\(.*\)"/\1/p')
+
+if [ -z "$latest" ]; then
+    echo "Failed to determine the latest nightly date from $CHANNEL_URL" >&2
+    exit 1
+fi
+
+sed -i "s/^channel = \"nightly-[0-9-]*\"/channel = \"nightly-${latest}\"/" "$TOOLCHAIN_FILE"
+
+grep '^channel' "$TOOLCHAIN_FILE"

--- a/contrib/bump-nightly.sh
+++ b/contrib/bump-nightly.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 #
-# Pin rust-toolchain.toml to the latest available nightly
+# Pin rust-toolchain.toml to the latest available nightly, and update the
+# matching pinned nightly entries in .github/workflows/rust.yml so CI
+# cache keys stay stable between weekly bumps.
 
 set -euo pipefail
 
 TOOLCHAIN_FILE="rust-toolchain.toml"
+WORKFLOW_FILE=".github/workflows/rust.yml"
 CHANNEL_URL="https://static.rust-lang.org/dist/channel-rust-nightly.toml"
 
 latest=$(curl -fsSL "$CHANNEL_URL" | sed -n 's/^date = "\(.*\)"/\1/p')
@@ -15,5 +18,7 @@ if [ -z "$latest" ]; then
 fi
 
 sed -i "s/^channel = \"nightly-[0-9-]*\"/channel = \"nightly-${latest}\"/" "$TOOLCHAIN_FILE"
+sed -i "s/nightly-[0-9][0-9-]*/nightly-${latest}/g" "$WORKFLOW_FILE"
 
 grep '^channel' "$TOOLCHAIN_FILE"
+grep -n 'nightly-[0-9]' "$WORKFLOW_FILE" || echo "No pinned nightly found in $WORKFLOW_FILE" >&2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-08-17"
 components = ["rust-analyzer", "rust-src"]


### PR DESCRIPTION
This is a followup on #1131 and the chain of related PRs. One thing I noticed was the restore keys were always grabbing new rust nightly versions so this attempts to at least affix the master version on a weekly basis if there is nothing merged in.  While this will not solve the immediate churn it think it can help prevent the master branch from being dropped every day.

Coded up with help from GLM-5.3

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
