### PR TITLE
Give weekly rust nightly update workflow write perms

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Because this job updates both standard files and workflow files this job needs additional permissions to be able to update workflow.yml files

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
