### PR TITLE
Support multi-output UIH selection

### DIFF
--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -270,8 +270,12 @@ impl WantsInputs {
     /// Based on the paper, we are looking for the candidate input which, when added to the
     /// transaction with 2 existing outputs, results in the minimum input amount to be greater than the minimum
     /// output amount. Note that when calculating the minimum output amount, we consider the
-    /// post-contribution amounts, and expect the output which pays to the receiver to have its
-    /// value increased by the amount of the candidate input.
+    /// post-contribution amounts.
+    ///
+    /// The receiver's own output (`change_vout`) still holds its pre-contribution value, so it is
+    /// excluded from the minimum and folded back in increased by the candidate. That increase is
+    /// an upper bound — a candidate partly consumed by receiver outputs added earlier raises it by
+    /// less — which only ever rejects a candidate, never accepts one that fails the heuristic.
     ///
     /// Errors if the transaction does not have exactly 2 outputs.
     pub(super) fn avoid_uih(
@@ -288,7 +292,9 @@ impl WantsInputs {
             .unsigned_tx
             .output
             .iter()
-            .map(|output| output.value)
+            .enumerate()
+            .filter(|(vout, _)| *vout != self.proposal.change_vout)
+            .map(|(_, output)| output.value)
             .min()
             .unwrap_or(Amount::MAX_MONEY);
 
@@ -689,6 +695,25 @@ mod tests {
         let candidate = candidate_input_from_test_vector(Amount::from_sat(3_000_000));
         let result = wants_inputs.avoid_uih(std::slice::from_ref(&candidate));
         assert_eq!(result.unwrap(), candidate);
+    }
+
+    #[test]
+    fn avoid_uih_uses_post_contribution_receiver_output() {
+        let original = original_from_test_vector();
+        let mut wants_inputs = WantsOutputs::new(original, vec![0]).commit_outputs();
+        // Smallest output before the contribution, but not after it.
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.output[0].value = Amount::ONE_SAT;
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.output[1].value =
+            Amount::from_sat(4_000_000);
+        let candidate = candidate_input_from_test_vector(Amount::from_sat(3_000_000));
+
+        let result = wants_inputs.avoid_uih(std::slice::from_ref(&candidate));
+
+        // Post-contribution the receiver's output holds 3_000_001 sat, above the candidate.
+        assert_eq!(
+            result.unwrap_err(),
+            CoinSelectionError::from(InternalCoinSelectionError::NotFound)
+        );
     }
 
     #[test]

--- a/payjoin/src/core/receive/common/mod.rs
+++ b/payjoin/src/core/receive/common/mod.rs
@@ -253,9 +253,8 @@ impl WantsInputs {
     /// avoiding the Unnecessary Input Heuristic 2 (UIH2) outlined in [Unnecessary Input
     /// Heuristics and PayJoin Transactions by Ghesmati et al. (2022)](https://eprint.iacr.org/2022/589).
     ///
-    /// Privacy preservation is only supported for 2-output transactions. If the PSBT has more than
-    /// 2 outputs or if none of the candidates are suitable for avoiding UIH2, this function
-    /// defaults to the first candidate in `candidate_inputs` list.
+    /// If the PSBT has fewer than 2 outputs, or if none of the candidates are suitable for
+    /// avoiding UIH2, this function defaults to the first candidate in `candidate_inputs` list.
     pub fn try_preserving_privacy(
         &self,
         candidate_inputs: impl IntoIterator<Item = InputPair>,
@@ -267,22 +266,26 @@ impl WantsInputs {
     /// Returns the candidate input which avoids the UIH2 defined in [Unnecessary Input
     /// Heuristics and PayJoin Transactions by Ghesmati et al. (2022)](https://eprint.iacr.org/2022/589).
     ///
-    /// Based on the paper, we are looking for the candidate input which, when added to the
-    /// transaction with 2 existing outputs, results in the minimum input amount to be greater than the minimum
-    /// output amount. Note that when calculating the minimum output amount, we consider the
-    /// post-contribution amounts.
+    /// An analyst who assumes output `o` is the spender's change treats input `i` as unnecessary
+    /// when `i <= o`, since dropping `i` would still fund every other output. The optimal change
+    /// heuristic (UIH1) points that assumption at the smallest output, so a transaction avoids
+    /// UIH2 exactly when its smallest input exceeds its smallest output, for any number of
+    /// outputs. Beyond 2 an analyst has more than one change hypothesis to try and this check only
+    /// defeats the UIH1 one, so it is correspondingly weaker there.
+    ///
+    /// Both minimums are taken over post-contribution amounts.
     ///
     /// The receiver's own output (`change_vout`) still holds its pre-contribution value, so it is
     /// excluded from the minimum and folded back in increased by the candidate. That increase is
     /// an upper bound — a candidate partly consumed by receiver outputs added earlier raises it by
     /// less — which only ever rejects a candidate, never accepts one that fails the heuristic.
     ///
-    /// Errors if the transaction does not have exactly 2 outputs.
+    /// Errors below 2 outputs: with no change output there is nothing for UIH1 to identify.
     pub(super) fn avoid_uih(
         &self,
         candidate_inputs: &[InputPair],
     ) -> Result<InputPair, CoinSelectionError> {
-        if self.proposal.payjoin_psbt.outputs.len() != 2 {
+        if self.proposal.payjoin_psbt.outputs.len() < 2 {
             return Err(InternalCoinSelectionError::UnsupportedOutputLength.into());
         }
 
@@ -695,6 +698,61 @@ mod tests {
         let candidate = candidate_input_from_test_vector(Amount::from_sat(3_000_000));
         let result = wants_inputs.avoid_uih(std::slice::from_ref(&candidate));
         assert_eq!(result.unwrap(), candidate);
+    }
+
+    #[test]
+    fn avoid_uih_supports_three_outputs() {
+        let original = original_from_test_vector();
+        let mut wants_inputs = WantsOutputs::new(original, vec![0]).commit_outputs();
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.output[0].value =
+            Amount::from_sat(2_000_000);
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.output[1].value =
+            Amount::from_sat(1_000_000);
+        wants_inputs
+            .proposal
+            .payjoin_psbt
+            .unsigned_tx
+            .output
+            .push(TxOut { value: Amount::from_sat(4_000_000), script_pubkey: ScriptBuf::new() });
+        wants_inputs.proposal.payjoin_psbt.outputs.push(Default::default());
+        let candidate = candidate_input_from_test_vector(Amount::from_sat(3_000_000));
+
+        let selected = wants_inputs.avoid_uih(std::slice::from_ref(&candidate));
+
+        assert_eq!(selected.unwrap(), candidate);
+    }
+
+    /// The n-input, m-output shape that motivates #551: batched payments and multiparty proposals
+    /// carry more than one input as well as more than two outputs.
+    #[test]
+    fn avoid_uih_supports_multiple_inputs_and_outputs() {
+        let original = original_from_test_vector();
+        let mut wants_inputs = WantsOutputs::new(original, vec![0]).commit_outputs();
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.output[0].value =
+            Amount::from_sat(2_000_000);
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.output[1].value =
+            Amount::from_sat(3_500_000);
+        wants_inputs
+            .proposal
+            .payjoin_psbt
+            .unsigned_tx
+            .output
+            .push(TxOut { value: Amount::from_sat(6_000_000), script_pubkey: ScriptBuf::new() });
+        wants_inputs.proposal.payjoin_psbt.outputs.push(Default::default());
+        // Below the test vector's input, so this one sets the minimum input.
+        let existing = candidate_input_from_test_vector(Amount::from_sat(4_000_000));
+        wants_inputs.proposal.payjoin_psbt.unsigned_tx.input.push(existing.txin.clone());
+        wants_inputs.proposal.payjoin_psbt.inputs.push(existing.psbtin.clone());
+
+        let too_small = candidate_input_from_test_vector(Amount::from_sat(3_000_000));
+        let suitable = candidate_input_from_test_vector(Amount::from_sat(5_000_000));
+
+        let selected = wants_inputs.avoid_uih(&[too_small, suitable.clone()]);
+
+        // Minimum output is the 3_500_000 sat sender output. The 3_000_000 sat candidate drags the
+        // minimum input below it; the 5_000_000 sat one leaves the existing 4_000_000 sat input
+        // binding, which clears it.
+        assert_eq!(selected.unwrap(), suitable);
     }
 
     #[test]

--- a/payjoin/src/core/receive/error.rs
+++ b/payjoin/src/core/receive/error.rs
@@ -370,10 +370,8 @@ impl fmt::Display for CoinSelectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.0 {
             InternalCoinSelectionError::Empty => write!(f, "No candidates available for selection"),
-            InternalCoinSelectionError::UnsupportedOutputLength => write!(
-                f,
-                "Current privacy selection implementation only supports 2-output transactions"
-            ),
+            InternalCoinSelectionError::UnsupportedOutputLength =>
+                write!(f, "Privacy preserving selection requires at least 2 outputs"),
             InternalCoinSelectionError::NotFound =>
                 write!(f, "No selection candidates improve privacy"),
         }

--- a/payjoin/src/core/receive/v2/mod.rs
+++ b/payjoin/src/core/receive/v2/mod.rs
@@ -1172,9 +1172,8 @@ impl Receiver<WantsInputs> {
     /// avoiding the Unnecessary Input Heuristic 2 (UIH2) outlined in [Unnecessary Input
     /// Heuristics and PayJoin Transactions by Ghesmati et al. (2022)](https://eprint.iacr.org/2022/589).
     ///
-    /// Privacy preservation is only supported for 2-output transactions. If the PSBT has more than
-    /// 2 outputs or if none of the candidates are suitable for avoiding UIH2, this function
-    /// defaults to the first candidate in `candidate_inputs` list.
+    /// If the PSBT has fewer than 2 outputs, or if none of the candidates are suitable for
+    /// avoiding UIH2, this function defaults to the first candidate in `candidate_inputs` list.
     pub fn try_preserving_privacy(
         &self,
         candidate_inputs: impl IntoIterator<Item = InputPair>,


### PR DESCRIPTION
Closes #551.

Two commits, split after review so the correctness fix and the design decision can be judged
separately. Each passes CI on its own.

### 1. `Compare UIH against post-contribution outputs`

`avoid_uih` documents its minimum output as post-contribution, but computed the minimum over every
output at its **pre**-contribution value and only then folded the receiver's output back in. When
the receiver's output is the strictly smallest, its pre-contribution value survives the outer `min`
and the check runs against an amount the transaction never has, accepting candidates that do not
avoid UIH2.

Reachable in the existing 2-output path: receiver output 1 sat, sender output 4,000,000 sat,
candidate 3,000,000 sat -> post-contribution `min_out = 3,000,001` vs `min_in = 3,000,000`, yet the
check passes on master. No existing expectation changes, since the 2-output test vector pays the
receiver its largest output (95,983,068 vs 2,000,000) — which is why the buggy branch had no
coverage.

### 2. `Support multi-output UIH selection`

Relax the `!= 2` guard to `< 2`.

The condition `min_in > min_out` does not depend on the output count. An analyst assuming output `o`
is the spender's change treats input `i` as unnecessary when `i <= o`, because dropping `i` would
still fund every other output; the optimal change heuristic points that at the smallest output. Only
the single-output case is genuinely unsupported — with no change output there is nothing for the
heuristic to identify.

More outputs give an analyst more change hypotheses, and this check only defeats the UIH1 one, so it
is weaker at n>2. It is never weaker than the status quo: today those transactions fall through to
`select_first_candidate` with no privacy check at all. Full reasoning is recorded on `avoid_uih`.

### Against #551's two motivations

**Anonymity set (n-input, m-output).** Covered. `avoid_uih_supports_three_outputs` plus
`avoid_uih_supports_multiple_inputs_and_outputs`, the latter with two existing inputs and three
outputs, where the binding minimum input comes from an existing input rather than the candidate.

**Multiparty / NS1R.** Not exercisable here, and I would rather say so than imply otherwise. NS1R
was removed from master in 6b87adc2 (backed up to `ns1r-master-backup`, see #922), so there is no
multiparty receiver path to route through `try_preserving_privacy` or to test against. Relaxing the
guard is the enabling change the issue asks for — when NS1R returns it inherits UIH-aware selection
instead of `select_first_candidate` — but the multiparty half cannot be demonstrated until then.

I did not take the issue's "relax only in the multi-party context" alternative: relaxing generally is
a superset, and a multiparty-only gate would currently have no call site.

Output splitting, candidate scoring, and ranking against non-UIH1 change hypotheses stay out of
scope, as proposed when claiming the issue.


### Tests

- `cargo test -p payjoin --all-features` (on each commit)
- `cargo clippy -p payjoin --all-targets --all-features -- -D warnings` (on each commit)
- `cargo fmt --all -- --check`
- `codespell`

co-authored by Codex and Claude
