### PR TITLE
Publish the npm tarball by explicit file path

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -152,7 +152,7 @@ jobs:
           subject-path: ${{ steps.locate.outputs.tarball }}
 
       - name: Publish to npmjs.com
-        run: npm publish "${{ steps.locate.outputs.tarball }}"
+        run: npm publish "./${{ steps.locate.outputs.tarball }}"
 
   github-release:
     name: "Attach tarball + SHA256SUMS to the GitHub release"


### PR DESCRIPTION
The first javascript release run ([payjoin-javascript-0.2.0+payjoin-1.0.0](https://github.com/payjoin/rust-payjoin/actions/runs/33085291663/job/98568914178)) failed in the publish step: npm parses a relative path containing a slash but no `./` prefix as a GitHub `owner/repo` shorthand, so `npm publish "dist/payjoin-0.2.0.tgz"` ran `git ls-remote ssh://git@github.com/dist/payjoin-0.2.0.tgz.git` and failed on SSH auth without ever contacting the registry. Prefixing `./` disambiguates the argument as a local tarball; reproduced and verified against npm 11.6.2 with `npm publish --dry-run` both ways.

Since the publish workflow runs at the tagged commit, the `payjoin-javascript-0.2.0+payjoin-1.0.0` tag will be recreated on master once this lands.

Disclosure: co-authored by Claude Fable 5

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>

https://claude.ai/code/session_019BcdiyBCQQChuJ3dy7QJwm