### PR TITLE
Improve Sender Input Validation Tests and Error Types

### DIFF
--- a/payjoin/src/core/send/mod.rs
+++ b/payjoin/src/core/send/mod.rs
@@ -720,7 +720,7 @@ mod test {
     use bitcoin::hex::FromHex;
     use bitcoin::secp256k1::{Message, PublicKey, Secp256k1, SecretKey, SECP256K1};
     use bitcoin::taproot::TaprootBuilder;
-    use bitcoin::{Amount, FeeRate, OutPoint, Script, ScriptBuf, Sequence, Witness};
+    use bitcoin::{Amount, FeeRate, Script, ScriptBuf, Sequence, Witness};
     use payjoin_test_utils::{
         BoxError, ADDITIONAL_FEE_OUTPUT_INDEX, MAX_ADDITIONAL_FEE_CONTRIBUTION,
         PARSED_ORIGINAL_PSBT, PARSED_PAYJOIN_PROPOSAL, PARSED_PAYJOIN_PROPOSAL_WITH_SENDER_INFO,
@@ -1397,14 +1397,9 @@ mod test {
             let ctx = create_psbt_context()?;
             let mut proposal: bitcoin::Psbt = PARSED_PAYJOIN_PROPOSAL.clone();
 
-            // If the outpoints are different, they are considered a receiver input and will be checked as such
-            let proposed_outpoint = proposal.unsigned_tx.input.first().unwrap().previous_output;
-            proposal.unsigned_tx.input.get_mut(0).unwrap().previous_output =
-                OutPoint::new(proposed_outpoint.txid, proposed_outpoint.vout + 1);
-
-            // Make the receiver's input un-finalized
-            proposal.inputs.get_mut(0).unwrap().final_script_sig = None;
-            proposal.inputs.get_mut(0).unwrap().final_script_witness = None;
+            // Make the receiver's input unfinalized.
+            proposal.inputs.get_mut(1).unwrap().final_script_sig = None;
+            proposal.inputs.get_mut(1).unwrap().final_script_witness = None;
 
             assert_eq!(
                 ctx.process_proposal(proposal).unwrap_err().to_string(),
@@ -1419,16 +1414,9 @@ mod test {
             let ctx = create_psbt_context()?;
             let mut proposal: bitcoin::Psbt = PARSED_PAYJOIN_PROPOSAL.clone();
 
-            // If the outpoints are different, they are considered a receiver input and will be checked as such
-            let proposed_outpoint = proposal.unsigned_tx.input.first().unwrap().previous_output;
-            proposal.unsigned_tx.input.get_mut(0).unwrap().previous_output =
-                OutPoint::new(proposed_outpoint.txid, proposed_outpoint.vout + 1);
-            proposal.inputs.get_mut(0).unwrap().final_script_sig = Some(ScriptBuf::new());
-            proposal.inputs.get_mut(0).unwrap().final_script_witness = Some(Witness::new());
-
-            // Make the receiver's input un-finalized
-            proposal.inputs.get_mut(0).unwrap().witness_utxo = None;
-            proposal.inputs.get_mut(0).unwrap().non_witness_utxo = None;
+            // Remove the receiver's UTXO information.
+            proposal.inputs.get_mut(1).unwrap().witness_utxo = None;
+            proposal.inputs.get_mut(1).unwrap().non_witness_utxo = None;
 
             assert_eq!(
                 ctx.process_proposal(proposal).unwrap_err().to_string(),
@@ -1443,16 +1431,9 @@ mod test {
             let mut ctx = create_psbt_context()?;
             let mut proposal: bitcoin::Psbt = PARSED_PAYJOIN_PROPOSAL.clone();
 
-            // If the outpoints are different, they are considered a receiver input and will be checked as such
-            let proposed_outpoint = proposal.unsigned_tx.input.first().unwrap().previous_output;
-            proposal.unsigned_tx.input.get_mut(0).unwrap().previous_output =
-                OutPoint::new(proposed_outpoint.txid, proposed_outpoint.vout + 1);
-            proposal.inputs.get_mut(0).unwrap().final_script_sig = Some(ScriptBuf::new());
-            proposal.inputs.get_mut(0).unwrap().final_script_witness = Some(Witness::new());
-
             // Ensure the sequence is different
             let sequence = ctx.original_psbt.unsigned_tx.input.get_mut(0).unwrap().sequence;
-            proposal.unsigned_tx.input.get_mut(0).unwrap().sequence =
+            proposal.unsigned_tx.input.get_mut(1).unwrap().sequence =
                 Sequence::from_consensus(sequence.to_consensus_u32() + 1);
 
             assert_eq!(


### PR DESCRIPTION
Part of #678.

## What

Check that every original sender outpoint is still present in the proposal, in its original order, before classifying any proposal input as the receiver's. Existing receiver-input tests now modify the proposal's actual receiver input instead of the sender's.

## Why

Master already rejects proposals with missing or shuffled sender inputs, but only after the input loop. An altered sender outpoint is classified as a receiver input first, so the sender sees an unrelated error ("an input in proposed transaction belonging to the receiver is not finalized"). Checking ordering up front makes the error name the actual problem.

The UTXO-data check was dropped per review; that part of #678 remains open.

## Tests

```sh
cargo test -p payjoin ordered_subsequence --all-features
cargo test -p payjoin test_sender_input_outpoint_changed --all-features
cargo test -p payjoin test_receiver_input_ --all-features
cargo test -p payjoin --all-features
cargo fmt --all -- --check
cargo clippy -p payjoin --all-targets --all-features -- -D warnings
codespell
```

Disclosure: code and PR text drafted with AI assistance (Codex, Claude); reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRG6vHFsY9Ny88eRtTQ2vz
