### PR TITLE
Rust nightly update references nix flake instead of rust curl

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set up nix
+        uses: ./.github/actions/setup-nix
       - name: Update nightly toolchain pin
         run: ./contrib/bump-nightly.sh
       - name: Mint bot token

--- a/contrib/bump-nightly.sh
+++ b/contrib/bump-nightly.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
 #
-# Pin rust-toolchain.toml to the latest available nightly, and update the
-# matching pinned nightly entries in .github/workflows/rust.yml so CI
-# cache keys stay stable between weekly bumps.
+# Pin rust-toolchain.toml to the latest nightly, and update the matching
+# pinned nightly entries in .github/workflows/rust.yml so CI cache keys
+# stay stable between weekly bumps.
+#
+# The date is derived from the rust-overlay revision pinned in flake.lock
+# (rather than static.rust-lang.org) so the pinned toolchain is guaranteed
+# to resolve for every job evaluating the flake with the committed lock.
 
 set -euo pipefail
 
 TOOLCHAIN_FILE="rust-toolchain.toml"
 WORKFLOW_FILE=".github/workflows/rust.yml"
-CHANNEL_URL="https://static.rust-lang.org/dist/channel-rust-nightly.toml"
 
-latest=$(curl -fsSL "$CHANNEL_URL" | sed -n 's/^date = "\(.*\)"/\1/p')
+nixpkgs_rev=$(jq -r '.nodes.root.inputs.nixpkgs as $id | .nodes[$id].locked.rev' flake.lock)
+rust_overlay_rev=$(jq -r '.nodes.root.inputs["rust-overlay"] as $id | .nodes[$id].locked.rev' flake.lock)
+
+latest=$(nix eval --raw --expr "
+  let
+    np = builtins.getFlake \"github:NixOS/nixpkgs/${nixpkgs_rev}\";
+    ro = builtins.getFlake \"github:oxalica/rust-overlay/${rust_overlay_rev}\";
+    pkgs = import np { system = \"x86_64-linux\"; overlays = [ ro.overlays.default ]; };
+  in builtins.head (builtins.sort (a: b: a > b)
+    (builtins.filter (n: n != \"latest\") (builtins.attrNames pkgs.rust-bin.nightly)))
+")
 
 if [ -z "$latest" ]; then
-    echo "Failed to determine the latest nightly date from $CHANNEL_URL" >&2
+    echo "Failed to determine the latest nightly date known to rust-overlay ${rust_overlay_rev}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Since we rely on nix flakes heavily we should only update to the latest rust nightly version available in the nix flake rather that the absolute latest rust nightly version available.

Gpt-5.3 coded the script up for me

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
