### PR TITLE
Ensure receiver properly handles malformed responses to mailbox

### DIFF
--- a/payjoin/src/core/hpke.rs
+++ b/payjoin/src/core/hpke.rs
@@ -200,9 +200,9 @@ pub fn decrypt_message_a(
     cursor.read_to_end(&mut ciphertext).map_err(|_| HpkeError::PayloadTooShort)?;
     let plaintext = decryption_ctx.open(&ciphertext, &[])?;
 
-    let reply_pk = pubkey_from_compressed_bytes(&plaintext[..PUBLIC_KEY_SIZE])?;
-
-    let body = &plaintext[PUBLIC_KEY_SIZE..];
+    let (reply_pk_bytes, body) =
+        plaintext.split_at_checked(PUBLIC_KEY_SIZE).ok_or(HpkeError::PayloadTooShort)?;
+    let reply_pk = pubkey_from_compressed_bytes(reply_pk_bytes)?;
 
     Ok((body.to_vec(), reply_pk))
 }


### PR DESCRIPTION
This ensures that any response that the receiver reads is within the payload size range preventing any panic due to an overflow.

~~Additionally in the case of an error this does not immediately close the session however I think this could be up to some debate whether these should be treated as fatal errors or not.~~ dropped until we can answer #1844 

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
