### PR TITLE
Shared cache keys

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -23,11 +23,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-26.04, macos-latest]
+    env:
+      RUSTUP_TOOLCHAIN: 1.85.0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv-workspace
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -23,11 +23,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-26.04, macos-latest]
+    env:
+      RUSTUP_TOOLCHAIN: 1.85.0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv-workspace
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -23,11 +23,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-26.04, macos-latest]
+    env:
+      RUSTUP_TOOLCHAIN: 1.85.0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv-workspace
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,11 +23,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-26.04, macos-latest]
+    env:
+      RUSTUP_TOOLCHAIN: 1.85.0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: "Install Rust 1.85.0"
+        uses: dtolnay/rust-toolchain@1.85.0
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv-workspace
       - name: Set up nix
         uses: ./.github/actions/setup-nix
       - name: "Build and test"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
           echo "$(nix build .#nginx-with-stream --print-out-paths --no-link)/bin" >> $GITHUB_PATH
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.rust == 'stable' && 'stable-workspace' || '' }}
       - name: Run tests
         run: RUST_LOG=debug bash contrib/test.sh
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.rust == 'stable' && 'stable-workspace' || '' }}
+          shared-key: ${{ matrix.rust == 'stable' && 'stable-workspace' || matrix.rust == '1.85.0' && 'msrv-workspace' || '' }}
       - name: Run tests
         run: RUST_LOG=debug bash contrib/test.sh
 


### PR DESCRIPTION
This is an attempt to unify the cache keys between several CI jobs that share the same rust env.

coverage notably is left separate as it apparently cannot use the same cache key as other stable CI jobs.

Coded with GLM 5.3

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [x] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [x] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
