### PR TITLE
Exchange OIDC token before dart pub publish

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -93,4 +93,4 @@ jobs:
         run: nix develop .#dart -c ./payjoin-ffi/dart/contrib/prepare-publish.sh
 
       - name: Publish to pub.dev
-        run: nix develop .#dart -c bash -c 'cd payjoin-ffi/dart && dart pub publish --force'
+        run: nix develop .#dart -c ./payjoin-ffi/dart/contrib/publish.sh

--- a/flake.nix
+++ b/flake.nix
@@ -357,6 +357,8 @@
               rustVersions.msrv
               dart
               bzip2
+              curl
+              jq
             ]
             ++ lib.optionals pkgs.stdenv.isLinux [
               pkg-config

--- a/payjoin-ffi/dart/contrib/publish.sh
+++ b/payjoin-ffi/dart/contrib/publish.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish the package to pub.dev via automated publishing (OIDC).
+# `dart pub publish` has no non-interactive authentication mode: without a
+# registered token it falls back to the browser sign-in flow and hangs the
+# job, so the runner-injected ACTIONS_ID_TOKEN_REQUEST_* variables (present
+# only in jobs granted `id-token: write`) are exchanged here for a
+# short-lived token that pub.dev verifies against the repository, tag
+# pattern, and environment configured on the package's admin page. This is
+# the same exchange the dart-lang/setup-dart action performs; we install
+# Dart through nix, so it has to happen here instead. Run
+# prepare-publish.sh first to generate the bindings that get packed.
+
+: "${ACTIONS_ID_TOKEN_REQUEST_URL:?must run in a GitHub Actions job with id-token: write}"
+: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?must run in a GitHub Actions job with id-token: write}"
+
+PUB_TOKEN="$(
+    curl --silent --show-error --fail --location \
+        --header "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+        "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://pub.dev" |
+        jq --raw-output .value
+)"
+export PUB_TOKEN
+dart pub token add https://pub.dev --env-var PUB_TOKEN
+
+cd "$(dirname "$0")/.."
+dart pub publish --force


### PR DESCRIPTION
Fix the hung workflow at https://github.com/payjoin/rust-payjoin/actions/runs/32496950357/job/96822481525 due to the OIDC token not getting through to the nix environment.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
