### PR TITLE
Add PartialEq to errors compared in tests

### DIFF
--- a/payjoin/src/core/persist.rs
+++ b/payjoin/src/core/persist.rs
@@ -770,7 +770,7 @@ impl<Err: std::error::Error, CurrentState> fmt::Display for RejectTransient<Err,
 }
 
 /// Error type that represents all possible errors that can be returned when processing a state transition
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct PersistedError<
     ApiError: std::error::Error,
     StorageError: std::error::Error,
@@ -910,7 +910,7 @@ impl<
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum ApiError<Err, ErrorState = (), CurrentState = ()> {
     /// Error indicating that the session should be retried from the same state,
     /// which is returned alongside the error
@@ -921,7 +921,7 @@ pub(crate) enum ApiError<Err, ErrorState = (), CurrentState = ()> {
     FatalWithState(Err, ErrorState),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum InternalPersistedError<ApiErr, StorageErr, ErrorState = (), CurrentState = ()>
 where
     ApiErr: std::error::Error,
@@ -1138,7 +1138,10 @@ mod tests {
         success: Option<SuccessState>,
     }
 
-    fn verify_sync<SuccessState: std::fmt::Debug + PartialEq, ErrorState: std::error::Error>(
+    fn verify_sync<
+        SuccessState: std::fmt::Debug + PartialEq,
+        ErrorState: std::error::Error + PartialEq,
+    >(
         persister: &InMemoryPersister<InMemoryTestEvent>,
         result: Result<SuccessState, ErrorState>,
         expected_result: &ExpectedResult<SuccessState, ErrorState>,
@@ -1159,9 +1162,7 @@ mod tests {
                 assert_eq!(Some(actual), expected_result.success.as_ref());
             }
             (Err(actual), Some(expected)) => {
-                // TODO: replace .to_string() with .eq(). This would introduce a trait bound on the internal API error type
-                // And not all internal API errors implement PartialEq
-                assert_eq!(actual.to_string(), expected.to_string());
+                assert_eq!(actual, expected);
             }
             _ => panic!("Unexpected result state"),
         }
@@ -1169,7 +1170,7 @@ mod tests {
 
     async fn verify_async<
         SuccessState: std::fmt::Debug + PartialEq + Send,
-        ErrorState: std::error::Error + Send,
+        ErrorState: std::error::Error + PartialEq + Send,
     >(
         persister: &InMemoryAsyncPersister<InMemoryTestEvent>,
         result: Result<SuccessState, ErrorState>,
@@ -1188,9 +1189,7 @@ mod tests {
                 assert_eq!(Some(actual), expected_result.success.as_ref());
             }
             (Err(actual), Some(exp)) => {
-                // TODO: replace .to_string() with .eq(). This would introduce a trait bound on the internal API error type
-                // And not all internal API errors implement PartialEq
-                assert_eq!(actual.to_string(), exp.to_string());
+                assert_eq!(actual, exp);
             }
             _ => panic!("Unexpected result state"),
         }
@@ -1402,7 +1401,11 @@ mod tests {
                     events: vec![fatal_event.clone()],
                     is_closed: false,
                     error: Some(
-                        InternalPersistedError::Api(ApiError::Fatal(InMemoryTestError {})).into(),
+                        InternalPersistedError::Api(ApiError::FatalWithState(
+                            InMemoryTestError {},
+                            next_state.clone(),
+                        ))
+                        .into(),
                     ),
                     success: None,
                 },

--- a/payjoin/src/core/receive/v1/error.rs
+++ b/payjoin/src/core/receive/v1/error.rs
@@ -11,10 +11,10 @@ use std::error;
 ///
 /// The error messages are formatted as JSON strings according to the BIP-78 spec with appropriate
 /// error codes and human-readable messages.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct RequestError(InternalRequestError);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum InternalRequestError {
     /// A required HTTP header is missing from the request
     MissingHeader(&'static str),

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -440,12 +440,13 @@ mod integration {
                     .expect_err("should fail")
                     .api_error()
                     .expect("expected api error");
-                // TODO: this should be replaced by comparing the error itself once the error types impl PartialEq
-                // Issue: https://github.com/payjoin/rust-payjoin/issues/645
-                assert_eq!(
-                    server_error.to_string(),
-                    "Protocol error: The receiver rejected the original PSBT."
-                );
+                match server_error {
+                    payjoin::receive::Error::Protocol(
+                        payjoin::receive::ProtocolError::OriginalPayload(_),
+                    ) => {}
+                    server_error =>
+                        panic!("expected original payload rejection, got: {server_error:#?}"),
+                }
 
                 let (session, session_history) = replay_receiver_event_log(&persister)?;
                 assert_eq!(session_history.status(), SessionStatus::Active);


### PR DESCRIPTION
### Summary

#645 asked for `PartialEq` on the error types so tests could compare errors directly. It was closed by #768, which added `PartialEq` only where every inner error type also implements it, and removed manual implementations that could never be fully correct. This PR completes that coverage and replaces the remaining `.to_string()` error comparisons in tests with real structural checks (the TODOs still referencing #645).

### Changes

- `payjoin/src/core/persist.rs`
  - Derive `PartialEq` on `PersistedError`, `ApiError`, and `InternalPersistedError`.
  - Add an `ErrorState: PartialEq` bound to `verify_sync`/`verify_async` and `assert_eq!` the errors instead of comparing `.to_string()`.
  - Fix a latent test bug the string comparison had masked: `fatal_advance` expected `ApiError::Fatal`, but the transition impl produces ApiError::FatalWithState`. The expectation now matches actual  behavior.
- `payjoin/src/core/receive/v1/error.rs`
  - Derive `PartialEq` on `RequestError` and `InternalRequestError`. Every inner error type implements `PartialEq`, so this follows the rule  established in `#768`.
- `payjoin/tests/integration.rs`
  - Replace the string comparison with a structural `match` on the  `Error::Protocol(ProtocolError::OriginalPayload(_))` variant, per the maintainer guidance in `#768`. The top-level receive `Error` hierarchy cannot implement `PartialEq` because inner types such as `bitcoin::psbt::PsbtParseError` and `http::Error` do not.

### Checklist

- [x] I have disclosed my use of AI in the body of this PR.
- [x] I have read CONTRIBUTING.md and rebased my branch to produce
      hygienic commits. The branch contains one commit that passes `cargo
      fmt --check`, `cargo clippy --all-targets --all-features -D
      warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and the local
      test suites.

Disclosure: co-authored by opencode