### PR TITLE
Prepare dart payjoin 0.2.2 for pub.dev

### DIFF
--- a/payjoin-ffi/dart/CHANGELOG.md
+++ b/payjoin-ffi/dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.2.2+payjoin-1.0.0]
+
+- Bindings for payjoin-1.0.0, the first stable payjoin release. No Dart
+  API changes since 0.2.1+payjoin-1.0.0-rc.8
+- The package description no longer carries the EXPERIMENTAL disclaimer
+
 ## [0.2.1+payjoin-1.0.0-rc.8]
 
 - Sender inputs must declare a sighash type that commits to all inputs and

--- a/payjoin-ffi/dart/native/Cargo.toml
+++ b/payjoin-ffi/dart/native/Cargo.toml
@@ -16,6 +16,6 @@ name = "payjoin_ffi_wrapper"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "e4f5a0b384462458b3d68aeec042c20ceffb8d80", features = [
+payjoin-ffi = { git = "https://github.com/payjoin/rust-payjoin.git", rev = "60d0adbf4ee8e60090209d55e9864893a4acc30e", features = [
   "dart",
 ] }

--- a/payjoin-ffi/dart/pubspec.yaml
+++ b/payjoin-ffi/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: payjoin
-description: Dart bindings for payjoin (EXPERIMENTAL)
-version: 0.2.1+payjoin-1.0.0-rc.8
+description: Dart bindings for payjoin
+version: 0.2.2+payjoin-1.0.0
 homepage: https://github.com/payjoin/rust-payjoin
 repository: https://github.com/payjoin/rust-payjoin
 


### PR DESCRIPTION
Bump the Dart package to `0.2.2+payjoin-1.0.0`, wrapping the first stable payjoin release. Per the versioning policy, the wrapped release changing is a patch bump at minimum; there are no Dart API changes since `0.2.1+payjoin-1.0.0-rc.8`.

- Point the native wrapper's `payjoin-ffi` dependency at the `payjoin-1.0.0` tag commit (`60d0adb`) so consumers build the released code
- Drop the EXPERIMENTAL disclaimer from the package description now that the wrapped library is stable
- Add the matching `CHANGELOG.md` heading

Once merged, publishing follows the CI flow from #1820: an annotated `payjoin-dart-0.2.2+payjoin-1.0.0` tag on the merge commit, signed by a maintainer key in `contrib/release/keys/`, triggers tag verification and pub.dev automated publishing through the `release` environment.

Disclosure: co-authored by Claude Code