### PR TITLE
Revert "Give weekly rust nightly update workflow write perms (#1838)"

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -24,7 +24,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This reverts commit 34d470b3ed0544ea4426f7459fc485b7bb92986a, reversing changes made to d64730fe2d2f05739007e0bfa72a20ebb5d69c8e.

I goofed, this is not a workflow permission file change this needs to be permissions for the bot specifically

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
